### PR TITLE
fix: ice server list items on renderstreaming inspector not displayed

### DIFF
--- a/Assets/Scripts/Editor/RenderStreamingEditor.cs
+++ b/Assets/Scripts/Editor/RenderStreamingEditor.cs
@@ -21,25 +21,22 @@ public class RenderStreamingEditor : Editor
     static void ShowIceServerList(SerializedProperty list)
     {
         EditorGUILayout.PropertyField(list.FindPropertyRelative("Array.size"), new GUIContent(list.displayName));
-        if (list.isExpanded)
+        EditorGUI.indentLevel += 1;
+        for (int i = 0; i < list.arraySize; i++)
         {
-            EditorGUI.indentLevel += 1;
-            for (int i = 0; i < list.arraySize; i++)
+            var element = list.GetArrayElementAtIndex(i);
+            var label = "Ice server [" + i + "]";
+            EditorGUILayout.PropertyField(element, new GUIContent(label));
+            if (element.isExpanded)
             {
-                var element = list.GetArrayElementAtIndex(i);
-                var label = "Ice server [" + i + "]";
-                EditorGUILayout.PropertyField(element, new GUIContent(label));
-                if (element.isExpanded)
-                {
-                    EditorGUI.indentLevel += 1;
-                    EditorGUILayout.PropertyField(element.FindPropertyRelative("urls"), true);
-                    EditorGUILayout.PropertyField(element.FindPropertyRelative("username"));
-                    EditorGUILayout.PropertyField(element.FindPropertyRelative("credential"));
-                    EditorGUILayout.PropertyField(element.FindPropertyRelative("credentialType"));
-                    EditorGUI.indentLevel -= 1;
-                }
+                EditorGUI.indentLevel += 1;
+                EditorGUILayout.PropertyField(element.FindPropertyRelative("urls"), true);
+                EditorGUILayout.PropertyField(element.FindPropertyRelative("username"));
+                EditorGUILayout.PropertyField(element.FindPropertyRelative("credential"));
+                EditorGUILayout.PropertyField(element.FindPropertyRelative("credentialType"));
+                EditorGUI.indentLevel -= 1;
             }
-            EditorGUI.indentLevel -= 1;
         }
+        EditorGUI.indentLevel -= 1;
     }
 }


### PR DESCRIPTION
### before
![renderstreaming_inspector](https://user-images.githubusercontent.com/1132081/63078760-897a0700-bf77-11e9-9082-86e1f20ab7fa.png)

### after
![renderstreaming_inspector2](https://user-images.githubusercontent.com/1132081/63078759-897a0700-bf77-11e9-9b15-88c4db1a3af4.png)
