### PR TITLE
fix: Added conditions that detect Safari on Mac OS

### DIFF
--- a/WebApp/public/scripts/video-player.js
+++ b/WebApp/public/scripts/video-player.js
@@ -41,7 +41,11 @@ export class VideoPlayer {
 
     // RTCDataChannel don't work on iOS safari
     // https://github.com/webrtc/samples/issues/1123
-    if (navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)) {
+    if (
+      navigator.userAgent.match(/iPad/i) ||
+      navigator.userAgent.match(/iPhone/i) ||
+      navigator.userAgent.match(/Safari/i) && !navigator.userAgent.match(/Chrome/i)
+    ) {
       let stream = await navigator.mediaDevices.getUserMedia({audio: true});
       stream.getTracks().forEach(t => t.stop());
     }


### PR DESCRIPTION
## Expect
It works streaming on Safari browser

## Actual
It doesn't work streaming on Safari browser

## How to fix
This issue has discussed the website.
https://github.com/webrtc/samples/issues/1123

I added a workaround to avoid the issue.