### PR TITLE
fix : Stop editing SDP to custom bitrate

### DIFF
--- a/WebApp/public/scripts/video-player.js
+++ b/WebApp/public/scripts/video-player.js
@@ -166,7 +166,6 @@ export class VideoPlayer {
     const offer = await this.pc.createOffer(this.offerOptions);
 
     // set local sdp
-    offer.sdp = offer.sdp.replace(/useinbandfec=1/, 'useinbandfec=1;stereo=1;maxaveragebitrate=1048576');
     const desc = new RTCSessionDescription({ sdp: offer.sdp, type: "offer" });
     await this.pc.setLocalDescription(desc);
     await this.signaling.sendOffer(offer.sdp);

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/CameraStreamer.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/CameraStreamer.cs
@@ -1,3 +1,4 @@
+using System;
 using Unity.WebRTC;
 using UnityEngine;
 
@@ -12,9 +13,16 @@ namespace Unity.RenderStreaming
         private Camera m_camera;
         private VideoStreamTrack m_track;
 
-        public void ChangeBitrate(ulong bitrate)
+        public void ChangeBitrate(int bitrate)
         {
-            RenderStreaming.Instance?.ChangeBitrate(m_track, bitrate);
+            RenderStreaming.Instance?.ChangeVideoParameters(
+                m_track, Convert.ToUInt64(bitrate), null);
+        }
+
+        public void ChangeFramerate(int framerate)
+        {
+            RenderStreaming.Instance?.ChangeVideoParameters(
+                m_track, null, Convert.ToUInt32(framerate));
         }
 
         void Awake()

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/CameraStreamer.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/CameraStreamer.cs
@@ -12,6 +12,11 @@ namespace Unity.RenderStreaming
         private Camera m_camera;
         private VideoStreamTrack m_track;
 
+        public void ChangeBitrate(ulong bitrate)
+        {
+            RenderStreaming.Instance?.ChangeBitrate(m_track, bitrate);
+        }
+
         void Awake()
         {
             m_camera = GetComponent<Camera>();

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/RenderStreaming.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/RenderStreaming.cs
@@ -95,7 +95,6 @@ namespace Unity.RenderStreaming
             m_conf = default;
             m_conf.iceServers = iceServers;
             StartCoroutine(WebRTC.WebRTC.Update());
-            StartCoroutine(Monitor());
         }
 
         void OnEnable()

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/WebCamStreamer.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/WebCamStreamer.cs
@@ -17,6 +17,11 @@ namespace Unity.RenderStreaming
         private VideoStreamTrack m_track;
         private WebCamTexture m_webCamTexture;
 
+        public void ChangeBitrate(ulong bitrate)
+        {
+            RenderStreaming.Instance?.ChangeBitrate(m_track, bitrate);
+        }
+
         IEnumerator Start()
         {
             if (WebCamTexture.devices.Length == 0)

--- a/com.unity.template.renderstreaming-hd/Assets/Scripts/WebCamStreamer.cs
+++ b/com.unity.template.renderstreaming-hd/Assets/Scripts/WebCamStreamer.cs
@@ -1,7 +1,7 @@
+using System;
 using System.Collections;
 using Unity.WebRTC;
 using UnityEngine;
-using UnityEngine.Experimental.Rendering;
 
 namespace Unity.RenderStreaming
 {
@@ -17,9 +17,16 @@ namespace Unity.RenderStreaming
         private VideoStreamTrack m_track;
         private WebCamTexture m_webCamTexture;
 
-        public void ChangeBitrate(ulong bitrate)
+        public void ChangeBitrate(int bitrate)
         {
-            RenderStreaming.Instance?.ChangeBitrate(m_track, bitrate);
+            RenderStreaming.Instance?.ChangeVideoParameters(
+                m_track, Convert.ToUInt64(bitrate), null);
+        }
+
+        public void ChangeFramerate(int framerate)
+        {
+            RenderStreaming.Instance?.ChangeVideoParameters(
+                m_track, null, Convert.ToUInt32(framerate));
         }
 
         IEnumerator Start()


### PR DESCRIPTION
Related issues.
https://github.com/Unity-Technologies/com.unity.webrtc/issues/182
https://github.com/Unity-Technologies/com.unity.webrtc/issues/183

In this pull request, removed codes which make customized SDPs to change bitrate.
To customize SDPs happens unexpected results like the bitrate become unstable.