### PR TITLE
The cause of timeout error is mistake for the condition statement of IceConnectionState

### DIFF
--- a/Packages/com.unity.webrtc/Tests/Runtime/DataChannelTest.cs
+++ b/Packages/com.unity.webrtc/Tests/Runtime/DataChannelTest.cs
@@ -91,8 +91,8 @@ class DataChannelTest
         var op6 = peer1.SetRemoteDescription(ref op4.desc);
         yield return op6;
 
-        yield return new WaitUntil(() => peer1.IceConnectionState == RTCIceConnectionState.Connected);
-        yield return new WaitUntil(() => peer2.IceConnectionState == RTCIceConnectionState.Connected);
+        yield return new WaitUntil(() => peer1.IceConnectionState == RTCIceConnectionState.Connected || peer1.IceConnectionState == RTCIceConnectionState.Completed);
+        yield return new WaitUntil(() => peer2.IceConnectionState == RTCIceConnectionState.Connected || peer2.IceConnectionState == RTCIceConnectionState.Completed);
         yield return new WaitUntil(() => channel2 != null);
 
         Assert.AreEqual(channel1.Label, channel2.Label);


### PR DESCRIPTION
## Contents
The cause of timeout error is a mistake for the condition statement of `IceConnectionState`.

### Before
`peer1.IceConnectionState == RTCIceConnectionState.Connected`

### After
`peer1.IceConnectionState == RTCIceConnectionState.Connected || peer1.IceConnectionState == RTCIceConnectionState.Completed`