### PR TITLE
[FIXED] Disposing video encoding resources

### DIFF
--- a/Plugin/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin/WebRTCPlugin/PeerConnectionObject.cpp
@@ -8,6 +8,12 @@ namespace WebRTC
 
     PeerConnectionObject::~PeerConnectionObject()
     {
+        auto senders = connection->GetSenders();
+        for (auto sender : senders)
+        {
+            connection->RemoveTrack(sender);
+        }
+
         auto state = connection->peer_connection_state();
         if (state != webrtc::PeerConnectionInterface::PeerConnectionState::kClosed)
         {


### PR DESCRIPTION
## Expect
Always Video streaming process works correctly on Unity editor.

## Actual 
Video streaming process failed the third try on Unity editor but I did good on the first and second try.

## How to fix
Added removing tracks process to `PeerConnectionObject` destructor.
