### PR TITLE
[FIXED] libwebrtc build failed

### DIFF
--- a/build_libwebrtc.cmd
+++ b/build_libwebrtc.cmd
@@ -17,11 +17,12 @@ set ARTIFACTS_DIR=%cd%
 cmd /k fetch.bat webrtc
 
 cd src
+cmd /k git.bat config --system core.longpaths true
 cmd /k git.bat branch -r
 cmd /k git.bat checkout -b my_branch refs/remotes/branch-heads/%WEBRTC_VERSION%
 cd ..
 
-cmd /k gclient.bat sync
+cmd /k gclient.bat sync -f
 
 REM change jsoncpp static library
 powershell -File .\ReplaceText.ps1 "src\third_party\jsoncpp\BUILD.gn" "source_set" "static_library"


### PR DESCRIPTION
## Expect

build four libs ( `webrtc.lib`, `audio_decoder_opus.lib`, `webrtc_opus.lib`, `jsoncpp.lib` )

## Actual

got error log and don't build libs

```
C:\build\output\Unity-Technologies\UnityRenderStreaming>cmd /k gclient.bat sync 

[00:58:48.770 INF] error: cannot rebase: You have unstaged changes.
error: Please commit or stash them.

[00:58:48.783 INF] Failed to update depot_tools.

[00:58:54.459 INF] 
src/third_party (ERROR)
----------------------------------------
[0:00:00] Started.
----------------------------------------
Error: 6> 
6> ____ src\third_party at 3a20b86d38a3e17aa3cf24f6e36192013b535571
6> 	You have unstaged changes.
6> 	Please commit, stash, or reset.
```

## How to fix
- Changed `gclient sync` to `gclient sync -f`
- After changed `gclient`, we got error that the 260 character maximum path limit in Windows.
- Called command `cmd /k git.bat config --system core.longpaths true` to fix character length limitation.