### PR TITLE
refactor: Add `RenderStreamingInternal`

### DIFF
--- a/com.unity.renderstreaming/Runtime/AssemblyInfo.cs
+++ b/com.unity.renderstreaming/Runtime/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Unity.RenderStreaming.RuntimeTests")]
+[assembly: InternalsVisibleTo("Unity.RenderStreaming.EditorTests")]

--- a/com.unity.renderstreaming/Runtime/AssemblyInfo.cs.meta
+++ b/com.unity.renderstreaming/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81b39ad18b63ea145ad69369505d8405
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -1,0 +1,511 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Unity.RenderStreaming.Signaling;
+using Unity.WebRTC;
+
+namespace Unity.RenderStreaming
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    internal struct RenderStreamingDependencies
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public ISignaling signaling;
+        /// <summary>
+        /// 
+        /// </summary>
+        public EncoderType encoderType;
+        /// <summary>
+        /// 
+        /// </summary>
+        public RTCConfiguration config;
+        /// <summary>
+        /// 
+        /// </summary>
+        public Func<IEnumerator, Coroutine> startCoroutine;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    internal class RenderStreamingInternal : IDisposable
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public event Action onStart;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public event Action<string> onCreatedConnection;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public event Action<string> onDeletedConnection;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public event Action<string> onConnect;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public event Action<string> onDisconnect;
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public event Action<string, RTCRtpReceiver> onAddReceiver;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public event Action<string, RTCDataChannel> onAddChannel;
+
+        private bool _disposed;
+        private readonly ISignaling _signaling;
+        private RTCConfiguration _config;
+        private readonly Func<IEnumerator, Coroutine> _startCoroutine;
+        private readonly List<MediaStreamTrack> m_listTrackForPublicMode =
+            new List<MediaStreamTrack>();
+        private readonly Dictionary<string, RTCPeerConnection> m_mapConnectionIdAndPeer =
+            new Dictionary<string, RTCPeerConnection>();
+        private readonly Dictionary<string, RTCDataChannel> m_mapConnectionIdAndChannel =
+            new Dictionary<string, RTCDataChannel>();
+
+        static List<RenderStreamingInternal> s_list = new List<RenderStreamingInternal>();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dependencies"></param>
+        public RenderStreamingInternal(ref RenderStreamingDependencies dependencies)
+        {
+            if(dependencies.signaling == null)
+                throw new ArgumentException("Signaling instance is null.");
+            if(dependencies.startCoroutine == null)
+                throw new ArgumentException("Coroutine action instance is null.");
+
+            if (s_list.Count == 0)
+            {
+                WebRTC.WebRTC.Initialize(dependencies.encoderType);
+            }
+            
+            _config = dependencies.config;
+            _startCoroutine = dependencies.startCoroutine;
+            _signaling = dependencies.signaling;
+            _signaling.OnStart += OnStart;
+            _signaling.OnCreateConnection += OnCreateConnection;
+            _signaling.OnDestroyConnection += OnDestroyConnection;
+            _signaling.OnOffer += OnOffer;
+            _signaling.OnAnswer += OnAnswer;
+            _signaling.OnIceCandidate += OnIceCandidate;
+            _signaling.Start();
+
+            s_list.Add(this);
+            _startCoroutine(WebRTC.WebRTC.Update());
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        ~RenderStreamingInternal()
+        {
+            Dispose();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void Dispose()
+        {
+            if (this._disposed)
+            {
+                return;
+            }
+            _signaling.Stop();
+
+            s_list.Remove(this);
+            if (s_list.Count == 0)
+            {
+                WebRTC.WebRTC.Dispose();
+            }
+            this._disposed = true;
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionId"></param>
+        public void OpenConnection(string connectionId)
+        {
+            if (string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("Argument of connectionId is null or empty.");
+            _signaling.OpenConnection(connectionId);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionId"></param>
+        public void CloseConnection(string connectionId)
+        {
+            if (string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("Argument of connectionId is null or empty.");
+            _signaling.CloseConnection(connectionId);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionId"></param>
+        /// <param name="track"></param>
+        public void AddTrack(string connectionId, MediaStreamTrack track)
+        {
+            if (string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("Argument of connectionId is null or empty.");
+            if (track == null)
+                throw new ArgumentException("Argument of track is null or empty.");
+
+            var pc = m_mapConnectionIdAndPeer[connectionId];
+            if (pc.SignalingState != RTCSignalingState.Stable)
+            {
+                // todo:: RestartICE
+                throw new InvalidOperationException($"peerConnection's signaling state is not stable. {pc.SignalingState}");
+            }
+            pc.AddTrack(track);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionId"></param>
+        /// <param name="track"></param>
+        public void RemoveTrack(string connectionId, MediaStreamTrack track)
+        {
+            if (string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("Argument of connectionId is null or empty.");
+            if (track == null)
+                throw new ArgumentException("Argument of track is null or empty.");
+
+            var sender = GetSenders(connectionId, track).First(s => s.Track == track);
+            m_mapConnectionIdAndPeer[connectionId].RemoveTrack(sender);
+        }
+
+        /// <summary>
+        /// for public mode.
+        /// </summary>
+        /// <param name="track"></param>
+        public void AddTrack(MediaStreamTrack track)
+        {
+            m_listTrackForPublicMode.Add(track);
+        }
+
+        /// <summary>
+        /// for public mode.
+        /// </summary>
+        /// <param name="track"></param>
+        public void RemoveTrack(MediaStreamTrack track)
+        {
+            m_listTrackForPublicMode.Remove(track);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionId"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public RTCDataChannel CreateChannel(string connectionId, string name)
+        {
+            if (string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("Arguments of connectionId is null or empty.");
+
+            var pc = m_mapConnectionIdAndPeer[connectionId];
+            if (pc.SignalingState != RTCSignalingState.Stable)
+            {
+                // todo:: RestartICE
+                throw new InvalidOperationException($"peerConnection's signaling state is not stable. {pc.SignalingState}");
+            }
+            RTCDataChannelInit conf = new RTCDataChannelInit();
+            return m_mapConnectionIdAndPeer[connectionId].CreateDataChannel(name, conf);
+        }
+
+        public IEnumerable<RTCRtpSender> GetSenders(string connectionId, MediaStreamTrack track)
+        {
+            return m_mapConnectionIdAndPeer[connectionId].GetSenders();
+        }
+
+        public IEnumerable<RTCRtpReceiver> GetReceivers(string connectionId, MediaStreamTrack track)
+        {
+            return m_mapConnectionIdAndPeer[connectionId].GetReceivers();
+        }
+
+        void OnStart(ISignaling signaling)
+        {
+            // this connection is for public mode
+            //signaling.OpenConnection(Guid.NewGuid().ToString());
+            onStart?.Invoke();
+        }
+
+        void OnCreateConnection(ISignaling signaling, string connectionId, bool peerExists)
+        {
+            CreatePeerConnection(connectionId, peerExists);
+
+            onCreatedConnection?.Invoke(connectionId);
+        }
+
+        void OnDestroyConnection(ISignaling signaling, string connectionId)
+        {
+            DeletePeerConnection(connectionId);
+
+            onDeletedConnection?.Invoke(connectionId);
+        }
+
+        RTCPeerConnection CreatePeerConnection(string connectionId, bool isOffer)
+        {
+            if (m_mapConnectionIdAndPeer.TryGetValue(connectionId, out var peer))
+            {
+                peer.Close();
+            }
+            var pc = new RTCPeerConnection();
+            m_mapConnectionIdAndPeer[connectionId] = pc;
+
+            pc.SetConfiguration(ref _config);
+            pc.OnDataChannel = channel => { OnDataChannel(connectionId, channel); };
+            pc.OnIceCandidate = candidate =>
+            {
+                _signaling.SendCandidate(connectionId, candidate);
+            };
+            pc.OnIceConnectionChange = state => OnIceConnectionChange(connectionId, state);
+
+            pc.OnTrack = trackEvent =>
+            {
+                onAddReceiver?.Invoke(connectionId, trackEvent.Receiver);
+            };
+            pc.OnNegotiationNeeded = () => OnNegotiationNeeded(connectionId, isOffer);
+            return pc;
+        }
+
+        void DeletePeerConnection(string connectionId)
+        {
+            if (m_mapConnectionIdAndPeer.TryGetValue(connectionId, out var pc))
+            {
+                //RemoveTracks(connectionId, pc);
+                // m_mapPeerAndChannelDictionary.Remove(pc);
+                pc.Dispose();
+            }
+            m_mapConnectionIdAndPeer.Remove(connectionId);
+        }
+
+        void OnDataChannel(string connectionId, RTCDataChannel channel)
+        {
+            m_mapConnectionIdAndChannel.Add(connectionId, channel);
+            onAddChannel?.Invoke(connectionId, channel);
+
+            //if (!m_mapPeerAndChannelDictionary.TryGetValue(pc, out var channels))
+            //{
+            //    channels = new DataChannelDictionary();
+            //    m_mapPeerAndChannelDictionary.Add(pc, channels);
+            //}
+
+            //channels.Add(channel.Id, channel);
+
+            //if (channel.Label != "data")
+            //{
+            //    return;
+            //}
+
+            //RemoteInput input = RemoteInputReceiver.Create();
+            //input.ActionButtonClick = OnButtonClick;
+
+            //// device.current must be changed after creating devices
+            //m_defaultInput.MakeCurrent();
+
+            //m_mapChannelAndRemoteInput.Add(channel, input);
+            //channel.OnMessage = bytes => m_mapChannelAndRemoteInput[channel].ProcessInput(bytes);
+            //channel.OnClose = () => OnCloseChannel(channel);
+
+            //// find controller that not assigned remote input
+            //SimpleCameraController controller = m_listController
+            //    .FirstOrDefault(_controller => !m_remoteInputAndCameraController.ContainsValue(_controller));
+
+            //if (controller != null)
+            //{
+            //    controller.SetInput(input);
+            //    m_remoteInputAndCameraController.Add(input, controller);
+
+            //    byte index = (byte)m_listController.IndexOf(controller);
+            //    byte[] bytes = { (byte)UnityEventType.SwitchVideo, index };
+            //    channel.Send(bytes);
+            //}
+        }
+
+        void OnIceConnectionChange(string connectionId, RTCIceConnectionState state)
+        {
+            switch (state)
+            {
+                case RTCIceConnectionState.Connected:
+                    onConnect?.Invoke(connectionId);
+                    break;
+                case RTCIceConnectionState.Disconnected:
+                    m_mapConnectionIdAndPeer[connectionId].Close();
+                    m_mapConnectionIdAndPeer.Remove(connectionId);
+                    onDisconnect?.Invoke(connectionId);
+                    break;
+            }
+        }
+
+        void OnNegotiationNeeded(string connectionId, bool isOffer)
+        {
+            if (!isOffer)
+            {
+                return;
+            }
+            _startCoroutine(SendOffer(connectionId));
+        }
+
+        IEnumerator SendOffer(string connectionId)
+        {
+            if (!m_mapConnectionIdAndPeer.TryGetValue(connectionId, out var pc))
+            {
+                Debug.LogError($"connectionId: {connectionId}, did not created peerConnection");
+                yield break;
+            }
+            RTCOfferOptions option = new RTCOfferOptions { offerToReceiveAudio = true, offerToReceiveVideo = true };
+            var offerOp = pc.CreateOffer(ref option);
+            yield return offerOp;
+
+            if (offerOp.IsError)
+            {
+                Debug.LogError($"Network Error: {offerOp.Error.message}");
+                yield break;
+            }
+
+            if (pc.SignalingState != RTCSignalingState.Stable)
+            {
+                Debug.LogError($"peerConnection's signaling state is not stable. {pc.SignalingState}");
+                yield break;
+            }
+
+            var desc = offerOp.Desc;
+            var setLocalSdp = pc.SetLocalDescription(ref desc);
+            yield return setLocalSdp;
+            if (setLocalSdp.IsError)
+            {
+                Debug.LogError($"Network Error: {setLocalSdp.Error.message}");
+                yield break;
+            }
+            _signaling.SendOffer(connectionId, desc);
+        }
+
+        void OnAnswer(ISignaling m_signaling, DescData e)
+        {
+            _startCoroutine(OnAnswerCoroutine(e));
+        }
+
+        IEnumerator OnAnswerCoroutine(DescData e)
+        {
+            if (!m_mapConnectionIdAndPeer.TryGetValue(e.connectionId, out var pc))
+            {
+                Debug.Log($"connectionId:{e.connectionId}, peerConnection not exist");
+                yield break;
+            }
+
+            var desc = new RTCSessionDescription();
+            desc.type = RTCSdpType.Answer;
+            desc.sdp = e.sdp;
+            var opRemoteSdp = pc.SetRemoteDescription(ref desc);
+            yield return opRemoteSdp;
+
+            if (opRemoteSdp.IsError)
+            {
+                Debug.LogError($"Network Error: {opRemoteSdp.Error.message}");
+                yield break;
+            }
+        }
+
+        void OnIceCandidate(ISignaling m_signaling, CandidateData e)
+        {
+            if (!m_mapConnectionIdAndPeer.TryGetValue(e.connectionId, out var pc))
+            {
+                return;
+            }
+
+            RTCIceCandidateInit option = new RTCIceCandidateInit
+            {
+                candidate = e.candidate,
+                sdpMLineIndex = e.sdpMLineIndex,
+                sdpMid = e.sdpMid
+            };
+            pc.AddIceCandidate(new RTCIceCandidate(option));
+        }
+
+        void OnOffer(ISignaling signaling, DescData e)
+        {
+            var connectionId = e.connectionId;
+            if (!m_mapConnectionIdAndPeer.TryGetValue(connectionId, out var pc))
+            {
+                pc = CreatePeerConnection(connectionId, false);
+            }
+
+            _startCoroutine(SendAnswerCoroutine(connectionId, pc, e.sdp));
+        }
+
+        IEnumerator SendAnswerCoroutine(string connectionId, RTCPeerConnection pc, string sdp)
+        {
+            RTCSessionDescription _desc;
+            _desc.type = RTCSdpType.Offer;
+            _desc.sdp = sdp;
+
+            var opRemoteDesc = pc.SetRemoteDescription(ref _desc);
+            yield return opRemoteDesc;
+
+            if (opRemoteDesc.IsError)
+            {
+                Debug.LogError($"Network Error: {opRemoteDesc.Error.message}");
+                yield break;
+            }
+
+            // TODO:: make callback
+            //foreach (var track in m_listTrackForPublicMode)
+            //{
+            //    Debug.Log("track");
+            //    pc.AddTrack(track);
+            //}
+
+
+            RTCAnswerOptions options = default;
+            var op = pc.CreateAnswer(ref options);
+            yield return op;
+
+            if (op.IsError)
+            {
+                Debug.LogError($"Network Error: {op.Error.message}");
+                yield break;
+            }
+
+            var desc = op.Desc;
+            var opLocalDesc = pc.SetLocalDescription(ref desc);
+            yield return opLocalDesc;
+
+            if (opLocalDesc.IsError)
+            {
+                Debug.LogError($"Network Error: {opLocalDesc.Error.message}");
+                yield break;
+            }
+            _signaling.SendAnswer(connectionId, desc);
+        }
+    }
+}

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs.meta
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df5c53a4914cce44cb61fe0983c72587
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -198,10 +198,10 @@ namespace Unity.RenderStreaming.RuntimeTest
             target.onCreatedConnection += _ => { isCreatedConnection = true; };
             yield return new WaitUntil(() => isCreatedConnection);
 
-            Assert.That(() => target.AddTrack(null, null), Throws.TypeOf<ArgumentException>());
-            Assert.That(() => target.AddTrack(connectionId, null), Throws.TypeOf<ArgumentException>());
-            Assert.That(() => target.RemoveTrack(null, null), Throws.TypeOf<ArgumentException>());
-            Assert.That(() => target.RemoveTrack(connectionId, null), Throws.TypeOf<ArgumentException>());
+            Assert.That(() => target.AddTrack(null, null), Throws.TypeOf<ArgumentNullException>());
+            Assert.That(() => target.AddTrack(connectionId, null), Throws.TypeOf<ArgumentNullException>());
+            Assert.That(() => target.RemoveTrack(null, null), Throws.TypeOf<ArgumentNullException>());
+            Assert.That(() => target.RemoveTrack(connectionId, null), Throws.TypeOf<InvalidOperationException>());
             target.CloseConnection(connectionId);
             bool isDeletedConnection = false;
             target.onDeletedConnection += _ => { isDeletedConnection = true; };

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -14,6 +14,8 @@ namespace Unity.RenderStreaming.RuntimeTest
         PublicMode
     }
 
+    [UnityPlatform(exclude = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.OSXPlayer, RuntimePlatform.LinuxEditor, RuntimePlatform.LinuxPlayer })]
+    [ConditionalIgnore(ConditionalIgnore.IL2CPP, "Process.Start does not implement in IL2CPP.")]
     class RenderStreamingInternalTest
     {
         class MyMonoBehaviourTest : MonoBehaviour, IMonoBehaviourTest

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
+using Unity.RenderStreaming.RuntimeTest.Signaling;
+using Unity.WebRTC;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.RenderStreaming.RuntimeTest
+{
+    enum TestMode
+    {
+        PrivateMode,
+        PublicMode
+    }
+
+    class RenderStreamingInternalTest
+    {
+        class MyMonoBehaviourTest : MonoBehaviour, IMonoBehaviourTest
+        {
+            public bool IsTestFinished
+            {
+                get { return true; }
+            }
+        }
+
+        private MonoBehaviourTest<MyMonoBehaviourTest> test;
+
+        [SetUp]
+        public void SetUp()
+        {
+            test = new MonoBehaviourTest<MyMonoBehaviourTest>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            test.component.StopAllCoroutines();
+            UnityEngine.Object.Destroy(test.gameObject);
+        }
+
+        private RenderStreamingDependencies CreateDependencies()
+        {
+            return new RenderStreamingDependencies
+            {
+                signaling = new MockSignaling(),
+                config = new RTCConfiguration
+                {
+                    iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } },
+                },
+                encoderType = EncoderType.Software,
+                startCoroutine = test.component.StartCoroutine
+            };
+        }
+
+        [TestCase(TestMode.PublicMode, ExpectedResult = null)]
+        [TestCase(TestMode.PrivateMode, ExpectedResult = null)]
+        [UnityTest, Timeout(1000)]
+        public IEnumerator Construct(TestMode mode)
+        {
+            MockSignaling.Reset(mode == TestMode.PrivateMode);
+
+            var dependencies = CreateDependencies();
+            var target = new RenderStreamingInternal(ref dependencies);
+
+            bool isStarted = false;
+            target.onStart += () => { isStarted = true; };
+            yield return new WaitUntil(() => isStarted);
+
+            target.Dispose();
+        }
+
+        [TestCase(TestMode.PublicMode, ExpectedResult = null)]
+        [TestCase(TestMode.PrivateMode, ExpectedResult = null)]
+        [UnityTest, Timeout(1000)]
+        public IEnumerator ConstructMultiple(TestMode mode)
+        {
+            MockSignaling.Reset(mode == TestMode.PrivateMode);
+
+            var dependencies1 = CreateDependencies();
+            var dependencies2 = CreateDependencies();
+            var target1 = new RenderStreamingInternal(ref dependencies1);
+            var target2 = new RenderStreamingInternal(ref dependencies2);
+
+            bool isStarted1 = false;
+            bool isStarted2 = false;
+            target1.onStart += () => { isStarted1 = true; };
+            target2.onStart += () => { isStarted2 = true; };
+            yield return new WaitUntil(() => isStarted1);
+            yield return new WaitUntil(() => isStarted2);
+
+            target1.Dispose();
+            target2.Dispose();
+        }
+
+        [TestCase(TestMode.PublicMode, ExpectedResult = null)]
+        [TestCase(TestMode.PrivateMode, ExpectedResult = null)]
+        [UnityTest, Timeout(1000)]
+        public IEnumerator OpenConnection(TestMode mode)
+        {
+            MockSignaling.Reset(mode == TestMode.PrivateMode);
+
+            var dependencies = CreateDependencies();
+            var target = new RenderStreamingInternal(ref dependencies);
+
+            bool isStarted = false;
+            target.onStart += () => { isStarted = true; };
+            yield return new WaitUntil(() => isStarted);
+
+            target.OpenConnection("12345");
+            bool isCreatedConnection = false;
+            target.onCreatedConnection += _ => { isCreatedConnection = true; };
+            yield return new WaitUntil(() => isCreatedConnection);
+
+            target.CloseConnection("12345");
+            bool isDeletedConnection = false;
+            target.onDeletedConnection += _ => { isDeletedConnection = true; };
+            yield return new WaitUntil(() => isDeletedConnection);
+
+            target.Dispose();
+        }
+
+        [TestCase(TestMode.PublicMode, ExpectedResult = null)]
+        [TestCase(TestMode.PrivateMode, ExpectedResult = null)]
+        [UnityTest, Timeout(1000)]
+        public IEnumerator OpenConnectionThrowException(TestMode mode)
+        {
+            MockSignaling.Reset(mode == TestMode.PrivateMode);
+
+            var dependencies = CreateDependencies();
+            var target = new RenderStreamingInternal(ref dependencies);
+
+            bool isStarted = false;
+            target.onStart += () => { isStarted = true; };
+            yield return new WaitUntil(() => isStarted);
+
+            Assert.That(() => target.OpenConnection(null), Throws.TypeOf<ArgumentException>());
+            Assert.That(() => target.OpenConnection(string.Empty), Throws.TypeOf<ArgumentException>());
+            target.Dispose();
+        }
+
+        [TestCase(TestMode.PublicMode, ExpectedResult = null)]
+        [TestCase(TestMode.PrivateMode, ExpectedResult = null)]
+        [UnityTest, Timeout(1000)]
+        public IEnumerator AddTrack(TestMode mode)
+        {
+            MockSignaling.Reset(mode == TestMode.PrivateMode);
+
+            var dependencies = CreateDependencies();
+            var target = new RenderStreamingInternal(ref dependencies);
+
+            bool isStarted = false;
+            target.onStart += () => { isStarted = true; };
+            yield return new WaitUntil(() => isStarted);
+
+            var connectionId = "12345";
+            target.OpenConnection(connectionId);
+            bool isCreatedConnection = false;
+            target.onCreatedConnection += _ => { isCreatedConnection = true; };
+            yield return new WaitUntil(() => isCreatedConnection);
+
+            var camObj = new GameObject("Camera");
+            var camera = camObj.AddComponent<Camera>();
+            VideoStreamTrack track = camera.CaptureStreamTrack(1280, 720, 0);
+
+            target.AddTrack(connectionId, track);
+            target.RemoveTrack(connectionId, track);
+
+            target.CloseConnection(connectionId);
+            bool isDeletedConnection = false;
+            target.onDeletedConnection += _ => { isDeletedConnection = true; };
+            yield return new WaitUntil(() => isDeletedConnection);
+
+            target.Dispose();
+            track.Dispose();
+            UnityEngine.Object.Destroy(camObj);
+        }
+
+        [TestCase(TestMode.PublicMode, ExpectedResult = null)]
+        [TestCase(TestMode.PrivateMode, ExpectedResult = null)]
+        [UnityTest]
+        public IEnumerator AddTrackThrowException(TestMode mode)
+        {
+            MockSignaling.Reset(mode == TestMode.PrivateMode);
+
+            var dependencies = CreateDependencies();
+            var target = new RenderStreamingInternal(ref dependencies);
+
+            bool isStarted = false;
+            target.onStart += () => { isStarted = true; };
+            yield return new WaitUntil(() => isStarted);
+
+            var connectionId = "12345";
+            target.OpenConnection(connectionId);
+            bool isCreatedConnection = false;
+            target.onCreatedConnection += _ => { isCreatedConnection = true; };
+            yield return new WaitUntil(() => isCreatedConnection);
+
+            Assert.That(() => target.AddTrack(null, null), Throws.TypeOf<ArgumentException>());
+            Assert.That(() => target.AddTrack(connectionId, null), Throws.TypeOf<ArgumentException>());
+            Assert.That(() => target.RemoveTrack(null, null), Throws.TypeOf<ArgumentException>());
+            Assert.That(() => target.RemoveTrack(connectionId, null), Throws.TypeOf<ArgumentException>());
+            target.CloseConnection(connectionId);
+            bool isDeletedConnection = false;
+            target.onDeletedConnection += _ => { isDeletedConnection = true; };
+            yield return new WaitUntil(() => isDeletedConnection);
+
+            target.Dispose();
+        }
+
+        [TestCase(TestMode.PublicMode, ExpectedResult = null)]
+        [TestCase(TestMode.PrivateMode, ExpectedResult = null)]
+        [UnityTest]
+        public IEnumerator AddTrackMultiple(TestMode mode)
+        {
+            MockSignaling.Reset(mode == TestMode.PrivateMode);
+
+            var dependencies = CreateDependencies();
+            var target = new RenderStreamingInternal(ref dependencies);
+
+            bool isStarted = false;
+            target.onStart += () => { isStarted = true; };
+            yield return new WaitUntil(() => isStarted);
+
+            var connectionId = "12345";
+            target.OpenConnection(connectionId);
+            bool isCreatedConnection = false;
+            target.onCreatedConnection += _ => { isCreatedConnection = true; };
+            yield return new WaitUntil(() => isCreatedConnection);
+
+            var camObj = new GameObject("Camera");
+            var camera = camObj.AddComponent<Camera>();
+            VideoStreamTrack track = camera.CaptureStreamTrack(1280, 720, 0);
+            target.AddTrack(connectionId, track);
+
+            var camObj2 = new GameObject("Camera2");
+            var camera2 = camObj2.AddComponent<Camera>();
+            VideoStreamTrack track2 = camera2.CaptureStreamTrack(1280, 720, 0);
+            target.AddTrack(connectionId, track2);
+
+            target.CloseConnection(connectionId);
+            bool isDeletedConnection = false;
+            target.onDeletedConnection += _ => { isDeletedConnection = true; };
+            yield return new WaitUntil(() => isDeletedConnection);
+
+            target.Dispose();
+            track.Dispose();
+            track2.Dispose();
+            UnityEngine.Object.Destroy(camObj);
+            UnityEngine.Object.Destroy(camObj2);
+        }
+
+        [TestCase(TestMode.PublicMode, ExpectedResult = null)]
+        [TestCase(TestMode.PrivateMode, ExpectedResult = null)]
+        [UnityTest, Timeout(1000)]
+        public IEnumerator CreateChannel(TestMode mode)
+        {
+            MockSignaling.Reset(mode == TestMode.PrivateMode);
+
+            var dependencies = CreateDependencies();
+            var target = new RenderStreamingInternal(ref dependencies);
+            bool isStarted = false;
+            target.onStart += () => { isStarted = true; };
+            yield return new WaitUntil(() => isStarted);
+
+            var connectionId = "12345";
+            target.OpenConnection(connectionId);
+            bool isCreatedConnection = false;
+            target.onCreatedConnection += _ => { isCreatedConnection = true; };
+            yield return new WaitUntil(() => isCreatedConnection);
+
+            string channelName = "test";
+            var channel = target.CreateChannel(connectionId, channelName);
+            Assert.That(channel.Label, Is.EqualTo(channelName));
+
+            target.CloseConnection(connectionId);
+            bool isDeletedConnection = false;
+            target.onDeletedConnection += _ => { isDeletedConnection = true; };
+            yield return new WaitUntil(() => isDeletedConnection);
+
+            target.Dispose();
+            channel.Dispose();
+        }
+
+        [UnityTest, Timeout(1000)]
+        public IEnumerator OnAddReceiverPrivateMode()
+        {
+            MockSignaling.Reset(true);
+
+            var dependencies1 = CreateDependencies();
+            var dependencies2 = CreateDependencies();
+            var target1 = new RenderStreamingInternal(ref dependencies1);
+            var target2 = new RenderStreamingInternal(ref dependencies2);
+
+            bool isStarted1 = false;
+            bool isStarted2 = false;
+            target1.onStart += () => { isStarted1 = true; };
+            target2.onStart += () => { isStarted2 = true; };
+            yield return new WaitUntil(() => isStarted1 && isStarted2);
+
+            bool isCreatedConnection1 = false;
+            bool isCreatedConnection2 = false;
+            target1.onCreatedConnection += _ => { isCreatedConnection1 = true; };
+            target2.onCreatedConnection += _ => { isCreatedConnection2 = true; };
+
+            var connectionId = "12345";
+
+            // target1 is receiver in private mode
+            target1.OpenConnection(connectionId);
+            yield return new WaitUntil(() => isCreatedConnection1);
+
+            // target2 is sender in private mode
+            target2.OpenConnection(connectionId);
+            yield return new WaitUntil(() => isCreatedConnection2);
+
+            bool isAddReceiver1 = false;
+            target1.onAddReceiver += (_, receiver) => { isAddReceiver1 = true; };
+
+            var camObj = new GameObject("Camera");
+            var camera = camObj.AddComponent<Camera>();
+            VideoStreamTrack track = camera.CaptureStreamTrack(1280, 720, 0);
+            target2.AddTrack(connectionId, track);
+
+            yield return new WaitUntil(() => isAddReceiver1);
+
+            target1.CloseConnection(connectionId);
+            target2.CloseConnection(connectionId);
+
+            bool isDeletedConnection1 = false;
+            bool isDeletedConnection2 = false;
+            target1.onDeletedConnection += _ => { isDeletedConnection1 = true; };
+            target2.onDeletedConnection += _ => { isDeletedConnection2 = true; };
+            yield return new WaitUntil(() => isDeletedConnection1 && isDeletedConnection2);
+
+            target1.Dispose();
+            target2.Dispose();
+            track.Dispose();
+            UnityEngine.Object.Destroy(camObj);
+        }
+
+        [UnityTest, Timeout(1000)]
+        public IEnumerator OnAddChannelPrivateMode()
+        {
+            MockSignaling.Reset(true);
+
+            var dependencies1 = CreateDependencies();
+            var dependencies2 = CreateDependencies();
+            var target1 = new RenderStreamingInternal(ref dependencies1);
+            var target2 = new RenderStreamingInternal(ref dependencies2);
+
+            bool isStarted1 = false;
+            bool isStarted2 = false;
+            target1.onStart += () => { isStarted1 = true; };
+            target2.onStart += () => { isStarted2 = true; };
+            yield return new WaitUntil(() => isStarted1 && isStarted2);
+
+            bool isCreatedConnection1 = false;
+            bool isCreatedConnection2 = false;
+            target1.onCreatedConnection += _ => { isCreatedConnection1 = true; };
+            target2.onCreatedConnection += _ => { isCreatedConnection2 = true; };
+
+            var connectionId = "12345";
+
+            // target1 is receiver in private mode
+            target1.OpenConnection(connectionId);
+            yield return new WaitUntil(() => isCreatedConnection1);
+
+            // target2 is sender in private mode
+            target2.OpenConnection(connectionId);
+            yield return new WaitUntil(() => isCreatedConnection2);
+
+            bool isAddChannel1 = false;
+            target1.onAddChannel += (_, channel) => { isAddChannel1 = true; };
+
+            target2.CreateChannel(connectionId, "test");
+
+            yield return new WaitUntil(() => isAddChannel1);
+
+            target1.CloseConnection(connectionId);
+            target2.CloseConnection(connectionId);
+
+            bool isDeletedConnection1 = false;
+            bool isDeletedConnection2 = false;
+            target1.onDeletedConnection += _ => { isDeletedConnection1 = true; };
+            target2.onDeletedConnection += _ => { isDeletedConnection2 = true; };
+            yield return new WaitUntil(() => isDeletedConnection1 && isDeletedConnection2);
+
+            target1.Dispose();
+            target2.Dispose();
+        }
+    }
+}

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs.meta
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 982c6d2f26e4a4a4787bd5158b574941
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
@@ -220,16 +220,22 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
 
         public void OpenConnection(string connectionId)
         {
+            if(string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("connectionId is null or empty.");
             manager.OpenConnection(this, connectionId);
         }
 
         public void CloseConnection(string connectionId)
         {
+            if (string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("connectionId is null or empty.");
             manager.CloseConnection(this, connectionId);
         }
 
         public void SendOffer(string connectionId, RTCSessionDescription offer)
         {
+            if (string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("connectionId is null or empty.");
             DescData data = new DescData
             {
                 connectionId = connectionId,
@@ -241,6 +247,8 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
 
         public void SendAnswer(string connectionId, RTCSessionDescription answer)
         {
+            if (string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("connectionId is null or empty.");
             DescData data = new DescData
             {
                 connectionId = connectionId,
@@ -252,6 +260,8 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
 
         public void SendCandidate(string connectionId, RTCIceCandidate candidate)
         {
+            if (string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("connectionId is null or empty.");
             CandidateData data = new CandidateData
             {
                 connectionId = connectionId,


### PR DESCRIPTION
Added `RenderStreamingInternal` class (This class name might be changed to a better one) to improve the testability of `RenderStreaming` class.

In the past, there is not a test of `RenderStreaming` class, because for two reasons.

- `RenderStreaming` class inherits `MonoBehaviour` class
- Testing of `RenderStreaming` needs to run the Signaling server

After this change, I will refactor `RenderStreaming` class to use `RenderStreamingInternal` class.