### PR TITLE
chore: Remove unused licenses

### DIFF
--- a/Packages/com.unity.webrtc/Third Party Notices.md
+++ b/Packages/com.unity.webrtc/Third Party Notices.md
@@ -518,49 +518,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 
-# fft
-```
-/*
- * Copyright(c)1995,97 Mark Olesen <olesen@me.QueensU.CA>
- *    Queen's Univ at Kingston (Canada)
- *
- * Permission to use, copy, modify, and distribute this software for
- * any purpose without fee is hereby granted, provided that this
- * entire notice is included in all copies of any software which is
- * or includes a copy or modification of this software and in all
- * copies of the supporting documentation for such software.
- *
- * THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR
- * IMPLIED WARRANTY.  IN PARTICULAR, NEITHER THE AUTHOR NOR QUEEN'S
- * UNIVERSITY AT KINGSTON MAKES ANY REPRESENTATION OR WARRANTY OF ANY
- * KIND CONCERNING THE MERCHANTABILITY OF THIS SOFTWARE OR ITS
- * FITNESS FOR ANY PARTICULAR PURPOSE.
- *
- * All of which is to say that you can do what you like with this
- * source code provided you don't try to sell it as your own and you
- * include an unaltered copy of this message (including the
- * copyright).
- *
- * It is also implicitly understood that bug fixes and improvements
- * should make their way back to the general Internet community so
- * that everyone benefits.
- */
-
-```
-
-# fft4g
-```
-/*
- * http://www.kurims.kyoto-u.ac.jp/~ooura/fft.html
- * Copyright Takuya OOURA, 1996-2001
- *
- * You may use, copy, modify and distribute this code for any purpose (include
- * commercial use) and without fee. Please refer to this package when you modify
- * this code.
- */
-
-```
-
 # fiat
 ```
 The MIT License (MIT)


### PR DESCRIPTION
WebRTC package doesn't depend on `fft` and `fft4g`.
I removed licenses of two libraries from `Third Party Notices.md` .

### TODO
Fix [`build_libwebrtc.cmd`](https://github.com/Unity-Technologies/UnityRenderStreaming/blob/release/1.1.0/build_libwebrtc.cmd) to remove `fft` and `fft4g` headers from `webrtc-win.zip`