### PR TITLE
add standalone player command line args for ICE JSON url and signaling

### DIFF
--- a/Assets/Scripts/Editor/RenderStreamingEditor.cs
+++ b/Assets/Scripts/Editor/RenderStreamingEditor.cs
@@ -10,6 +10,7 @@ public class RenderStreamingEditor : Editor
         {
             serializedObject.Update();
             EditorGUILayout.PropertyField(serializedObject.FindProperty("urlSignaling"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("iceServerURL"));
             ShowIceServerList(serializedObject.FindProperty("iceServers"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("interval"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("streamingSize"));

--- a/Assets/Scripts/RenderStreaming.cs
+++ b/Assets/Scripts/RenderStreaming.cs
@@ -21,6 +21,9 @@ namespace Unity.RenderStreaming
     public class RenderStreaming : MonoBehaviour
     {
 #pragma warning disable 0649
+        [SerializeField, Tooltip("URL to fetch JSON ICE servers from")]
+        private string iceServerURL = "http://localhost:8000/turn";
+        
         [SerializeField, Tooltip("Address for signaling server")]
         private string urlSignaling = "http://localhost";
 
@@ -54,6 +57,67 @@ namespace Unity.RenderStreaming
         private MediaStream videoStream;
         private MediaStream audioStream;
 
+        // Helper function for getting the command line arguments
+        private static string GetArg(string name)
+        {
+            var args = System.Environment.GetCommandLineArgs();
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] == name && args.Length > i + 1)
+                {
+                    return args[i + 1];
+                }
+            }
+            return null;
+        }
+
+        IEnumerator GetRTCIceServers(System.Action<RTCIceServer[]> result)
+        {
+            List<RTCIceServer> serverList = new List<RTCIceServer>();
+
+            // Add servers from config
+            foreach (var server in iceServers)
+            {
+                serverList.Add(server);
+            }
+
+            string iceUrlArg = GetArg("-iceUrl");
+            if (iceUrlArg != null)
+            {
+                iceServerURL = iceUrlArg;
+            }
+
+            if (iceServerURL.Length > 0)
+            {
+                Debug.Log($"Fetching ICE servers from: {iceServerURL}");
+                yield return FetchICE(iceServerURL, (server) =>
+                {
+                    Debug.Log($"got ice server from json: {string.Join(",", server.urls)}");
+                    serverList.Add(server);
+                });
+            }
+
+            result(serverList.ToArray());
+        }
+
+        IEnumerator FetchICE(string url, System.Action<RTCIceServer> result)
+        {
+            UnityWebRequest request = UnityWebRequest.Get(url);
+            yield return request.SendWebRequest();
+            if (request.isNetworkError)
+            {
+                Debug.LogError($"Failed to fetch ICE servers from {url}: {request.error}");
+            }
+            else
+            {
+                JsonICE ice = JsonICE.CreateFromJSON(request.downloadHandler.text);
+                foreach (var server in ice.iceServers)
+                {
+                    result(server);
+                }
+            }
+        }
+
         public void Awake()
         {
             WebRTC.WebRTC.Initialize(); 
@@ -73,6 +137,14 @@ namespace Unity.RenderStreaming
             {
                 yield break;
             }
+
+            string signalingArg = GetArg("-signaling");
+            if (signalingArg != null)
+            {
+                urlSignaling = signalingArg;
+            }
+            Debug.Log($"Using signaling server: {urlSignaling}");
+
             videoStream = captureCamera.CaptureStream(streamingSize.x, streamingSize.y);
             audioStream = Unity.WebRTC.Audio.CaptureStream();
             signaling = new Signaling(urlSignaling);
@@ -80,14 +152,14 @@ namespace Unity.RenderStreaming
             yield return opCreate;
             if (opCreate.webRequest.isNetworkError)
             {
-                Debug.LogError($"Network Error: {opCreate.webRequest.error}");
+                Debug.LogError($"Failed to connect to signaling server at {urlSignaling}: {opCreate.webRequest.error}");
                 yield break;
             }
             var newResData = opCreate.webRequest.DownloadHandlerJson<NewResData>().GetObject();
             sessionId = newResData.sessionId;
 
             conf = default;
-            conf.iceServers = iceServers;
+            yield return StartCoroutine(GetRTCIceServers((result) => conf.iceServers = result));
             StartCoroutine(WebRTC.WebRTC.Update());
             StartCoroutine(LoopPolling());
         }


### PR DESCRIPTION
This patch allows for passing the signaling URL and a ICE JSON url via command line argument.

The JSON returned by the URL is generated to work with coTURN in the form of:

```json
{
  "lifetimeDuration": "86400s",
  "iceServers": [
    {
      "urls": [
        "stun:1.2.3.4:3478"
      ]
    },
    {
      "urls": [
        "turn:1.2.3.4:3478?transport=udp"
      ],
      "username": "1572994870-user@example.com",
      "credential": "some-base64-hmac-sha1-generated-credential"
    }
  ],
  "blockStatus": "NOT_BLOCKED",
  "iceTransportPolicy": "all"
}
```