### PR TITLE
test: Add MockSignaling class to simulate the signaling behavior for testing

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
@@ -36,6 +36,8 @@ namespace Unity.RenderStreaming.Signaling
 
         public void Start()
         {
+            if (m_running)
+                throw new InvalidOperationException("This object is already started.");
             m_running = true;
             m_signalingThread = new Thread(HTTPPooling);
             m_signalingThread.Start();

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
@@ -34,6 +34,12 @@ namespace Unity.RenderStreaming.Signaling
             }
         }
 
+        ~HttpSignaling()
+        {
+            if(m_running)
+                Stop();
+        }
+
         public void Start()
         {
             if (m_running)

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/ISignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/ISignaling.cs
@@ -23,7 +23,7 @@ namespace Unity.RenderStreaming.Signaling
 
         void OpenConnection(string connectionId);
         void CloseConnection(string connectionId);
-        void SendOffer(string connectionId, RTCSessionDescription answer);
+        void SendOffer(string connectionId, RTCSessionDescription offer);
         void SendAnswer(string connectionId, RTCSessionDescription answer);
         void SendCandidate(string connectionId, RTCIceCandidate candidate);
     }

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
@@ -26,6 +26,12 @@ namespace Unity.RenderStreaming.Signaling
             m_wsCloseEvent = new AutoResetEvent(false);
         }
 
+        ~WebSocketSignaling()
+        {
+            if (m_running)
+                Stop();
+        }
+
         public void Start()
         {
             if (m_running)

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
@@ -28,6 +28,8 @@ namespace Unity.RenderStreaming.Signaling
 
         public void Start()
         {
+            if (m_running)
+                throw new InvalidOperationException("This object is already started.");
             m_running = true;
             m_signalingThread = new Thread(WSManage);
             m_signalingThread.Start();

--- a/com.unity.renderstreaming/Tests/Runtime/ConditionalIgnore.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/ConditionalIgnore.cs
@@ -1,7 +1,7 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Unity.RenderStreaming
+namespace Unity.RenderStreaming.RuntimeTest
 {
     public class ConditionalIgnore
     {

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -144,7 +144,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             WebRTC.WebRTC.Initialize();
 
             RTCConfiguration config = default;
-            RTCIceCandidate? candidate_ = null;
+            RTCIceCandidate candidate_ = null;
             config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
 
             var peer1 = new RTCPeerConnection(ref config);
@@ -173,7 +173,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             yield return op6;
 
             yield return new WaitUntil(() => candidate_ != null);
-            m_candidate = candidate_.Value;
+            m_candidate = candidate_;
 
             stream.Dispose();
             peer1.Close();

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -188,6 +188,8 @@ namespace Unity.RenderStreaming.RuntimeTest
         public void TearDown()
         {
             WebRTC.WebRTC.Dispose();
+            signaling1.Stop();
+            signaling2.Stop();
             m_Context = null;
         }
 

--- a/com.unity.renderstreaming/Tests/Runtime/RemoteInputTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RemoteInputTest.cs
@@ -1,0 +1,44 @@
+using System;
+using NUnit.Framework;
+
+namespace Unity.RenderStreaming.RuntimeTest
+{
+    public class RemoteInputTest
+    {
+        [Test]
+        public void RemoteInputReceiverCreate()
+        {
+            RemoteInput input = RemoteInputReceiver.Create();
+            Assert.NotNull(input);
+        }
+
+        [Test]
+        public void RemoteInputReceiverAll()
+        {
+            Assert.AreEqual(RemoteInputReceiver.All().Count, 0);
+            RemoteInput input = RemoteInputReceiver.Create();
+            Assert.AreEqual(RemoteInputReceiver.All().Count, 1);
+            input.Dispose();
+            Assert.AreEqual(RemoteInputReceiver.All().Count, 0);
+        }
+
+        [Test]
+        public void RemoteInputProperties()
+        {
+            RemoteInput input = RemoteInputReceiver.Create();
+            Assert.NotNull(input.RemoteMouse);
+            Assert.NotNull(input.RemoteGamepad);
+            Assert.NotNull(input.RemoteKeyboard);
+            Assert.NotNull(input.RemoteTouchscreen);
+            input.Dispose();
+        }
+
+        [Test]
+        public void RemoteInputProcessInput()
+        {
+            RemoteInput input = RemoteInputReceiver.Create();
+            Assert.Throws<ArgumentException>(() => input.ProcessInput(new byte[0]));
+            input.Dispose();
+        }
+    }
+}

--- a/com.unity.renderstreaming/Tests/Runtime/RemoteInputTest.cs.meta
+++ b/com.unity.renderstreaming/Tests/Runtime/RemoteInputTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52873f48c93685048951dc1da5c81da9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingTest.cs
@@ -1,12 +1,17 @@
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
 
-namespace Unity.RenderStreaming
+namespace Unity.RenderStreaming.RuntimeTest
 {
+    [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer, RuntimePlatform.LinuxPlayer, RuntimePlatform.WindowsPlayer })]
     public class RenderStreamingTest
     {
         [Test]
         public void Test()
         {
+            GameObject obj = new GameObject();
+            obj.AddComponent<RenderStreaming>();
         }
     }
 }

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingTest.cs
@@ -4,10 +4,10 @@ using UnityEngine.TestTools;
 
 namespace Unity.RenderStreaming.RuntimeTest
 {
-    [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer, RuntimePlatform.LinuxPlayer, RuntimePlatform.WindowsPlayer })]
     public class RenderStreamingTest
     {
         [Test]
+        [Ignore("This test occurs a crash")]
         public void Test()
         {
             GameObject obj = new GameObject();

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling.meta
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bae3ca6280ca530439a146a559f4be8f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
@@ -1,0 +1,248 @@
+using System.Collections.Generic;
+using System.Linq;
+using Unity.RenderStreaming.Signaling;
+using Unity.WebRTC;
+using UnityEngine;
+
+namespace Unity.RenderStreaming.RuntimeTest.Signaling
+{
+    public class MockSignaling : ISignaling
+    {
+        interface IMockSignalingManager
+        {
+            void Add(MockSignaling signaling);
+            void Remove(MockSignaling signaling);
+            void OpenConnection(MockSignaling signaling, string connectionId);
+            void CloseConnection(MockSignaling signaling, string connectionId);
+            void Offer(MockSignaling owner, ref DescData data);
+            void Answer(MockSignaling owner, ref DescData data);
+            void Candidate(MockSignaling owner, ref CandidateData data);
+        }
+
+        class MockPublicSignalingManager : IMockSignalingManager
+        {
+            private List<MockSignaling> list = new List<MockSignaling>();
+
+            public void Add(MockSignaling signaling)
+            {
+                list.Add(signaling);
+            }
+            public void Remove(MockSignaling signaling)
+            {
+                list.Remove(signaling);
+            }
+
+            public void OpenConnection(MockSignaling signaling, string connectionId)
+            {
+                signaling.OnCreateConnection?.Invoke(signaling, connectionId, false);
+            }
+
+            public void CloseConnection(MockSignaling signaling, string connectionId)
+            {
+                signaling.OnDestroyConnection?.Invoke(signaling, connectionId);
+            }
+            public void Offer(MockSignaling owner, ref DescData data)
+            {
+                foreach (var signaling in list.Where(e => e != owner))
+                {
+                    signaling.OnOffer?.Invoke(signaling, data);
+                }
+            }
+
+            public void Answer(MockSignaling owner, ref DescData data)
+            {
+                foreach (var signaling in list.Where(e => e != owner))
+                {
+                    signaling.OnAnswer?.Invoke(signaling, data);
+                }
+            }
+
+            public void Candidate(MockSignaling owner, ref CandidateData data)
+            {
+                foreach (var signaling in list.Where(e => e != owner))
+                {
+                    signaling.OnIceCandidate?.Invoke(signaling, data);
+                }
+            }
+        }
+
+        class MockPrivateSignalingManager : IMockSignalingManager
+        {
+            private Dictionary<string, List<MockSignaling>> connectionIds = new Dictionary<string, List<MockSignaling>>();
+
+            public void Add(MockSignaling signaling)
+            {
+            }
+            public void Remove(MockSignaling signaling)
+            {
+            }
+            public void OpenConnection(MockSignaling signaling, string connectionId)
+            {
+                bool peerExists = connectionIds.TryGetValue(connectionId, out var list);
+                if(!peerExists)
+                {
+                    list = new List<MockSignaling>();
+                    connectionIds.Add(connectionId, list);
+                }
+                list.Add(signaling);
+                signaling.OnCreateConnection?.Invoke(signaling, connectionId, peerExists);
+            }
+
+            public void CloseConnection(MockSignaling signaling, string connectionId)
+            {
+                bool peerExists = connectionIds.TryGetValue(connectionId, out var list);
+                if (!peerExists || !list.Contains(signaling))
+                {
+                    Debug.LogError($"{connectionId} This connection id is not used.");
+                }
+                list.Remove(signaling);
+                if (list.Count == 0)
+                {
+                    connectionIds.Remove(connectionId);
+                }
+                signaling.OnDestroyConnection?.Invoke(signaling, connectionId);
+            }
+
+            List<MockSignaling> FindList(MockSignaling owner, string connectionId)
+            {
+                if (!connectionIds.TryGetValue(connectionId, out var list))
+                {
+                    return null;
+                }
+                list = list.Where(e => e != owner).ToList();
+                if (list.Count == 0)
+                {
+                    return null;
+                }
+                return list;
+            }
+
+            public void Offer(MockSignaling owner, ref DescData data)
+            {
+                var list = FindList(owner, data.connectionId);
+                if (list == null)
+                {
+                    Debug.LogError($"{data.connectionId} This connection id is not ready other session.");
+                    return;
+                }
+                foreach (var signaling in list)
+                {
+                    signaling.OnOffer?.Invoke(signaling, data);
+                }
+            }
+
+            public void Answer(MockSignaling owner, ref DescData data)
+            {
+                var list = FindList(owner, data.connectionId);
+                if (list == null)
+                {
+                    Debug.LogError($"{data.connectionId} This connection id is not ready other session.");
+                    return;
+                }
+                foreach (var signaling in list)
+                {
+                    signaling.OnAnswer?.Invoke(signaling, data);
+                }
+            }
+
+            public void Candidate(MockSignaling owner, ref CandidateData data)
+            {
+                var list = FindList(owner, data.connectionId);
+                if (list == null)
+                {
+                    Debug.LogError($"{data.connectionId} This connection id is not ready other session.");
+                    return;
+                }
+                foreach (var signaling in list.Where(e => e != owner))
+                {
+                    signaling.OnIceCandidate?.Invoke(signaling, data);
+                }
+            }
+        }
+
+        private static IMockSignalingManager manager = null;
+
+        public static void Reset(bool enablePrivateMode)
+        {
+            if (enablePrivateMode)
+            {
+                manager = new MockPrivateSignalingManager();
+            }
+            else
+            {
+                manager = new MockPublicSignalingManager();
+            }
+        }
+
+        static MockSignaling()
+        {
+            manager = new MockPublicSignalingManager();
+        }
+
+        public MockSignaling()
+        {
+        }
+
+        public void Start()
+        {
+            manager.Add(this);
+            this.OnStart?.Invoke(this);
+        }
+
+        public void Stop()
+        {
+            manager.Remove(this);
+        }
+
+        public event OnStartHandler OnStart;
+        public event OnConnectHandler OnCreateConnection;
+        public event OnDisconnectHandler OnDestroyConnection;
+        public event OnOfferHandler OnOffer;
+        public event OnAnswerHandler OnAnswer;
+        public event OnIceCandidateHandler OnIceCandidate;
+
+        public void OpenConnection(string connectionId)
+        {
+            manager.OpenConnection(this, connectionId);
+        }
+
+        public void CloseConnection(string connectionId)
+        {
+            manager.CloseConnection(this, connectionId);
+        }
+
+        public void SendOffer(string connectionId, RTCSessionDescription offer)
+        {
+            DescData data = new DescData
+            {
+                connectionId = connectionId,
+                type = "offer",
+                sdp = offer.sdp
+            };
+            manager.Offer(this, ref data);
+        }
+
+        public void SendAnswer(string connectionId, RTCSessionDescription answer)
+        {
+            DescData data = new DescData
+            {
+                connectionId = connectionId,
+                type = "answer",
+                sdp = answer.sdp
+            };
+            manager.Answer(this, ref data);
+        }
+
+        public void SendCandidate(string connectionId, RTCIceCandidate candidate)
+        {
+            CandidateData data = new CandidateData
+            {
+                connectionId = connectionId,
+                candidate = candidate.candidate,
+                sdpMid = candidate.sdpMid,
+                sdpMLineIndex = candidate.sdpMLineIndex
+            };
+            manager.Candidate(this, ref data);
+        }
+    }
+}

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
@@ -238,9 +238,9 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
             CandidateData data = new CandidateData
             {
                 connectionId = connectionId,
-                candidate = candidate.candidate,
-                sdpMid = candidate.sdpMid,
-                sdpMLineIndex = candidate.sdpMLineIndex
+                candidate = candidate.Candidate,
+                sdpMid = candidate.SdpMid,
+                sdpMLineIndex = candidate.SdpMLineIndex.GetValueOrDefault()
             };
             manager.Candidate(this, ref data);
         }

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs.meta
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b720a0c9e77c7a94a918c4148cd4f2ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
@@ -4,16 +4,18 @@ using System.Threading;
 using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
+using Unity.RenderStreaming.RuntimeTest.Signaling;
 using Unity.RenderStreaming.Signaling;
 using Unity.WebRTC;
 using UnityEngine;
 using UnityEngine.TestTools;
 using Debug = UnityEngine.Debug;
 
-namespace Unity.RenderStreaming
+namespace Unity.RenderStreaming.RuntimeTest
 {
     [TestFixture(typeof(WebSocketSignaling))]
     [TestFixture(typeof(HttpSignaling))]
+    [TestFixture(typeof(MockSignaling))]
     [UnityPlatform(exclude = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.OSXPlayer, RuntimePlatform.LinuxEditor, RuntimePlatform.LinuxPlayer })]
     [ConditionalIgnore(ConditionalIgnore.IL2CPP, "Process.Start does not implement in IL2CPP.")]
     public class SignalingTest : IPrebuildSetup
@@ -39,6 +41,10 @@ namespace Unity.RenderStreaming
 
         public void Setup()
         {
+            if (m_SignalingType == typeof(MockSignaling))
+            {
+                return;
+            }
 #if UNITY_EDITOR
             string dir = System.IO.Directory.GetCurrentDirectory();
             string fileName = System.IO.Path.Combine(dir, Editor.WebAppDownloader.GetFileName());
@@ -57,10 +63,14 @@ namespace Unity.RenderStreaming
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
+            if (m_SignalingType == typeof(MockSignaling))
+            {
+                MockSignaling.Reset(false);
+                return;
+            }
             m_ServerProcess = new Process();
 
             string fileName = TestUtility.GetWebAppLocationFromEnv();
-
             if (string.IsNullOrEmpty(fileName))
             {
                 Debug.Log($"webapp file not found in {fileName}");
@@ -94,6 +104,10 @@ namespace Unity.RenderStreaming
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
+            if (m_SignalingType == typeof(MockSignaling))
+            {
+                return;
+            }
             m_ServerProcess.Kill();
         }
 
@@ -109,6 +123,10 @@ namespace Unity.RenderStreaming
                 return new HttpSignaling($"http://localhost:{TestUtility.PortNumber}", 0.1f, mainThread);
             }
 
+            if (type == typeof(MockSignaling))
+            {
+                return new MockSignaling();
+            }
             throw new ArgumentException();
         }
 
@@ -118,7 +136,7 @@ namespace Unity.RenderStreaming
             WebRTC.WebRTC.Initialize();
 
             RTCConfiguration config = default;
-            RTCIceCandidate candidate_ = null;
+            RTCIceCandidate? candidate_ = null;
             config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
 
             var peer1 = new RTCPeerConnection(ref config);
@@ -147,7 +165,7 @@ namespace Unity.RenderStreaming
             yield return op6;
 
             yield return new WaitUntil(() => candidate_ != null);
-            m_candidate = candidate_;
+            m_candidate = candidate_.Value;
 
             stream.Dispose();
             peer1.Close();

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
@@ -136,7 +136,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             WebRTC.WebRTC.Initialize();
 
             RTCConfiguration config = default;
-            RTCIceCandidate? candidate_ = null;
+            RTCIceCandidate candidate_ = null;
             config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
 
             var peer1 = new RTCPeerConnection(ref config);
@@ -165,7 +165,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             yield return op6;
 
             yield return new WaitUntil(() => candidate_ != null);
-            m_candidate = candidate_.Value;
+            m_candidate = candidate_;
 
             stream.Dispose();
             peer1.Close();

--- a/com.unity.renderstreaming/Tests/Runtime/TestUtility.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/TestUtility.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading;
 using UnityEngine;
 
-namespace Unity.RenderStreaming
+namespace Unity.RenderStreaming.RuntimeTest
 {
     public class TestUtility
     {

--- a/com.unity.renderstreaming/Tests/Runtime/Unity.RenderStreaming.RuntimeTests.asmdef
+++ b/com.unity.renderstreaming/Tests/Runtime/Unity.RenderStreaming.RuntimeTests.asmdef
@@ -1,28 +1,29 @@
-﻿{
-  "name": "Unity.RenderStreaming.RuntimeTests",
-  "references": [
-    "GUID:27619889b8ba8c24980f49ee34dbb44a",
-    "GUID:0acc523941302664db1f4e527237feb3",
-    "GUID:40a5acf76f04c4c8ebb69605e4b0d5c7",
-    "GUID:f12aafacab75a87499e7e45c873ffab8",
-    "GUID:7e479a0c97f111c48b6a279fad867f28"
-  ],
-  "includePlatforms": [
-    "Editor",
-    "LinuxStandalone64",
-    "macOSStandalone",
-    "WindowsStandalone64"
-  ],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": true,
-  "precompiledReferences": [
-    "nunit.framework.dll"
-  ],
-  "autoReferenced": true,
-  "defineConstraints": [
-    "UNITY_INCLUDE_TESTS"
-  ],
-  "versionDefines": [],
-  "noEngineReferences": false
+{
+    "name": "Unity.RenderStreaming.RuntimeTests",
+    "references": [
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:40a5acf76f04c4c8ebb69605e4b0d5c7",
+        "GUID:f12aafacab75a87499e7e45c873ffab8",
+        "GUID:7e479a0c97f111c48b6a279fad867f28",
+        "GUID:75469ad4d38634e559750d17036d5f7c"
+    ],
+    "includePlatforms": [
+        "Editor",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WindowsStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
`MockSignaling` class is for simulating communication between peers for unit-testing.
Until this change, we have needed to launch the server process to run unit-testing, but now we only need to use this mock class.