### PR TITLE
fix: Fixed downloading process for webapp

### DIFF
--- a/Packages/com.unity.renderstreaming/Editor/RenderStreamingMenu.cs
+++ b/Packages/com.unity.renderstreaming/Editor/RenderStreamingMenu.cs
@@ -54,10 +54,10 @@ namespace Unity.RenderStreaming.Editor
                 client.DownloadProgressChanged += (object sender, DownloadProgressChangedEventArgs e) =>
                 {
                     var progress = e.ProgressPercentage / 100f;
-                    var progressing = EditorUtility.DisplayCancelableProgressBar("Downloading", url, progress);
-                    if (progressing)
-                        return;
-                    client.CancelAsync();
+                    if(EditorUtility.DisplayCancelableProgressBar("Downloading", url, progress))
+                    {
+                        client.CancelAsync();
+                    }
                 };
                 client.DownloadFileAsync(new System.Uri(url), tmpFilePath);
             });


### PR DESCRIPTION
`EditorUtility.DisplayCancelableProgressBar` returns `true` when pushed cancel button on the progress window.