### PR TITLE
chore: rename display name

### DIFF
--- a/com.unity.template.renderstreaming-hd/Packages/com.unity.template.renderstreaming-hd/package.json
+++ b/com.unity.template.renderstreaming-hd/Packages/com.unity.template.renderstreaming-hd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.template.renderstreaming-hd",
-  "displayName": "Unity Render Streaming Template HDRP",
+  "displayName": "Render Streaming HDRP",
   "version": "2.0.0-preview",
   "type": "template",
   "unity": "2019.3",

--- a/com.unity.template.renderstreaming-rtx/Packages/com.unity.template.renderstreaming-rtx/package.json
+++ b/com.unity.template.renderstreaming-rtx/Packages/com.unity.template.renderstreaming-rtx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.template.renderstreaming-rtx",
-  "displayName": "Unity Render Streaming Template Raytracing",
+  "displayName": "Render Streaming Raytracing",
   "version": "2.0.0-preview",
   "type": "template",
   "unity": "2019.3",


### PR DESCRIPTION
Before this PR, a display name is too long so the layout on the Unity hub is broken.
![image](https://user-images.githubusercontent.com/1132081/79557621-d6514700-80dd-11ea-8287-eceede47ea98.png)
