### PR TITLE
fix: fixed byte array layout of the message for gamepad

### DIFF
--- a/WebApp/public/scripts/register-events.js
+++ b/WebApp/public/scripts/register-events.js
@@ -149,8 +149,6 @@ const Keymap = {
   // "IMESelected": 111,
 };
 
-
-let isPlayMode = false;
 export function registerGamepadEvents(videoPlayer) {
   const _videoPlayer = videoPlayer;
   document.addEventListener("gamepadButtonDown", sendGamepadButtonDown, false);
@@ -158,55 +156,47 @@ export function registerGamepadEvents(videoPlayer) {
   document.addEventListener("gamepadButtonPressed", sendGamepadButtonPressed, false);
   document.addEventListener("gamepadAxis", gamepadAxisChange, false);
 
-  function sendGamepadButtonDown(e)
-  {
+  function sendGamepadButtonDown(e) {
     console.log("gamepad id: " + e.id + " button index: " + e.index + " value " + e.value + " down" );
     let data = new DataView(new ArrayBuffer(19));
     data.setUint8(0, InputEvent.Gamepad);
-    data.setFloat64(1, e.id, true);
-    data.setUint8(9, GamepadEventType.ButtonDown);
-    data.setUint8(10, e.index);
-    data.setFloat64(11, e.value, true);
+    data.setUint8(1, GamepadEventType.ButtonDown);
+    data.setUint8(2, e.index);
+    data.setFloat64(3, e.value, true);
 
     _videoPlayer && _videoPlayer.sendMsg(data.buffer);
   }
 
-  function sendGamepadButtonUp(e)
-  {
+  function sendGamepadButtonUp(e) {
     console.log("gamepad id: " + e.id + " button index: " + e.index + " value " + e.value + " up" );
     let data = new DataView(new ArrayBuffer(19));
     data.setUint8(0, InputEvent.Gamepad);
-    data.setFloat64(1, e.id, true);
-    data.setUint8(9, GamepadEventType.ButtonUp);
-    data.setUint8(10, e.index);
-    data.setFloat64(11, e.value, true);
+    data.setUint8(1, GamepadEventType.ButtonUp);
+    data.setUint8(2, e.index);
+    data.setFloat64(3, e.value, true);
 
     _videoPlayer && _videoPlayer.sendMsg(data.buffer);
   }
 
-  function sendGamepadButtonPressed(e)
-  {
+  function sendGamepadButtonPressed(e) {
     console.log("gamepad id: " + e.id + " button index: " + e.index + " value " + e.value + " pressed" );
     let data = new DataView(new ArrayBuffer(19));
     data.setUint8(0, InputEvent.Gamepad);
-    data.setFloat64(1, e.id, true);
-    data.setUint8(9, GamepadEventType.ButtonPressed);
-    data.setUint8(10, e.index);
-    data.setFloat64(11, e.value, true);
+    data.setUint8(1, GamepadEventType.ButtonPressed);
+    data.setUint8(2, e.index);
+    data.setFloat64(3, e.value, true);
     
     _videoPlayer && _videoPlayer.sendMsg(data.buffer);
   }
 
-  function gamepadAxisChange(e)
-  {
+  function gamepadAxisChange(e) {
     console.log("gamepad id: " + e.id + " axis: " + e.index + " value " + e.value + " x:" + e.x + " y:" + e.y );
     let data = new DataView(new ArrayBuffer(27));
     data.setUint8(0, InputEvent.Gamepad);  
-    data.setFloat64(1, e.id, true);
-    data.setUint8(9, GamepadEventType.Axis);  
-    data.setUint8(10, e.index);
-    data.setFloat64(11, e.x, true);
-    data.setFloat64(19, e.y, true);
+    data.setUint8(1, GamepadEventType.Axis);  
+    data.setUint8(2, e.index);
+    data.setFloat64(3, e.x, true);
+    data.setFloat64(11, e.y, true);
     _videoPlayer && _videoPlayer.sendMsg(data.buffer);
   }
 }

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/RemoteInput.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/RemoteInput.cs
@@ -117,8 +117,6 @@ namespace Unity.RenderStreaming
 
         static UnityEngine.Vector2Int m_prevMousePos;
 
-        private const int offset = 0;
-
         public RemoteInput(ref InputUser user)
         {
             RemoteMouse = user.pairedDevices.FirstOrDefault(device => device is Mouse) as Mouse;
@@ -131,30 +129,30 @@ namespace Unity.RenderStreaming
 
         public void ProcessInput(byte[] bytes)
         {
-            switch ((EventType)bytes[offset + 0])
+            switch ((EventType)bytes[0])
             {
                 case EventType.Keyboard:
-                    var type = (KeyboardEventType)bytes[offset + 1];
-                    var repeat = bytes[offset + 2] == 1;
-                    var key = bytes[offset + 3];
-                    var character = (char)bytes[offset + 4];
+                    var type = (KeyboardEventType)bytes[1];
+                    var repeat = bytes[2] == 1;
+                    var key = bytes[3];
+                    var character = (char)bytes[4];
                     ProcessKeyEvent(type, repeat, key, character);
                     break;
                 case EventType.Mouse:
-                    var deltaX = BitConverter.ToInt16(bytes, offset + 1);
-                    var deltaY = BitConverter.ToInt16(bytes, offset + 3);
+                    var deltaX = BitConverter.ToInt16(bytes, 1);
+                    var deltaY = BitConverter.ToInt16(bytes, 3);
                     var button = bytes[5];
                     ProcessMouseMoveEvent(deltaX, deltaY, button);
                     break;
                 case EventType.MouseWheel:
-                    var scrollX = BitConverter.ToSingle(bytes, offset + 1);
-                    var scrollY = BitConverter.ToSingle(bytes, offset + 5);
+                    var scrollX = BitConverter.ToSingle(bytes, 1);
+                    var scrollY = BitConverter.ToSingle(bytes, 5);
                     ProcessMouseWheelEvent(scrollX, scrollY);
                     break;
                 case EventType.Touch:
                     {
-                        var length = bytes[offset + 1];
-                        var index = offset + 2;
+                        var length = bytes[1];
+                        var index = 2;
                         var touches = new TouchState[length];
                         for (int i = 0; i < length; i++)
                         {
@@ -186,12 +184,12 @@ namespace Unity.RenderStreaming
                     
                     break;
                 case EventType.ButtonClick:
-                    var elementId = BitConverter.ToInt16(bytes, offset + 1);
+                    var elementId = BitConverter.ToInt16(bytes, 1);
                     ProcessButtonClickEvent(elementId);
                     break;
                 case EventType.Gamepad:
                     {
-                        GamepadEventType gamepadEventType = (GamepadEventType)bytes[offset + 9];
+                        GamepadEventType gamepadEventType = (GamepadEventType)bytes[1];
                         
                         switch (gamepadEventType)
                         {
@@ -199,16 +197,16 @@ namespace Unity.RenderStreaming
                             case GamepadEventType.ButtonUp:
                             case GamepadEventType.ButtonPressed:
                                 {
-                                    var buttonIndex = bytes[offset + 10];
-                                    var value = BitConverter.ToDouble(bytes, offset + 11);
+                                    var buttonIndex = bytes[2];
+                                    var value = BitConverter.ToDouble(bytes, 3);
                                     ProcessGamepadButtonEvent(gamepadEventType, (GamepadKeyCode) buttonIndex, value);
                                 }
                                 break;
                             case GamepadEventType.Axis:
                                 {
-                                    var buttonIndex = bytes[offset + 10];
-                                    var x = BitConverter.ToDouble(bytes, offset + 11);
-                                    var y = BitConverter.ToDouble(bytes, offset + 19);
+                                    var buttonIndex = bytes[2];
+                                    var x = BitConverter.ToDouble(bytes, 3);
+                                    var y = BitConverter.ToDouble(bytes, 11);
                                     ProcessGamepadAxisEvent(x, y, (GamepadKeyCode) buttonIndex);
                                 }
                                 break;

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/UIController.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/UIController.cs
@@ -16,7 +16,6 @@ namespace Unity.RenderStreaming
             new AnimationCurve(
                 new Keyframe(0.75f, 1f, 0f, 0f),
                 new Keyframe(1f, 0f, 0f, 0f));
-        [SerializeField] RenderStreaming m_renderStreaming = null;
 
         private float timeTransition = 0f;
         private Color transparentColor = new Color(0, 0, 0, 0);


### PR DESCRIPTION
Remove unused byte array contained in a message of the gamepad event.

## Before
||byte length|start offset|
|--|--|--|
|eventtype|1|0|
|datetime|8|1|
|gamepadEventType|1|9|
|buttonIndex|1|10|
|value|8|11|

## After
||byte length|start offset|
|--|--|--|
|eventtype|1|0|
|gamepadEventType|1|1|
|buttonIndex|1|2|
|value|8|3|

## Other 

Remove unused member in `UIContoller` class