### PR TITLE
chore: depend on com.unity.webrtc 1.1.0 using git URL.

### DIFF
--- a/.yamato/upm-ci-test-renderstreaming-samples.yml
+++ b/.yamato/upm-ci-test-renderstreaming-samples.yml
@@ -1,7 +1,6 @@
 # .yamato/upm-ci-test-renderstreaming-samples.yml
 editors:
-  - version: 2019.1
-  - version: 2019.2  
+  - version: 2019.3  
 #  - version: trunk
 platforms:
   - name: win

--- a/Packages/com.unity.renderstreaming/package.json
+++ b/Packages/com.unity.renderstreaming/package.json
@@ -5,7 +5,7 @@
   "unity": "2019.1",
   "description": "This is HDRP sample scene project integrated with Unity Render Streaming technology.\n\nAlong with its signaling web server, you could play around the scene in any webrtc supported web browser.",
   "dependencies": {
-    "com.unity.webrtc": "1.0.1-preview",
+    "com.unity.webrtc": "https://github.com/Unity-Technologies/com.unity.webrtc.git#release/1.1.0",    
     "com.unity.inputsystem": "0.9.6-preview"
   }, 
   
@@ -17,7 +17,5 @@
      "path": "Samples~/HDRP"
    }
  ]  
-
-
 
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -11,7 +11,7 @@
     "com.unity.test-framework": "1.1.3",
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.ugui": "1.0.0",
-    "com.unity.webrtc": "1.0.1-preview",
+    "com.unity.webrtc": "https://github.com/Unity-Technologies/com.unity.webrtc.git#release/1.1.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
@@ -46,5 +46,11 @@
   },
   "testables": [
     "com.unity.webrtc"
-  ]
+  ],
+  "lock": {
+    "com.unity.webrtc": {
+      "revision": "release/1.1.0",
+      "hash": "bde9ee2a4cadf67d57e7f961d21c721dd65162db"
+    }
+  }
 }


### PR DESCRIPTION
This dependency is temporary until webrtc 1.1.0 is officially released.