### PR TITLE
Fix: enable Linux SignalingTest only websockeet signaling

### DIFF
--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -39,7 +39,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     {% else %}
     - | 
       export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
-      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!PrivateSignalingTest"
+      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!PrivateSignalingTest,!HttpSignaling"
     {% endif %}
   triggers:
     branches:

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -38,8 +38,8 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
       upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
     {% else %}
     - | 
-      export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
-      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
+      export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
+      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!PrivateSignalingTest"
     {% endif %}
   triggers:
     branches:

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -10,10 +10,11 @@ pack_{{ package.name }}:
   name: Pack {{ package.packagename }}
   agent:
     type: Unity::VM
-    image: renderstreaming/win10:latest
+    image: package-ci/ubuntu:stable
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
+    - find ./{{ project.packagename }} -type l -exec bash -c 'sh BuildScripts~/convert_symlinks.sh "$0"' {} \;    
     - upm-ci package pack --package-path {{ package.packagename }}
   artifacts:
     {{ package.name }}_package:  

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -39,7 +39,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     {% else %}
     - | 
       export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
-      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!PrivateSignalingTest,!HttpSignaling"
+      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!HttpSignaling"
     {% endif %}
   triggers:
     branches:

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -17,7 +17,7 @@ namespace Unity.RenderStreaming.RuntimeTest
     [TestFixture(typeof(WebSocketSignaling))]
     [TestFixture(typeof(HttpSignaling))]
     [TestFixture(typeof(MockSignaling))]
-    [UnityPlatform(exclude = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.OSXPlayer, RuntimePlatform.LinuxEditor, RuntimePlatform.LinuxPlayer })]
+    [UnityPlatform(exclude = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.OSXPlayer })]
     [ConditionalIgnore(ConditionalIgnore.IL2CPP, "Process.Start does not implement in IL2CPP.")]
     public class PrivateSignalingTest : IPrebuildSetup
     {

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
@@ -16,7 +16,7 @@ namespace Unity.RenderStreaming.RuntimeTest
     [TestFixture(typeof(WebSocketSignaling))]
     [TestFixture(typeof(HttpSignaling))]
     [TestFixture(typeof(MockSignaling))]
-    [UnityPlatform(exclude = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.OSXPlayer, RuntimePlatform.LinuxEditor, RuntimePlatform.LinuxPlayer })]
+    [UnityPlatform(exclude = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.OSXPlayer })]
     [ConditionalIgnore(ConditionalIgnore.IL2CPP, "Process.Start does not implement in IL2CPP.")]
     public class SignalingTest : IPrebuildSetup
     {


### PR DESCRIPTION
HttpSignalingTest faild only on Yamato

mac still can't be enabled because setup use metal on yamato