### PR TITLE
[Added] Changed RenderStreaming inspector parameters

### DIFF
--- a/Assets/Scenes/HDRPScene.unity
+++ b/Assets/Scenes/HDRPScene.unity
@@ -1393,9 +1393,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   urlSignaling: http://localhost
-  urlSTUN: stun:stun.l.google.com:19302
+  urlsIceServer:
+  - stun:stun.l.google.com:19302
   interval: 5
-  cam: {fileID: 1297650283}
+  captureCamera: {fileID: 1297650283}
   arrayButtonClickEvent:
   - elementId: 1
     click:

--- a/Assets/Scripts/RenderStreaming.cs
+++ b/Assets/Scripts/RenderStreaming.cs
@@ -24,13 +24,13 @@ namespace Unity.RenderStreaming
         private string urlSignaling = "http://localhost";
 
         [SerializeField, Tooltip("Address for stun server")]
-        private string urlSTUN = "stun:stun.l.google.com:19302";
+        private string[] urlsIceServer = new string[] { "stun:stun.l.google.com:19302" };
 
         [SerializeField, Tooltip("Time interval for polling from signaling server")]
         private float interval = 5.0f;
 
         [SerializeField, Tooltip("Camera to capture video stream")]
-        private Camera cam;
+        private Camera captureCamera;
 
         [SerializeField]
         private ButtonClickElement[] arrayButtonClickEvent;
@@ -60,7 +60,7 @@ namespace Unity.RenderStreaming
             {
                 yield break;
             }
-            videoStream = cam.CaptureStream(1280, 720);
+            videoStream = captureCamera.CaptureStream(1280, 720);
             signaling = new Signaling(urlSignaling);
             var opCreate = signaling.Create();
             yield return opCreate;
@@ -75,7 +75,7 @@ namespace Unity.RenderStreaming
             conf = default;
             conf.iceServers = new RTCIceServer[]
             {
-            new RTCIceServer { urls = new string[] { urlSTUN } }
+            new RTCIceServer { urls = urlsIceServer }
             };
             StartCoroutine(WebRTC.WebRTC.Update());
             StartCoroutine(LoopPolling());


### PR DESCRIPTION
## What
Changed `RenderStreaming` inspector parameters.

- Renamed `cam` to `captureCamera`
- Renamed `urlSTUN` to `urlsIceServer`
- Changed `urlsIceServer` type to `string[]`

![renderstreaming_inspector](https://user-images.githubusercontent.com/1132081/60473386-d21b8080-9ca7-11e9-98de-bfcbe157a97d.png)