### PR TITLE
fix: pressing multiple buttons on a keyboard do not work well

### DIFF
--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/RemoteInput.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/RemoteInput.cs
@@ -115,7 +115,9 @@ namespace Unity.RenderStreaming
 
         public Action<int> ActionButtonClick;
 
-        static UnityEngine.Vector2Int m_prevMousePos;
+        private UnityEngine.Vector2Int m_prevMousePos;
+        private KeyboardState m_keyboardState = new KeyboardState();
+
 
         public RemoteInput(ref InputUser user)
         {
@@ -293,7 +295,8 @@ namespace Unity.RenderStreaming
                 case KeyboardEventType.KeyDown:
                     if (!repeat)
                     {
-                        InputSystem.QueueStateEvent(RemoteKeyboard, new KeyboardState((Key)keyCode));
+                        m_keyboardState.Set((Key)keyCode, true);
+                        InputSystem.QueueStateEvent(RemoteKeyboard, m_keyboardState);
                     }
                     if(character != 0)
                     {
@@ -301,7 +304,8 @@ namespace Unity.RenderStreaming
                     }
                     break;
                 case KeyboardEventType.KeyUp:
-                    InputSystem.QueueStateEvent(RemoteKeyboard, new KeyboardState());
+                    m_keyboardState.Set((Key)keyCode, false);
+                    InputSystem.QueueStateEvent(RemoteKeyboard, m_keyboardState);
                     break;
             }
         }
@@ -309,7 +313,7 @@ namespace Unity.RenderStreaming
         void ProcessMouseMoveEvent(short x, short y, byte button)
         {
             UnityEngine.Vector2Int pos = new UnityEngine.Vector2Int(x, y);
-            UnityEngine.Vector2Int delta = pos- m_prevMousePos;
+            UnityEngine.Vector2Int delta = pos - m_prevMousePos;
             InputSystem.QueueStateEvent(RemoteMouse, new MouseState {
                 position = pos,
                 delta = delta,


### PR DESCRIPTION
## Problem
Pressing the multiple keys simultaneously recognize only one of them.

## Fix

The cause of the issue is clearing the previous state of the keyboard when receive new input.

In this changes, the previous state of keyboard is kept.
So if received new input, merges it to previous state.