### PR TITLE
chore: fixed package name to "Unity Render Streaming"

### DIFF
--- a/Packages/com.unity.renderstreaming/package.json
+++ b/Packages/com.unity.renderstreaming/package.json
@@ -1,9 +1,9 @@
 {
   "name": "com.unity.renderstreaming",
-  "displayName": "Render Streaming",
+  "displayName": "Unity Render Streaming",
   "version": "1.0.0-preview",
   "unity": "2019.1",
-  "description": "This is HDRP sample scene project integrated with RenderStreaming technology.\n\nAlong with its signaling web server, you could play around the scene in any webrtc supported web browser.",
+  "description": "This is HDRP sample scene project integrated with Unity Render Streaming technology.\n\nAlong with its signaling web server, you could play around the scene in any webrtc supported web browser.",
   "dependencies": {
     "com.unity.webrtc": "1.0.0-preview",
     "com.unity.inputsystem": "0.2.10-preview"
@@ -13,7 +13,7 @@
 
    {
      "displayName": "HDRP",
-     "description": "HDRP RenderStreaming Sample",
+     "description": "HDRP Unity Render Streaming Sample",
      "path": "Samples~/HDRP"
    }
  ]  

--- a/Packages/com.unity.template.renderstreaming/package.json
+++ b/Packages/com.unity.template.renderstreaming/package.json
@@ -1,10 +1,10 @@
 {
   "name": "com.unity.template.renderstreaming",
-  "displayName": "Render Streaming Template",
+  "displayName": "Unity Render Streaming Template",
   "version": "1.0.0-preview",
   "type": "template",
   "unity": "2019.1",
-  "description": "This is HDRP sample scene project integrated with RenderStreaming technology.\n\nAlong with its signaling web server, you could play around the scene in any webrtc supported web browser.",
+  "description": "This is HDRP sample scene project integrated with Unity Render Streaming technology.\n\nAlong with its signaling web server, you could play around the scene in any webrtc supported web browser.",
   "dependencies": {
     "com.unity.webrtc": "1.0.0-preview",
     "com.unity.inputsystem": "0.2.10-preview",


### PR DESCRIPTION
Official name of the packages is **Unity Render Streaming**.
For that reason I modified `package.json`.

Please tell me if you find wrong names.