### PR TITLE
fixed: Fixed bugs that receive wrong position when detect multi-touch

### DIFF
--- a/Assets/Scripts/RemoteInput.cs
+++ b/Assets/Scripts/RemoteInput.cs
@@ -176,10 +176,15 @@ namespace Unity.RenderStreaming
                 int touchId = Touch.activeTouches[i].touchId;
                 if (!Array.Exists(touches, v => v.touchId == touchId))
                 {
+                    if (Touch.activeTouches[i].phase == TouchPhase.Ended)
+                    {
+                        continue;
+                    }
                     InputSystem.QueueStateEvent(RemoteTouch, new TouchState
                     {
                         touchId = touchId,
-                        phase = UnityEngine.InputSystem.TouchPhase.Ended
+                        phase = TouchPhase.Ended,
+                        position = Touch.activeTouches[i].screenPosition
                     });
                 }
             }

--- a/Assets/Scripts/SimpleCameraController.cs
+++ b/Assets/Scripts/SimpleCameraController.cs
@@ -148,7 +148,7 @@ namespace UnityTemplateProjects
             var activeTouches = UnityEngine.InputSystem.EnhancedTouch.Touch.activeTouches;
             if (activeTouches.Count == 2)
             {
-                direction = GetTranslationFromInput(activeTouches[0].delta);
+                direction = GetTranslationFromInput((activeTouches[0].delta + activeTouches[1].delta) / 2f);
             } else if (IsMouseDragged(Mouse.current,true)) {
                 direction = GetTranslationFromInput(Mouse.current.delta.ReadValue());
             } else if (IsMouseDragged(RemoteInput.RemoteMouse,true)) {

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.EnhancedTouch;
 using TMPro;
 
 namespace Unity.RenderStreaming
@@ -44,8 +45,13 @@ namespace Unity.RenderStreaming
             }
             else if (UnityEngine.InputSystem.EnhancedTouch.Touch.activeTouches.Count > 0)
             {
-                var position = UnityEngine.InputSystem.EnhancedTouch.Touch.activeTouches[0].screenPosition;
-                pointer.rectTransform.anchoredPosition = position;
+                var position = Vector2.zero;
+                var count = UnityEngine.InputSystem.EnhancedTouch.Touch.activeTouches.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    position += UnityEngine.InputSystem.EnhancedTouch.Touch.activeTouches[i].screenPosition;
+                }
+                pointer.rectTransform.anchoredPosition = position / (float)count;
                 pointer.color = Color.red;
             }
             else

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -1,7 +1,6 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.InputSystem;
-using UnityEngine.InputSystem.EnhancedTouch;
 using TMPro;
 
 namespace Unity.RenderStreaming


### PR DESCRIPTION
## What problem is it solved?
- Got wrong touch position when detects multi-touch

## How solve is it?
- Sometimes `TouchPhase.End` touch events aren't detected on the browser
- We need to force change touch status to `TouchPhase.End`
- But it didn't set position when force change touch status
- Fixed to set the previous position to the touch event 
