### PR TITLE
add location path name to signaling path

### DIFF
--- a/WebApp/public/scripts/signaling.js
+++ b/WebApp/public/scripts/signaling.js
@@ -10,7 +10,7 @@ export default class Signaling {
   };
 
   url(method) {
-    return location.protocol + '//' + location.host + '/signaling/' + method;
+    return location.protocol + '//' + location.host + location.pathname + 'signaling/' + method;
   };
   async createConnection(sessionId) {
     return await fetch(this.url('connection'), {method: 'PUT', headers: this.headers(sessionId)});


### PR DESCRIPTION
This patch lets the signaling web server run behind a proxy with a url prefix other than "/".