### PR TITLE
[FIXED]Fix cpu keep growing even if browser side is closed

### DIFF
--- a/Assets/Scripts/RenderStreaming.cs
+++ b/Assets/Scripts/RenderStreaming.cs
@@ -54,7 +54,7 @@ namespace Unity.RenderStreaming
             {
             new RTCIceServer { urls = new string[] { urlSTUN } }
             };
-
+            StartCoroutine(WebRTC.WebRTC.Update());
             StartCoroutine(LoopPolling());
         }
 
@@ -95,6 +95,13 @@ namespace Unity.RenderStreaming
                 pc.OnDataChannel = new DelegateOnDataChannel(channel => { OnDataChannel(pc, channel); });
                 pc.SetConfiguration(ref conf);
                 pc.OnIceCandidate = new DelegateOnIceCandidate(candidate => { StartCoroutine(OnIceCandidate(offer.connectionId, candidate)); });
+                pc.OnIceConnectionChange = new DelegateOnIceConnectionChange(state =>
+                {
+                    if(state == RTCIceConnectionState.Disconnected)
+                    {
+                        pc.Close();  
+                    }
+                });
                 //make video bit rate starts at 16000kbits, and 160000kbits at max.
                 string pattern = @"(a=fmtp:\d+ .*level-asymmetry-allowed=.*)\r\n";
                 _desc.sdp = Regex.Replace(_desc.sdp, pattern, "$1;x-google-start-bitrate=16000;x-google-max-bitrate=160000\r\n");
@@ -103,7 +110,6 @@ namespace Unity.RenderStreaming
                 {
                     pc.AddTrack(track);
                 }
-                StartCoroutine(WebRTC.WebRTC.Update());
                 StartCoroutine(Answer(connectionId));
             }
         }

--- a/Packages/com.unity.webrtc/Runtime/Srcipts/RTCPeerConnection.cs
+++ b/Packages/com.unity.webrtc/Runtime/Srcipts/RTCPeerConnection.cs
@@ -31,13 +31,13 @@ namespace Unity.WebRTC
 
         public void Dispose()
         {
-            NativeMethods.PeerConnectionClose(self);
+            NativeMethods.PeerConnectionClose(self, m_id);
         }
 
         public RTCIceConnectionState IceConnectionState
         {
             get
-            {
+            { 
                 return NativeMethods.PeerConnectionIceConditionState(self);
             }
         }
@@ -185,7 +185,7 @@ namespace Unity.WebRTC
 
         public void Close()
         {
-            NativeMethods.PeerConnectionClose(self);
+            NativeMethods.PeerConnectionClose(self, m_id);
         }
 
         public RTCRtpSender AddTrack(MediaStreamTrack track)

--- a/Packages/com.unity.webrtc/Runtime/Srcipts/WebRTC.cs
+++ b/Packages/com.unity.webrtc/Runtime/Srcipts/WebRTC.cs
@@ -213,7 +213,7 @@ namespace Unity.WebRTC
                 flipMat = new Material(flipShader); 
             }
         }
-        public static IEnumerator Update()
+        public static IEnumerator Update() 
         {
             while (true)
             {
@@ -300,7 +300,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr ContextCreatePeerConnectionWithConfig(IntPtr ptr, int id, string conf);
         [DllImport(WebRTC.Lib)]
-        public static extern void PeerConnectionClose(IntPtr ptr);
+        public static extern void PeerConnectionClose(IntPtr ptr, int id);
         [DllImport(WebRTC.Lib)]
         public static extern void PeerConnectionSetConfiguration(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string conf);
         [DllImport(WebRTC.Lib)]

--- a/Plugin/WebRTCPlugin/Context.h
+++ b/Plugin/WebRTCPlugin/Context.h
@@ -52,6 +52,7 @@ namespace WebRTC
         void EncodeFrame() { nvVideoCapturer->EncodeVideoData(); }
         void StopCapturer() { nvVideoCapturer->Stop(); }
         void ProcessAudioData(const float* data, int32 size) { audioDevice->ProcessAudioData(data, size); }
+        void DeleteClient(int id) { clients.erase(id); }
     private:
         int m_uid;
         std::unique_ptr<rtc::Thread> workerThread;

--- a/Plugin/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin/WebRTCPlugin/WebRTCPlugin.cpp
@@ -179,9 +179,10 @@ extern "C"
     {
         return ctx->CreatePeerConnection(id, conf);
     }
-    UNITY_INTERFACE_EXPORT void PeerConnectionClose(PeerConnectionObject* obj)
+    UNITY_INTERFACE_EXPORT void PeerConnectionClose(PeerConnectionObject* obj, int id)
     {
         obj->Close();
+        ContextManager::GetInstance()->curContext->DeleteClient(id);
     }
     UNITY_INTERFACE_EXPORT webrtc::RtpSenderInterface* PeerConnectionAddTrack(PeerConnectionObject* obj, webrtc::MediaStreamTrackInterface* track)
     {


### PR DESCRIPTION
## Expected
CPU cost would drop when the client browser is shut down.
## Actual
CPU cost doesn't drop down
## How to fix
- move `StartCoroutine(WebRTC.WebRTC.Update())` outside of `GetOffer()` since it just needs to be called once
- Close pc and delete pc from c++ side to stop its cpu cose