### PR TITLE
fix: divide webapp release mac

### DIFF
--- a/.yamato/upm-ci-publish-github-release.yml
+++ b/.yamato/upm-ci-publish-github-release.yml
@@ -30,6 +30,7 @@ publish_github_release_webapp:
   commands:
     - npm install github-release-cli -g
     - github-release upload -o "Unity-Technologies" -r "UnityRenderStreaming" -t "%GIT_TAG%" -n "%GIT_TAG%" "WebApp/bin~/webserver"
+    - github-release upload -o "Unity-Technologies" -r "UnityRenderStreaming" -t "%GIT_TAG%" -n "%GIT_TAG%" "WebApp/bin~/webserver_mac"
     - github-release upload -o "Unity-Technologies" -r "UnityRenderStreaming" -t "%GIT_TAG%" -n "%GIT_TAG%" "WebApp/bin~/webserver.exe"
   dependencies:
    {% for platform in platforms %}

--- a/.yamato/upm-ci-webapp.yml
+++ b/.yamato/upm-ci-webapp.yml
@@ -9,14 +9,14 @@ platforms:
     type: Unity::VM::osx
     image: buildfarm/mac:stable
     flavor: m1.mac
-    pack_command: ./pack_webapp_mac.sh
+    pack_command: ./pack_webapp.sh
     test_command: ./test_webapp.sh
   - name: linux
     type: Unity::VM
     image: cds-ops/ubuntu-18.04-base:stable
     flavor: b1.xlarge
     pack_command: ./pack_webapp.sh
-    test_command: ./test_webapp.sh    
+    test_command: ./test_webapp.sh
 projects:
   - packagename: com.unity.webapp.renderstreaming
 ---

--- a/.yamato/upm-ci-webapp.yml
+++ b/.yamato/upm-ci-webapp.yml
@@ -9,7 +9,7 @@ platforms:
     type: Unity::VM::osx
     image: buildfarm/mac:stable
     flavor: m1.mac
-    pack_command: ./pack_webapp.sh
+    pack_command: ./pack_webapp_mac.sh
     test_command: ./test_webapp.sh
   - name: linux
     type: Unity::VM

--- a/com.unity.renderstreaming/Editor/WebAppDownloader.cs
+++ b/com.unity.renderstreaming/Editor/WebAppDownloader.cs
@@ -12,7 +12,7 @@ namespace Unity.RenderStreaming.Editor
         const string LatestKnownVersion = "2.0.0-preview";
 
         // TODO::fix release process of webserver runtime.
-        const string PathWebAppForMac = "releases/download/{0}/webserver";
+        const string PathWebAppForMac = "releases/download/{0}/webserver_mac";
         const string PathWebAppForLinux = "releases/download/{0}/webserver";
         const string PathWebAppForWin = "releases/download/{0}/webserver.exe";
         //

--- a/pack_webapp.sh
+++ b/pack_webapp.sh
@@ -2,7 +2,16 @@ cd WebApp
 npm install
 npm run build
 npm run pack
+
+app_name=webserver
+
+if [ "$(uname)" == 'Darwin' ]; then
+  app_name=webserver_mac
+fi
+
 chmod a+x webserver
+mv webserver $app_name
+
 cd ..
 mkdir WebApp/bin~
-mv WebApp/webserver WebApp/bin~
+mv WebApp/$app_name WebApp/bin~

--- a/pack_webapp_mac.sh
+++ b/pack_webapp_mac.sh
@@ -1,9 +1,0 @@
-cd WebApp
-npm install
-npm run build
-npm run pack
-mv webserver webserver_mac
-chmod a+x webserver_mac
-cd ..
-mkdir WebApp/bin~
-mv WebApp/webserver_mac WebApp/bin~

--- a/pack_webapp_mac.sh
+++ b/pack_webapp_mac.sh
@@ -1,0 +1,9 @@
+cd WebApp
+npm install
+npm run build
+npm run pack
+mv webserver webserver_mac
+chmod a+x webserver_mac
+cd ..
+mkdir WebApp/bin~
+mv WebApp/webserver_mac WebApp/bin~


### PR DESCRIPTION
Rename appname on macos and release each binary.

Issue: https://github.com/Unity-Technologies/UnityRenderStreaming/issues/305