### PR TITLE
fix: Remove CS0067 warning in FurioosSignaling class

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/FurioosSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/FurioosSignaling.cs
@@ -63,19 +63,16 @@ namespace Unity.RenderStreaming.Signaling
         }
 
         //todo: not implemented
+#pragma warning disable 0067
         public event OnStartHandler OnStart;
-
         public event OnSignedInHandler OnSignedIn;
-
-        //todo: not implemented
         public event OnConnectHandler OnCreateConnection;
         public event OnDisconnectHandler OnDestroyConnection;
         public event OnOfferHandler OnOffer;
-        #pragma warning disable 0067
         // this event is never used in this class
         public event OnAnswerHandler OnAnswer;
-        #pragma warning restore 0067
         public event OnIceCandidateHandler OnIceCandidate;
+#pragma warning restore 0067
         public void SendOffer(string connectionId, RTCSessionDescription offer)
         {
             throw new NotImplementedException();

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
@@ -309,8 +309,13 @@ namespace Unity.RenderStreaming.Signaling
                 dataStream.Close();
             }
 
+            var data = HTTPParseTextResponse(HTTPGetResponse(request));
+
+            if (data == null) return false;
+
             Debug.Log("Signaling: HTTP delete connection, connectionId : " + connectionId);
-            return (HTTPParseTextResponse(HTTPGetResponse(request)) != null);
+            m_mainThreadContext.Post(d => OnDestroyConnection?.Invoke(this, connectionId), null);
+            return true;
         }
 
         private bool HTTPGetOffers()


### PR DESCRIPTION
This change is for removing `CS0067` warning in `FurioosSignaling` class
![image](https://user-images.githubusercontent.com/1132081/105448340-81b8a900-5cb9-11eb-9a59-4493f25dbe30.png)
