### PR TITLE
fix: fixed yaml to publish the packages on GitHub Release

### DIFF
--- a/.yamato/meta/environments.yml
+++ b/.yamato/meta/environments.yml
@@ -34,3 +34,8 @@ platforms:
     run_editor_tests_command:  ./run_editor_tests.sh
     import_unity_package_command: ./import_unity_package.sh
     unity_path: .Editor/Unity
+projects:
+  - name: renderstreaming-hd
+    packagename: com.unity.template.renderstreaming-hd
+  - name: renderstreaming-rtx
+    packagename: com.unity.template.renderstreaming-rtx    

--- a/.yamato/upm-ci-publish-github-release.yml
+++ b/.yamato/upm-ci-publish-github-release.yml
@@ -24,11 +24,19 @@ publish_github_release:
       only:
         - /^(v|V)?\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
   dependencies:
-    {% for editor in editors %}
-    {% for platform in platforms %}
+   {% for platform in platforms %}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
-    {% for param in platform.test_params %}
-    - .yamato/upm-ci-template.yml#test_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}
-    {% endfor %}
-    {% endfor %}
-    {% endfor %}
+   {% endfor %}
+   {% for project in projects %}
+    - .yamato/upm-ci-template.yml#pack_{{ project.name }}
+   {% endfor %}
+# todo(kazuki): template test is broken on Yamato, commented out before until the problem is corrected.  
+# 
+#    {% for editor in editors %}
+#   {% for platform in platforms %}
+#    - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
+#    {% for param in platform.test_params %}
+#    - .yamato/upm-ci-template.yml#test_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}
+#    {% endfor %}
+#    {% endfor %}
+#    {% endfor %}

--- a/.yamato/upm-ci-template.yml
+++ b/.yamato/upm-ci-template.yml
@@ -17,6 +17,9 @@ pack_{{ project.name }}:
     packages:
       paths:
         - "upm-ci~/packages/**/*"
+# todo(kazuki): Commented out to avoid the error occurred when publishing the template packages to GitHub release.
+#               This error occurring caused by two templates using the same file path to put artifacts.
+#
 #        - "upm-ci~/templates/**/*"
   dependencies:
     {% for platform in platforms %}

--- a/.yamato/upm-ci-template.yml
+++ b/.yamato/upm-ci-template.yml
@@ -17,7 +17,7 @@ pack_{{ project.name }}:
     packages:
       paths:
         - "upm-ci~/packages/**/*"
-        - "upm-ci~/templates/**/*"
+#        - "upm-ci~/templates/**/*"
   dependencies:
     {% for platform in platforms %}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}

--- a/.yamato/upm-ci-template.yml
+++ b/.yamato/upm-ci-template.yml
@@ -1,11 +1,6 @@
 # .yamato/upm-ci-template.yml
 {% metadata_file .yamato/meta/environments.yml %}
 
-projects:
-  - name: renderstreaming-hd
-    packagename: com.unity.template.renderstreaming-hd
-  - name: renderstreaming-rtx
-    packagename: com.unity.template.renderstreaming-rtx
 ---
 {% for project in projects %}
 pack_{{ project.name }}:


### PR DESCRIPTION
Fixed the job that publishes packages to GitHub Release.

 - Exclude dependency job that unstable template test   
 - Remove artifacts that occur build error