### PR TITLE
fix: Render Sreaming inspector layout

### DIFF
--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Editor/RenderStreamingEditor.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Editor/RenderStreamingEditor.cs
@@ -27,7 +27,7 @@ public class RenderStreamingEditor : Editor
         {
             var element = list.GetArrayElementAtIndex(i);
             var label = "Ice server [" + i + "]";
-            EditorGUILayout.PropertyField(element, new GUIContent(label));
+            EditorGUILayout.PropertyField(element, new GUIContent(label), false);
             if (element.isExpanded)
             {
                 EditorGUI.indentLevel += 1;


### PR DESCRIPTION
Fixed the broken `Render Streaming` Inspector 

## Before

![image](https://user-images.githubusercontent.com/1132081/79416539-dde3f380-7fea-11ea-8f3e-d3eeb66a5c7b.png)


## After

![image](https://user-images.githubusercontent.com/1132081/79416517-d15f9b00-7fea-11ea-924f-722af92aa177.png)
