### PR TITLE
fix: Fix an issue of the signaling client  

### DIFF
--- a/com.unity.renderstreaming/Editor/RenderStreamingMenu.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingMenu.cs
@@ -1,8 +1,5 @@
 using UnityEditor;
-using UnityEditor.PackageManager;
-using UnityEditor.PackageManager.Requests;
 using UnityEngine;
-using System.Net;
 
 namespace Unity.RenderStreaming.Editor
 {
@@ -12,7 +9,7 @@ namespace Unity.RenderStreaming.Editor
         static void DownloadWebAppFromMenu() {
             WebAppDownloader.GetPackageVersion("com.unity.renderstreaming", (version) => {
                 var dstPath = EditorUtility.OpenFolderPanel("Select download folder", "", "");
-                WebAppDownloader.DownloadWebApp(version, dstPath);
+                WebAppDownloader.DownloadWebApp(version, dstPath, null);
             });
         }
 

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/FurioosSignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/FurioosSignaling.cs
@@ -40,6 +40,14 @@ namespace Unity.RenderStreaming.Signaling
             m_wsCloseEvent = new AutoResetEvent(false);
         }
 
+        public string connectionId
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         public void Start()
         {
             m_running = true;
@@ -54,14 +62,15 @@ namespace Unity.RenderStreaming.Signaling
         }
 
         public event OnSignedInHandler OnSignedIn;
+
+        public event OnConnectHandler OnConnect;
         public event OnOfferHandler OnOffer;
         #pragma warning disable 0067
         // this event is never used in this class
         public event OnAnswerHandler OnAnswer;
         #pragma warning restore 0067
         public event OnIceCandidateHandler OnIceCandidate;
-
-        public void SendOffer()
+        public void SendOffer(string connectionId, RTCSessionDescription offer)
         {
             throw new NotImplementedException();
         }

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/FurioosSignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/FurioosSignaling.cs
@@ -63,7 +63,7 @@ namespace Unity.RenderStreaming.Signaling
 
         public event OnSignedInHandler OnSignedIn;
 
-        public event OnConnectHandler OnConnect;
+        public event OnConnectHandler OnCreateConnection;
         public event OnOfferHandler OnOffer;
         #pragma warning disable 0067
         // this event is never used in this class

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/FurioosSignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/FurioosSignaling.cs
@@ -61,8 +61,12 @@ namespace Unity.RenderStreaming.Signaling
             m_webSocket?.Close();
         }
 
+        //todo: not implemented
+        public event OnStartHandler OnStart;
+
         public event OnSignedInHandler OnSignedIn;
 
+        //todo: not implemented
         public event OnConnectHandler OnCreateConnection;
         public event OnOfferHandler OnOffer;
         #pragma warning disable 0067
@@ -102,6 +106,11 @@ namespace Unity.RenderStreaming.Signaling
             routedMessage.message = data;
 
             WSSend(routedMessage);
+        }
+
+        public void CreateConnection()
+        {
+            this.WSSend("{\"type\":\"connect\"}");
         }
 
         private void WSManage()

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/HttpSignaling.cs
@@ -43,6 +43,7 @@ namespace Unity.RenderStreaming.Signaling
             m_running = false;
         }
 
+        public event OnStartHandler OnStart;
         public event OnConnectHandler OnCreateConnection;
 
         public event OnOfferHandler OnOffer;
@@ -83,6 +84,11 @@ namespace Unity.RenderStreaming.Signaling
             HTTPPost("signaling/candidate", data);
         }
 
+        public void CreateConnection()
+        {
+            HTTPConnect();
+        }
+
         private void HTTPPooling()
         {
             // ignore messages arrived before 30 secs ago
@@ -93,13 +99,6 @@ namespace Unity.RenderStreaming.Signaling
             while (m_running && string.IsNullOrEmpty(m_sessionId))
             {
                 HTTPCreate();
-                Thread.Sleep((int)(m_timeout * 1000));
-            }
-
-            while (m_running)
-            {
-                if(HTTPConnect())
-                    break;
                 Thread.Sleep((int)(m_timeout * 1000));
             }
 
@@ -201,6 +200,8 @@ namespace Unity.RenderStreaming.Signaling
             {
                 m_sessionId = resp.sessionId;
                 Debug.Log("Signaling: HTTP connected, sessionId : " + m_sessionId);
+
+                OnStart?.Invoke(this);
                 return true;
             }
             else

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/HttpSignaling.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net;
 using System.Net.Security;
@@ -33,6 +33,14 @@ namespace Unity.RenderStreaming.Signaling
             }
         }
 
+        public string connectionId
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         public void Start()
         {
             m_running = true;
@@ -45,6 +53,8 @@ namespace Unity.RenderStreaming.Signaling
             m_running = false;
         }
 
+        public event OnConnectHandler OnConnect;
+
         public event OnOfferHandler OnOffer;
         #pragma warning disable 0067
         // this event is never used in this class
@@ -52,7 +62,7 @@ namespace Unity.RenderStreaming.Signaling
         #pragma warning restore 0067
         public event OnIceCandidateHandler OnIceCandidate;
 
-        public void SendOffer()
+        public void SendOffer(string connectionId, RTCSessionDescription offer)
         {
             throw new NotImplementedException();
         }

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/HttpSignaling.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Net;
-using System.Net.Security;
 using System.Threading;
 using Unity.WebRTC;
 using UnityEngine;
@@ -32,12 +31,6 @@ namespace Unity.RenderStreaming.Signaling
             }
         }
 
-        public string connectionId
-        {
-            get;
-            private set;
-        }
-
         public void Start()
         {
             m_running = true;
@@ -50,7 +43,7 @@ namespace Unity.RenderStreaming.Signaling
             m_running = false;
         }
 
-        public event OnConnectHandler OnConnect;
+        public event OnConnectHandler OnCreateConnection;
 
         public event OnOfferHandler OnOffer;
         #pragma warning disable 0067
@@ -103,9 +96,10 @@ namespace Unity.RenderStreaming.Signaling
                 Thread.Sleep((int)(m_timeout * 1000));
             }
 
-            while (m_running && string.IsNullOrEmpty(connectionId))
+            while (m_running)
             {
-                HTTPConnect();
+                if(HTTPConnect())
+                    break;
                 Thread.Sleep((int)(m_timeout * 1000));
             }
 
@@ -266,8 +260,7 @@ namespace Unity.RenderStreaming.Signaling
             m_lastTimeGetOfferRequest = DateTimeExtension.ParseHttpDate(response.Headers[HttpResponseHeader.Date])
                 .ToJsMilliseconds();
 
-            connectionId = data.connectionId;
-            OnConnect?.Invoke(this);
+            OnCreateConnection?.Invoke(this, data.connectionId);
 
             return true;
         }

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/ISignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/ISignaling.cs
@@ -2,7 +2,7 @@ using Unity.WebRTC;
 
 namespace Unity.RenderStreaming.Signaling
 {
-    public delegate void OnConnectHandler(ISignaling signaling);
+    public delegate void OnConnectHandler(ISignaling signaling, string connectionId);
     public delegate void OnOfferHandler(ISignaling signaling, DescData e);
     public delegate void OnAnswerHandler(ISignaling signaling, DescData e);
     public delegate void OnIceCandidateHandler(ISignaling signaling, CandidateData e);
@@ -12,15 +12,14 @@ namespace Unity.RenderStreaming.Signaling
         void Start();
         void Stop();
 
-        event OnConnectHandler OnConnect;
+        event OnConnectHandler OnCreateConnection;
         event OnOfferHandler OnOffer;
         event OnAnswerHandler OnAnswer;
         event OnIceCandidateHandler OnIceCandidate;
 
+//        void CreateConnection();
         void SendOffer(string connectionId, RTCSessionDescription answer);
         void SendAnswer(string connectionId, RTCSessionDescription answer);
         void SendCandidate(string connectionId, RTCIceCandidate​ candidate);
-
-        string connectionId { get; }
     }
 }

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/ISignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/ISignaling.cs
@@ -2,6 +2,7 @@ using Unity.WebRTC;
 
 namespace Unity.RenderStreaming.Signaling
 {
+    public delegate void OnConnectHandler(ISignaling signaling);
     public delegate void OnOfferHandler(ISignaling signaling, DescData e);
     public delegate void OnAnswerHandler(ISignaling signaling, DescData e);
     public delegate void OnIceCandidateHandler(ISignaling signaling, CandidateData e);
@@ -11,12 +12,15 @@ namespace Unity.RenderStreaming.Signaling
         void Start();
         void Stop();
 
+        event OnConnectHandler OnConnect;
         event OnOfferHandler OnOffer;
         event OnAnswerHandler OnAnswer;
         event OnIceCandidateHandler OnIceCandidate;
 
-        void SendOffer();
+        void SendOffer(string connectionId, RTCSessionDescription answer);
         void SendAnswer(string connectionId, RTCSessionDescription answer);
         void SendCandidate(string connectionId, RTCIceCandidate​ candidate);
+
+        string connectionId { get; }
     }
 }

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/ISignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/ISignaling.cs
@@ -2,6 +2,7 @@ using Unity.WebRTC;
 
 namespace Unity.RenderStreaming.Signaling
 {
+    public delegate void OnStartHandler(ISignaling signaling);
     public delegate void OnConnectHandler(ISignaling signaling, string connectionId);
     public delegate void OnOfferHandler(ISignaling signaling, DescData e);
     public delegate void OnAnswerHandler(ISignaling signaling, DescData e);
@@ -12,12 +13,13 @@ namespace Unity.RenderStreaming.Signaling
         void Start();
         void Stop();
 
+        event OnStartHandler OnStart;
         event OnConnectHandler OnCreateConnection;
         event OnOfferHandler OnOffer;
         event OnAnswerHandler OnAnswer;
         event OnIceCandidateHandler OnIceCandidate;
 
-//        void CreateConnection();
+        void CreateConnection();
         void SendOffer(string connectionId, RTCSessionDescription answer);
         void SendAnswer(string connectionId, RTCSessionDescription answer);
         void SendCandidate(string connectionId, RTCIceCandidate​ candidate);

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/SignalingMessage.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/SignalingMessage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -55,6 +55,13 @@ namespace Unity.RenderStreaming
         public DescData[] offers;
     }
 
+    [Serializable]
+    class AnswerResDataList
+    {
+        public DescData[] answers;
+    }
+
+    
     [Serializable]
     class CandidateContainerResDataList
     {

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/WebSocketSignaling.cs
@@ -193,22 +193,23 @@ namespace Unity.RenderStreaming.Signaling
                             Debug.LogError("Signaling: Received message from unknown peer");
                         }
                     }
-                }
-                else if (!string.IsNullOrEmpty(msg.candidate))
-                {
-                    if (!string.IsNullOrEmpty(routedMessage.from))
+                    else if (routedMessage.type == "candidate")
                     {
-                        CandidateData candidate = new CandidateData();
-                        candidate.connectionId = routedMessage.from;
-                        candidate.candidate = msg.candidate;
-                        candidate.sdpMLineIndex = msg.sdpMLineIndex;
-                        candidate.sdpMid = msg.sdpMid;
-
-                        OnIceCandidate?.Invoke(this, candidate);
-                    }
-                    else
-                    {
-                        Debug.LogError("Signaling: Received message from unknown peer");
+                        if (!string.IsNullOrEmpty(routedMessage.from))
+                        {
+                            CandidateData candidate = new CandidateData
+                            {
+                                connectionId = routedMessage.@from,
+                                candidate = msg.candidate,
+                                sdpMLineIndex = msg.sdpMLineIndex,
+                                sdpMid = msg.sdpMid
+                            };
+                            OnIceCandidate?.Invoke(this, candidate);
+                        }
+                        else
+                        {
+                            Debug.LogError("Signaling: Received message from unknown peer");
+                        }
                     }
                 }
             }

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/WebSocketSignaling.cs
@@ -24,12 +24,6 @@ namespace Unity.RenderStreaming.Signaling
             m_wsCloseEvent = new AutoResetEvent(false);
         }
 
-        public string connectionId
-        {
-            get;
-            private set;
-        }
-
         public void Start()
         {
             m_running = true;
@@ -48,7 +42,7 @@ namespace Unity.RenderStreaming.Signaling
             }
         }
 
-        public event OnConnectHandler OnConnect;
+        public event OnConnectHandler OnCreateConnection;
         public event OnOfferHandler OnOffer;
         #pragma warning disable 0067
         // this event is never used in this class
@@ -159,8 +153,8 @@ namespace Unity.RenderStreaming.Signaling
                 {
                     if (routedMessage.type == "connect")
                     {
-                        connectionId = JsonUtility.FromJson<SignalingMessage>(content).connectionId;
-                        OnConnect?.Invoke(this);
+                        string connectionId = JsonUtility.FromJson<SignalingMessage>(content).connectionId;
+                        OnCreateConnection?.Invoke(this, connectionId);
                     }
                     else if (routedMessage.type == "offer")
                     {

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/Signaling/WebSocketSignaling.cs
@@ -42,6 +42,7 @@ namespace Unity.RenderStreaming.Signaling
             }
         }
 
+        public event OnStartHandler OnStart;
         public event OnConnectHandler OnCreateConnection;
         public event OnOfferHandler OnOffer;
         #pragma warning disable 0067
@@ -94,6 +95,11 @@ namespace Unity.RenderStreaming.Signaling
             routedMessage.type = "candidate";
 
             WSSend(routedMessage);
+        }
+
+        public void CreateConnection()
+        {
+            this.WSSend("{\"type\":\"connect\"}");
         }
 
         private void WSManage()
@@ -215,7 +221,7 @@ namespace Unity.RenderStreaming.Signaling
         private void WSConnected(object sender, EventArgs e)
         {
             Debug.Log("Signaling: WS connected.");
-            this.WSSend("{\"type\":\"connect\"}");
+            OnStart?.Invoke(this);
         }
 
 

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Editor.meta
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38c8801665692b14fb724364c6ec8c6f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Editor/RenderStreamingTemplateEditorTest.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Editor/RenderStreamingTemplateEditorTest.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+namespace Unity.RenderStreaming.Editor
+{
+    public class RenderStreamingTemplateEditorTest
+    {
+        [Test]
+        public void Test()
+        {
+        }
+    }
+}

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Editor/RenderStreamingTemplateEditorTest.cs.meta
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Editor/RenderStreamingTemplateEditorTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38e961ea05600444891936724fb77d57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Editor/Unity.Template.RenderStreaming.EditorTests.asmdef
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Editor/Unity.Template.RenderStreaming.EditorTests.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "Unity.Template.RenderStreaming.EditorTests",
+    "references": [
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Editor/Unity.Template.RenderStreaming.EditorTests.asmdef.meta
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Editor/Unity.Template.RenderStreaming.EditorTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4bf580de0092e704e8d907c9f13690da
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
@@ -245,7 +245,8 @@ namespace Unity.RenderStreaming
             bool startRaised2 = false;
             bool offerRaised = false;
             bool answerRaised = false;
-            bool candidateRaised = false;
+            bool candidateRaised1 = false;
+            bool candidateRaised2 = false;
             string connectionId1 = null;
 
             signaling1.Start();
@@ -266,10 +267,13 @@ namespace Unity.RenderStreaming
             signaling2.SendAnswer(connectionId1, m_DescAnswer);
             Assert.True(Wait(() => answerRaised));
 
-            signaling2.OnIceCandidate += (s, e) => { candidateRaised = true; };
+            signaling2.OnIceCandidate += (s, e) => { candidateRaised1 = true; };
             signaling1.SendCandidate(connectionId1, m_candidate);
+            Assert.True(Wait(() => candidateRaised1));
 
-            Assert.True(Wait(() => candidateRaised));
+            signaling1.OnIceCandidate += (s, e) => { candidateRaised2 = true; };
+            signaling2.SendCandidate(connectionId1, m_candidate);
+            Assert.True(Wait(() => candidateRaised2));
         }
     }
 }

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
@@ -51,21 +51,22 @@ namespace Unity.RenderStreaming
             m_SignalingType = type;
         }
 
-        // this is override method for IPrebuildSetup
+        //        // todo:(kazuki) need to upgrade com.unity.renderstreaming version 2.2
+        //        // this is override method for IPrebuildSetup
         public void Setup()
         {
-#if UNITY_EDITOR
-            string dir = System.IO.Directory.GetCurrentDirectory();
-            string fileName = Editor.WebAppDownloader.GetFileName();
-            if (System.IO.File.Exists(System.IO.Path.Combine(dir, fileName)))
-            {
-                // already exists.
-                return;
-            }
-            bool downloadRaised = false;
-            Editor.WebAppDownloader.DownloadCurrentVersionWebApp(dir, success => { downloadRaised = true; });
-            Wait(() => downloadRaised, 10000);
-#endif
+            //#if UNITY_EDITOR
+            //            string dir = System.IO.Directory.GetCurrentDirectory();
+            //            string fileName = Editor.WebAppDownloader.GetFileName();
+            //            if (System.IO.File.Exists(System.IO.Path.Combine(dir, fileName)))
+            //            {
+            //                // already exists.
+            //                return;
+            //            }
+            //            bool downloadRaised = false;
+            //            Editor.WebAppDownloader.DownloadCurrentVersionWebApp(dir, success => { downloadRaised = true; });
+            //            Wait(() => downloadRaised, 10000);
+            //#endif
         }
 
         [OneTimeSetUp]

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
@@ -148,29 +148,29 @@ namespace Unity.RenderStreaming
         [Test]
         public void OnConnect()
         {
-            bool connectRaised = false;
+            string connectionId1 = null;
 
             signaling1.Start();
-            signaling1.OnConnect += (s) => { connectRaised = true; };
-            Assert.True(Wait(() => connectRaised));
-            Assert.IsNotEmpty(signaling1.connectionId);
+            signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
+            Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1)));
+            Assert.IsNotEmpty(connectionId1);
         }
 
         [Test]
         public void OnOffer()
         {
             bool offerRaised = false;
-            bool connectRaised1 = false;
-            bool connectRaised2 = false;
+            string connectionId1 = null;
+            string connectionId2 = null;
 
             signaling1.Start();
             signaling2.Start();
-            signaling1.OnConnect += (s) => { connectRaised1 = true; };
-            signaling2.OnConnect += (s) => { connectRaised2 = true; };
-            Assert.True(Wait(() => connectRaised1 && connectRaised2));
+            signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
+            signaling2.OnCreateConnection += (s, connectionId) => { connectionId2 = connectionId; };
+            Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1) && !string.IsNullOrEmpty(connectionId2)));
 
             signaling2.OnOffer += (s, e) => { offerRaised = true; };
-            signaling1.SendOffer(signaling1.connectionId, m_DescOffer);
+            signaling1.SendOffer(connectionId1, m_DescOffer);
             Assert.True(Wait(() => offerRaised));
         }
 
@@ -180,21 +180,21 @@ namespace Unity.RenderStreaming
         {
             bool offerRaised = false;
             bool answerRaised = false;
-            bool connectRaised1 = false;
-            bool connectRaised2 = false;
+            string connectionId1 = null;
+            string connectionId2 = null;
 
             signaling1.Start();
             signaling2.Start();
-            signaling1.OnConnect += (s) => { connectRaised1 = true; };
-            signaling2.OnConnect += (s) => { connectRaised2 = true; };
-            Assert.True(Wait(() => connectRaised1 && connectRaised2));
+            signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
+            signaling2.OnCreateConnection += (s, connectionId) => { connectionId2 = connectionId; };
+            Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1) && !string.IsNullOrEmpty(connectionId2)));
 
             signaling2.OnOffer += (s, e) => { offerRaised = true; };
-            signaling1.SendOffer(signaling1.connectionId, m_DescOffer);
+            signaling1.SendOffer(connectionId1, m_DescOffer);
             Assert.True(Wait(() => offerRaised));
 
             signaling1.OnAnswer += (s, e) => { answerRaised = true; };
-            signaling2.SendAnswer(signaling1.connectionId, m_DescAnswer);
+            signaling2.SendAnswer(connectionId1, m_DescAnswer);
             Assert.True(Wait(() => answerRaised));
         }
 
@@ -204,25 +204,25 @@ namespace Unity.RenderStreaming
             bool offerRaised = false;
             bool answerRaised = false;
             bool candidateRaised = false;
-            bool connectRaised1 = false;
-            bool connectRaised2 = false;
+            string connectionId1 = null;
+            string connectionId2 = null;
 
             signaling1.Start();
             signaling2.Start();
-            signaling1.OnConnect += (s) => { connectRaised1 = true; };
-            signaling2.OnConnect += (s) => { connectRaised2 = true; };
-            Assert.True(Wait(() => connectRaised1 && connectRaised2));
+            signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
+            signaling2.OnCreateConnection += (s, connectionId) => { connectionId2 = connectionId; };
+            Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1) && !string.IsNullOrEmpty(connectionId2)));
 
             signaling2.OnOffer += (s, e) => { offerRaised = true; };
-            signaling1.SendOffer(signaling1.connectionId, m_DescOffer);
+            signaling1.SendOffer(connectionId1, m_DescOffer);
             Assert.True(Wait(() => offerRaised));
 
             signaling1.OnAnswer += (s, e) => { answerRaised = true; };
-            signaling2.SendAnswer(signaling1.connectionId, m_DescAnswer);
+            signaling2.SendAnswer(connectionId1, m_DescAnswer);
             Assert.True(Wait(() => answerRaised));
 
             signaling2.OnIceCandidate += (s, e) => { candidateRaised = true; };
-            signaling1.SendCandidate(signaling1.connectionId, m_candidate.Value);
+            signaling1.SendCandidate(connectionId1, m_candidate.Value);
 
             Assert.True(Wait(() => candidateRaised));
         }

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
@@ -148,10 +148,15 @@ namespace Unity.RenderStreaming
         [Test]
         public void OnConnect()
         {
+            bool startRaised1 = false;
             string connectionId1 = null;
 
             signaling1.Start();
+            signaling1.OnStart += s => { startRaised1 = true; };
+            Assert.True(Wait(() => startRaised1));
+
             signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
+            signaling1.CreateConnection();
             Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1)));
             Assert.IsNotEmpty(connectionId1);
         }
@@ -159,14 +164,22 @@ namespace Unity.RenderStreaming
         [Test]
         public void OnOffer()
         {
+            bool startRaised1 = false;
+            bool startRaised2 = false;
             bool offerRaised = false;
             string connectionId1 = null;
             string connectionId2 = null;
 
             signaling1.Start();
             signaling2.Start();
+            signaling1.OnStart += s => { startRaised1 = true; };
+            signaling2.OnStart += s => { startRaised2 = true; };
+            Assert.True(Wait(() => startRaised1 && startRaised2));
+
             signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
             signaling2.OnCreateConnection += (s, connectionId) => { connectionId2 = connectionId; };
+            signaling1.CreateConnection();
+            signaling2.CreateConnection();
             Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1) && !string.IsNullOrEmpty(connectionId2)));
 
             signaling2.OnOffer += (s, e) => { offerRaised = true; };
@@ -178,6 +191,8 @@ namespace Unity.RenderStreaming
         [Test]
         public void OnAnswer()
         {
+            bool startRaised1 = false;
+            bool startRaised2 = false;
             bool offerRaised = false;
             bool answerRaised = false;
             string connectionId1 = null;
@@ -185,8 +200,14 @@ namespace Unity.RenderStreaming
 
             signaling1.Start();
             signaling2.Start();
+            signaling1.OnStart += s => { startRaised1 = true; };
+            signaling2.OnStart += s => { startRaised2 = true; };
+            Assert.True(Wait(() => startRaised1 && startRaised2));
+
             signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
             signaling2.OnCreateConnection += (s, connectionId) => { connectionId2 = connectionId; };
+            signaling1.CreateConnection();
+            signaling2.CreateConnection();
             Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1) && !string.IsNullOrEmpty(connectionId2)));
 
             signaling2.OnOffer += (s, e) => { offerRaised = true; };
@@ -201,6 +222,8 @@ namespace Unity.RenderStreaming
         [Test]
         public void OnCandidate()
         {
+            bool startRaised1 = false;
+            bool startRaised2 = false;
             bool offerRaised = false;
             bool answerRaised = false;
             bool candidateRaised = false;
@@ -209,8 +232,14 @@ namespace Unity.RenderStreaming
 
             signaling1.Start();
             signaling2.Start();
+            signaling1.OnStart += s => { startRaised1 = true; };
+            signaling2.OnStart += s => { startRaised2 = true; };
+            Assert.True(Wait(() => startRaised1 && startRaised2));
+
             signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
             signaling2.OnCreateConnection += (s, connectionId) => { connectionId2 = connectionId; };
+            signaling1.CreateConnection();
+            signaling2.CreateConnection();
             Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1) && !string.IsNullOrEmpty(connectionId2)));
 
             signaling2.OnOffer += (s, e) => { offerRaised = true; };

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
@@ -168,7 +168,6 @@ namespace Unity.RenderStreaming
             bool startRaised2 = false;
             bool offerRaised = false;
             string connectionId1 = null;
-            string connectionId2 = null;
 
             signaling1.Start();
             signaling2.Start();
@@ -177,10 +176,8 @@ namespace Unity.RenderStreaming
             Assert.True(Wait(() => startRaised1 && startRaised2));
 
             signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
-            signaling2.OnCreateConnection += (s, connectionId) => { connectionId2 = connectionId; };
             signaling1.CreateConnection();
-            signaling2.CreateConnection();
-            Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1) && !string.IsNullOrEmpty(connectionId2)));
+            Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1)));
 
             signaling2.OnOffer += (s, e) => { offerRaised = true; };
             signaling1.SendOffer(connectionId1, m_DescOffer);
@@ -196,7 +193,6 @@ namespace Unity.RenderStreaming
             bool offerRaised = false;
             bool answerRaised = false;
             string connectionId1 = null;
-            string connectionId2 = null;
 
             signaling1.Start();
             signaling2.Start();
@@ -205,10 +201,8 @@ namespace Unity.RenderStreaming
             Assert.True(Wait(() => startRaised1 && startRaised2));
 
             signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
-            signaling2.OnCreateConnection += (s, connectionId) => { connectionId2 = connectionId; };
             signaling1.CreateConnection();
-            signaling2.CreateConnection();
-            Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1) && !string.IsNullOrEmpty(connectionId2)));
+            Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1)));
 
             signaling2.OnOffer += (s, e) => { offerRaised = true; };
             signaling1.SendOffer(connectionId1, m_DescOffer);
@@ -228,7 +222,6 @@ namespace Unity.RenderStreaming
             bool answerRaised = false;
             bool candidateRaised = false;
             string connectionId1 = null;
-            string connectionId2 = null;
 
             signaling1.Start();
             signaling2.Start();
@@ -237,10 +230,8 @@ namespace Unity.RenderStreaming
             Assert.True(Wait(() => startRaised1 && startRaised2));
 
             signaling1.OnCreateConnection += (s, connectionId) => { connectionId1 = connectionId; };
-            signaling2.OnCreateConnection += (s, connectionId) => { connectionId2 = connectionId; };
             signaling1.CreateConnection();
-            signaling2.CreateConnection();
-            Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1) && !string.IsNullOrEmpty(connectionId2)));
+            Assert.True(Wait(() => !string.IsNullOrEmpty(connectionId1)));
 
             signaling2.OnOffer += (s, e) => { offerRaised = true; };
             signaling1.SendOffer(connectionId1, m_DescOffer);

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections;
+using System.Threading;
+using NUnit.Framework;
+using Unity.RenderStreaming.Signaling;
+using Unity.WebRTC;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.RenderStreaming
+{
+    public class SignalingTest
+    {
+        static void Wait(Func<bool> condition, int millisecondsTimeout = 1000, int millisecondsInterval = 100)
+        {
+            if (millisecondsTimeout < millisecondsInterval)
+            {
+                throw new ArgumentException();
+            }
+
+            int time = 0;
+            while (!condition() || millisecondsTimeout > time)
+            {
+                Thread.Sleep(millisecondsInterval);
+                time += millisecondsInterval;
+            }
+        }
+
+
+        private RTCSessionDescription desc;
+
+        [UnitySetUp]
+        public IEnumerator OntTimeSetUp()
+        {
+            WebRTC.WebRTC.Initialize();
+            var peer = new RTCPeerConnection();
+
+            RTCOfferOptions options = new RTCOfferOptions
+            {
+                iceRestart = false,
+                offerToReceiveAudio = false,
+                offerToReceiveVideo = false,
+            };
+            var op = peer.CreateOffer(ref options);
+            yield return op;
+            desc = op.Desc;
+        }
+
+        [UnityTearDown]
+        public IEnumerator OneTimeTearDown()
+        {
+            yield return 0;
+            WebRTC.WebRTC.Dispose();
+        }
+
+
+        [Test]
+        public void StartAndStop()
+        {
+            ISignaling signaling = new WebSocketSignaling("ws://localhost", 1000);
+
+            signaling.Start();
+            signaling.Stop();
+        }
+
+        [Test]
+        public void OnConnect()
+        {
+            ISignaling signaling = new WebSocketSignaling("ws://localhost", 1000);
+            bool connectRaised = false;
+
+            signaling.Start();
+            signaling.OnConnect += (s) => { connectRaised = true; };
+            Wait(() => connectRaised);
+
+            Assert.That(connectRaised, Is.True.After(1000, 100));
+            Assert.That(signaling.connectionId, Is.Not.Null.After(1000, 100));
+            signaling.Stop();
+        }
+
+        [Test]
+        public void OnOffer()
+        {
+            ISignaling signaling1 = new WebSocketSignaling("ws://localhost", 1000);
+            ISignaling signaling2 = new WebSocketSignaling("ws://localhost", 1000);
+
+            bool offerRaised = false;
+            bool connectRaised1 = false;
+            bool connectRaised2 = false;
+
+            signaling1.Start();
+            signaling2.Start();
+            signaling1.OnConnect += (s) => { connectRaised1 = true; };
+            signaling2.OnConnect += (s) => { connectRaised2 = true; };
+            Wait(() => connectRaised1 && connectRaised1);
+
+            signaling2.OnOffer += (s, e) => { offerRaised = true; };
+            signaling1.SendOffer(signaling2.connectionId, desc);
+            Wait(() => offerRaised);
+            Assert.That(offerRaised, Is.True.After(1000));
+
+            signaling1.Stop();
+            signaling2.Stop();
+        }
+
+
+        [Test]
+        public void OnAnswer()
+        {
+            ISignaling signaling1 = new WebSocketSignaling("ws://localhost", 1000);
+            ISignaling signaling2 = new WebSocketSignaling("ws://localhost", 1000);
+
+            bool answerRaised = false;
+            bool connectRaised1 = false;
+            bool connectRaised2 = false;
+
+            signaling1.Start();
+            signaling2.Start();
+            signaling1.OnConnect += (s) => { connectRaised1 = true; };
+            signaling2.OnConnect += (s) => { connectRaised2 = true; };
+            Wait(() => connectRaised1 && connectRaised1);
+
+            signaling2.OnAnswer += (s, e) => { answerRaised = true; };
+            signaling1.SendAnswer(signaling2.connectionId, desc);
+            Wait(() => answerRaised);
+            Assert.That(answerRaised, Is.True.After(1000));
+
+//            signaling1.SendCandidate(signaling2.connectionId, candidate);
+
+            signaling1.Stop();
+            signaling2.Stop();
+        }
+    }
+}

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Threading;
+using System.Diagnostics;
+using System.Linq;
 using NUnit.Framework;
 using Unity.RenderStreaming.Signaling;
 using Unity.WebRTC;
@@ -9,9 +11,11 @@ using UnityEngine.TestTools;
 
 namespace Unity.RenderStreaming
 {
+    [TestFixture(typeof(WebSocketSignaling))]
+    [TestFixture(typeof(HttpSignaling))]
     public class SignalingTest
     {
-        static void Wait(Func<bool> condition, int millisecondsTimeout = 1000, int millisecondsInterval = 100)
+        static bool Wait(Func<bool> condition, int millisecondsTimeout = 1000, int millisecondsInterval = 100)
         {
             if (millisecondsTimeout < millisecondsInterval)
             {
@@ -19,71 +23,142 @@ namespace Unity.RenderStreaming
             }
 
             int time = 0;
-            while (!condition() || millisecondsTimeout > time)
+            while (!condition() && millisecondsTimeout > time)
             {
                 Thread.Sleep(millisecondsInterval);
                 time += millisecondsInterval;
             }
+            return millisecondsTimeout > time;
         }
 
+        private readonly Type m_SignalingType;
+        private Process m_ServerProcess;
+        private RTCSessionDescription m_DescOffer;
+        private RTCSessionDescription m_DescAnswer;
+        private RTCIceCandidate​? m_candidate;
 
-        private RTCSessionDescription desc;
+        private ISignaling signaling1;
+        private ISignaling signaling2;
+
+        public SignalingTest(Type type)
+        {
+            m_SignalingType = type;
+        }
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            // todo: download and launch webapp for signaling test
+            m_ServerProcess = new Process();
+
+            string dir = System.IO.Directory.GetCurrentDirectory();
+            string filename = System.IO.Path.Combine(dir, "webserver.exe");
+
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                WindowStyle = ProcessWindowStyle.Hidden,
+                FileName = filename,
+                UseShellExecute = false
+            };
+
+            if (m_SignalingType == typeof(WebSocketSignaling))
+            {
+                startInfo.Arguments = "-w";
+            }
+            m_ServerProcess.StartInfo = startInfo;
+            m_ServerProcess.OutputDataReceived += (sender, e) =>
+            {
+                UnityEngine.Debug.Log(e.Data);
+            };
+            bool success = m_ServerProcess.Start();
+            Assert.True(success);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            m_ServerProcess.Kill();
+        }
+
+        ISignaling CreateSignaling(Type type)
+        {
+            if (type == typeof(WebSocketSignaling))
+            {
+                return new WebSocketSignaling("ws://localhost", 0.1f);
+            }
+            if (type == typeof(HttpSignaling))
+            {
+                return new HttpSignaling("http://localhost", 0.1f);
+            }
+            throw new ArgumentException();
+        }
 
         [UnitySetUp]
-        public IEnumerator OntTimeSetUp()
+        public IEnumerator UnitySetUp()
         {
             WebRTC.WebRTC.Initialize();
-            var peer = new RTCPeerConnection();
 
-            RTCOfferOptions options = new RTCOfferOptions
-            {
-                iceRestart = false,
-                offerToReceiveAudio = false,
-                offerToReceiveVideo = false,
-            };
-            var op = peer.CreateOffer(ref options);
-            yield return op;
-            desc = op.Desc;
+            RTCConfiguration config = default;
+            config.iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } };
+
+            var peer1 = new RTCPeerConnection(ref config);
+            var peer2 = new RTCPeerConnection(ref config);
+            peer1.OnIceCandidate += candidate => { m_candidate = candidate; };
+
+            MediaStream stream = WebRTC.Audio.CaptureStream();
+            peer1.AddTrack(stream.GetTracks().First());
+
+            RTCOfferOptions offerOptions = new RTCOfferOptions();
+            var op1 = peer1.CreateOffer(ref offerOptions);
+            yield return op1;
+            m_DescOffer = op1.Desc;
+            var op2 = peer1.SetLocalDescription(ref m_DescOffer);
+            yield return op2;
+            var op3 = peer2.SetRemoteDescription(ref m_DescOffer);
+            yield return op3;
+
+            RTCAnswerOptions answerOptions = new RTCAnswerOptions();
+            var op4 = peer2.CreateAnswer(ref answerOptions);
+            yield return op4;
+            m_DescAnswer = op4.Desc;
+            var op5 = peer2.SetLocalDescription(ref m_DescAnswer);
+            yield return op5;
+            var op6 = peer1.SetRemoteDescription(ref m_DescAnswer);
+            yield return op6;
+
+            yield return new WaitUntil(() => m_candidate != null);
+
+            stream.Dispose();
+            peer1.Close();
+            peer2.Close();
+
+            signaling1 = CreateSignaling(m_SignalingType);
+            signaling2 = CreateSignaling(m_SignalingType);
         }
 
-        [UnityTearDown]
-        public IEnumerator OneTimeTearDown()
+        [TearDown]
+        public void TearDown()
         {
-            yield return 0;
             WebRTC.WebRTC.Dispose();
-        }
 
-
-        [Test]
-        public void StartAndStop()
-        {
-            ISignaling signaling = new WebSocketSignaling("ws://localhost", 1000);
-
-            signaling.Start();
-            signaling.Stop();
+            signaling1.Stop();
+            signaling2.Stop();
         }
 
         [Test]
         public void OnConnect()
         {
-            ISignaling signaling = new WebSocketSignaling("ws://localhost", 1000);
             bool connectRaised = false;
 
-            signaling.Start();
-            signaling.OnConnect += (s) => { connectRaised = true; };
-            Wait(() => connectRaised);
-
-            Assert.That(connectRaised, Is.True.After(1000, 100));
-            Assert.That(signaling.connectionId, Is.Not.Null.After(1000, 100));
-            signaling.Stop();
+            signaling1.Start();
+            signaling1.OnConnect += (s) => { connectRaised = true; };
+            Assert.True(Wait(() => connectRaised));
+            Assert.IsNotEmpty(signaling1.connectionId);
         }
 
         [Test]
         public void OnOffer()
         {
-            ISignaling signaling1 = new WebSocketSignaling("ws://localhost", 1000);
-            ISignaling signaling2 = new WebSocketSignaling("ws://localhost", 1000);
-
             bool offerRaised = false;
             bool connectRaised1 = false;
             bool connectRaised2 = false;
@@ -92,24 +167,18 @@ namespace Unity.RenderStreaming
             signaling2.Start();
             signaling1.OnConnect += (s) => { connectRaised1 = true; };
             signaling2.OnConnect += (s) => { connectRaised2 = true; };
-            Wait(() => connectRaised1 && connectRaised1);
+            Assert.True(Wait(() => connectRaised1 && connectRaised2));
 
             signaling2.OnOffer += (s, e) => { offerRaised = true; };
-            signaling1.SendOffer(signaling2.connectionId, desc);
-            Wait(() => offerRaised);
-            Assert.That(offerRaised, Is.True.After(1000));
-
-            signaling1.Stop();
-            signaling2.Stop();
+            signaling1.SendOffer(signaling1.connectionId, m_DescOffer);
+            Assert.True(Wait(() => offerRaised));
         }
 
 
         [Test]
         public void OnAnswer()
         {
-            ISignaling signaling1 = new WebSocketSignaling("ws://localhost", 1000);
-            ISignaling signaling2 = new WebSocketSignaling("ws://localhost", 1000);
-
+            bool offerRaised = false;
             bool answerRaised = false;
             bool connectRaised1 = false;
             bool connectRaised2 = false;
@@ -118,17 +187,44 @@ namespace Unity.RenderStreaming
             signaling2.Start();
             signaling1.OnConnect += (s) => { connectRaised1 = true; };
             signaling2.OnConnect += (s) => { connectRaised2 = true; };
-            Wait(() => connectRaised1 && connectRaised1);
+            Assert.True(Wait(() => connectRaised1 && connectRaised2));
 
-            signaling2.OnAnswer += (s, e) => { answerRaised = true; };
-            signaling1.SendAnswer(signaling2.connectionId, desc);
-            Wait(() => answerRaised);
-            Assert.That(answerRaised, Is.True.After(1000));
+            signaling2.OnOffer += (s, e) => { offerRaised = true; };
+            signaling1.SendOffer(signaling1.connectionId, m_DescOffer);
+            Assert.True(Wait(() => offerRaised));
 
-//            signaling1.SendCandidate(signaling2.connectionId, candidate);
+            signaling1.OnAnswer += (s, e) => { answerRaised = true; };
+            signaling2.SendAnswer(signaling1.connectionId, m_DescAnswer);
+            Assert.True(Wait(() => answerRaised));
+        }
 
-            signaling1.Stop();
-            signaling2.Stop();
+        [Test]
+        public void OnCandidate()
+        {
+            bool offerRaised = false;
+            bool answerRaised = false;
+            bool candidateRaised = false;
+            bool connectRaised1 = false;
+            bool connectRaised2 = false;
+
+            signaling1.Start();
+            signaling2.Start();
+            signaling1.OnConnect += (s) => { connectRaised1 = true; };
+            signaling2.OnConnect += (s) => { connectRaised2 = true; };
+            Assert.True(Wait(() => connectRaised1 && connectRaised2));
+
+            signaling2.OnOffer += (s, e) => { offerRaised = true; };
+            signaling1.SendOffer(signaling1.connectionId, m_DescOffer);
+            Assert.True(Wait(() => offerRaised));
+
+            signaling1.OnAnswer += (s, e) => { answerRaised = true; };
+            signaling2.SendAnswer(signaling1.connectionId, m_DescAnswer);
+            Assert.True(Wait(() => answerRaised));
+
+            signaling2.OnIceCandidate += (s, e) => { candidateRaised = true; };
+            signaling1.SendCandidate(signaling1.connectionId, m_candidate.Value);
+
+            Assert.True(Wait(() => candidateRaised));
         }
     }
 }

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs.meta
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/SignalingTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc2fe5ae0229c5a4f94d1148cdd98322
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/Unity.Template.RenderStreaming.RuntimeTests.asmdef
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/Unity.Template.RenderStreaming.RuntimeTests.asmdef
@@ -4,7 +4,8 @@
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:0acc523941302664db1f4e527237feb3",
         "GUID:40a5acf76f04c4c8ebb69605e4b0d5c7",
-        "GUID:f12aafacab75a87499e7e45c873ffab8"
+        "GUID:f12aafacab75a87499e7e45c873ffab8",
+        "GUID:7e479a0c97f111c48b6a279fad867f28"
     ],
     "includePlatforms": [
         "Editor",

--- a/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/Unity.Template.RenderStreaming.RuntimeTests.asmdef
+++ b/com.unity.template.renderstreaming-hd/Assets/Tests/Runtime/Unity.Template.RenderStreaming.RuntimeTests.asmdef
@@ -2,7 +2,9 @@
     "name": "Unity.Template.RenderStreaming.RuntimeTests",
     "references": [
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
-        "GUID:0acc523941302664db1f4e527237feb3"
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:40a5acf76f04c4c8ebb69605e4b0d5c7",
+        "GUID:f12aafacab75a87499e7e45c873ffab8"
     ],
     "includePlatforms": [
         "Editor",


### PR DESCRIPTION
This PR fixes the issue occurred when signaling server using websocket.
By the issue, signaling is not work well. Even if using TURN server, video stream can not arrive another peer.

### Updates
- The signaling client had the bug: When the client received the "candidate" message, a callback was not fired.
- Add unittests to reproduce the issue.

### TODO
- Add signaling test running on CI after the package com.unity.renderstreaming upgrade 2.2.0.