### PR TITLE
[FIXED] Added dependencies package

### DIFF
--- a/Packages/com.unity.template.renderstreaming/package.json
+++ b/Packages/com.unity.template.renderstreaming/package.json
@@ -7,6 +7,7 @@
   "description": "This is HDRP sample scene project integrated with RenderStreaming technology.\n\nAlong with its signaling web server, you could play around the scene in any webrtc supported web browser.",
   "dependencies": {
     "com.unity.webrtc": "0.1.0-preview",
-    "com.unity.inputsystem": "0.2.10-preview"
+    "com.unity.inputsystem": "0.2.10-preview",
+    "com.unity.render-pipelines.high-definition": "5.7.2-preview"
   }
 }


### PR DESCRIPTION
## Expect
It imports the HDRP package when open `Render Streaming` template.

## Actual
It does not import the HDRP package when open `Render Streaming` template.

## How to fix
Added HDRP package to package.json for `com.unity.template.renderstreaming`

## TODO
I am not sure why `com.unity.template.hd` package doesn't have dependencies.
https://github.cds.internal.unity3d.com/unity/com.unity.template-hd/blob/2019.1/Packages/com.unity.template.hd/package.json