### PR TITLE
chore: Update yaml to replace upm registry

### DIFF
--- a/.yamato/meta/environments.yml
+++ b/.yamato/meta/environments.yml
@@ -1,3 +1,5 @@
+upm:
+  registry_url: https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
 editors:
   - version: 2019.3
 platforms:

--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,3 +1,5 @@
+{% metadata_file .yamato/meta/environments.yml %}
+
 test_editors:
   - version: 2019.3
 test_platforms:
@@ -22,7 +24,7 @@ promotion_test_{{ platform.name }}_{{ editor.version }}:
   variables:
     UPMCI_PROMOTION: 1
   commands:
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - upm-ci package test --unity-version {{ editor.version }} --package-path {{ package.packagename }}
   artifacts:
     logs:
@@ -42,7 +44,7 @@ promote_dry_run:
   variables:
     UPMCI_PROMOTION: 1
   commands:
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - upm-ci package promote --dry-run --package-path {{ package.packagename }}
   triggers:
     tags:
@@ -69,7 +71,7 @@ promote:
   variables:
     UPMCI_PROMOTION: 1
   commands:
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - upm-ci package promote --package-path {{ package.packagename }}
   triggers:
     tags:

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -13,7 +13,7 @@ pack_{{ package.name }}:
     image: renderstreaming/win10:latest
     flavor: b1.large
   commands:
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - upm-ci package pack --package-path {{ package.packagename }}
   artifacts:
     {{ package.name }}_package:  
@@ -29,7 +29,7 @@ test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }}
   triggers:
     branches:
@@ -53,7 +53,7 @@ publish_dry_run_{{ package.name }}:
     image: package-ci/win10:stable
     flavor: b1.large
   commands:
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - upm-ci package publish --dry-run --package-path {{ package.packagename }}
   triggers:
     tags:
@@ -78,7 +78,7 @@ publish_{{ package.name }}:
     image: package-ci/win10:stable
     flavor: b1.large
   commands:
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - upm-ci package publish --package-path {{ package.packagename }}
   triggers:
     tags:

--- a/.yamato/upm-ci-renderstreaming-unitypackage.yml
+++ b/.yamato/upm-ci-renderstreaming-unitypackage.yml
@@ -47,7 +47,7 @@ test_renderstreaming_sample_{{ sample.name }}_{{ platform.name }}_{{ editor.vers
     flavor: {{ platform.flavor}}
   commands:
     - {{ platform.copy_sample_command }} com.unity.renderstreaming {{ sample.name }}
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     {% if platform.name == "win" %}
     - pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple --upgrade
     {% else %}

--- a/.yamato/upm-ci-template.yml
+++ b/.yamato/upm-ci-template.yml
@@ -15,7 +15,7 @@ pack_{{ project.name }}:
     image: package-ci/ubuntu:stable    
     flavor: b1.large  
   commands:
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - find ./{{ project.packagename }} -type l -exec bash -c 'sh BuildScripts~/convert_symlinks.sh "$0"' {} \;    
     - upm-ci template pack --project-path {{ project.packagename }}
   artifacts:
@@ -45,7 +45,7 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     {% else %}
     - cp -r WebApp upm-ci~/templates/ProjectData~/
     {% endif %}
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - upm-ci template test -u {{ editor.version }} --project-path {{ project.packagename }} --platform {{ param.platform }} --backend {{ param.backend }}
 #
 #  todo(kazuki): Templete test is broken on Yamato yet, The date completed is still undecided.
@@ -74,7 +74,7 @@ publish_{{ project.name }}:
     image: package-ci/win10:stable
     flavor: b1.large
   commands:
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - upm-ci template publish --project-path {{ project.packagename }}
   triggers:
     tags:
@@ -105,7 +105,7 @@ publish_dryrun_{{ project.name }}:
     image: package-ci/win10:stable
     flavor: b1.large
   commands:
-    - npm install upm-ci-utils@latest -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@latest -g --registry {{ upm.registry_url }}
     - upm-ci template publish --dry-run
   triggers:
     tags:


### PR DESCRIPTION
This fix is for updating the yaml of Yamato because the upm registry URL is changed.