### PR TITLE
chore: run CI testing on macOS/iOS

### DIFF
--- a/.yamato/meta/environments.yml
+++ b/.yamato/meta/environments.yml
@@ -24,7 +24,7 @@ platforms:
         platform: standalone
   - name: mac
     type: Unity::metal::macmini
-    image: slough-ops/macos-10.14-xcode
+    image: package-ci/mac:stable
     flavor: m1.mac
     packed_webapp_name: webserver_mac
     test_params:

--- a/.yamato/meta/environments.yml
+++ b/.yamato/meta/environments.yml
@@ -24,7 +24,7 @@ platforms:
         platform: standalone
   - name: mac
     type: Unity::metal::macmini
-    image: package-ci/mac:stable
+    image: slough-ops/macos-10.14-xcode
     flavor: m1.mac
     packed_webapp_name: webserver_mac
     test_params:

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -23,8 +23,7 @@ pack_{{ package.name }}:
 
 {% for editor in editors %}
 {% for platform in platforms %}
-{% if target.name != "macos" -%}
-
+{% if platform.name != "mac" -%}
 {% for param in platform.test_params %}
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
   name : Test {{ package.packagename }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}
@@ -90,9 +89,7 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
 
 {% endfor %}
 {% endfor %}
-
 {% else -%}
-
 {% for param in platform.test_params %}
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
   name : Test {{ package.packagename }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}
@@ -107,7 +104,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
       TEST_RESULT_DIR: upm-ci~/test-results/
       WEBAPP_DIR: UnityRenderStreaming/WebApp/bin~
       WEBAPP_NAME: {{ platform.packed_webapp_name }}
-      TEST_TARGET: {{ target.name }}
+      TEST_TARGET: {{ platform.name }}
       TEST_PLATFORM: {{ param.platform }}
       SCRIPTING_BACKEND: {{ param.backend }}  
       EDITOR_VERSION: {{ editor.version }}
@@ -130,7 +127,6 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
     - .yamato/upm-ci-webapp.yml#test_{{ platform.name }}
 {% endfor %}
-
 {% endif -%}
 {% endfor %}
 

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -22,6 +22,50 @@ pack_{{ package.name }}:
         - "upm-ci~/packages/**/*"
 
 {% for editor in editors %}
+build_{{ package.name }}_{{ editor.version }}_ios:
+  name : Build {{ package.packagename }} with {{ editor.version }} for ios device
+  agent:
+    type: Unity::VM::osx
+    image: mobile/macos-10.13-testing:stable
+    flavor: b1.large
+  commands:
+    - find upm-ci~/packages/ -name "*.tgz" | xargs -I file tar xvf file -C upm-ci~
+    - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+    - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --fast -w
+    - curl -s https://artifactory.internal.unity3d.com/core-automation/tools/utr-standalone/utr --output utr
+    - chmod +x ./utr
+    - ./utr --suite=playmode --platform=iOS --editor-location=.Editor --testproject=RenderStreaming~ --player-save-path=build/players --architecture=ARM64 --artifacts_path=build/logs --build-only
+  artifacts:
+    players:
+      paths:
+        - "build/players/**"
+    logs:
+      paths:
+        - "build/logs/**"
+  dependencies:
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
+
+test_{{ package.name }}_{{ editor.version }}_ios:
+  name: Test {{ package.packagename }} with {{ editor.version }} on ios device
+  agent:
+    type: Unity::mobile::iPhone
+    image: mobile/macos-10.13-testing:stable
+    flavor: b1.medium
+  skip_checkout: true
+  dependencies:
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ editor.version }}_ios
+  commands:
+    # Download standalone UnityTestRunner
+    - curl -s https://artifactory.internal.unity3d.com/core-automation/tools/utr-standalone/utr --output utr
+    # Give UTR execution permissions
+    - chmod +x ./utr
+    # Run the test build on the device
+    - ./utr --suite=playmode --platform=iOS --player-load-path=build/players --artifacts_path=build/test-results
+  artifacts:
+    logs:
+      paths:
+        - "build/test-results/**"
+
 {% for platform in platforms %}
 {% if platform.name != "mac" -%}
 {% for param in platform.test_params %}

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -132,7 +132,6 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
 {% endfor %}
 
 {% endfor %}
-{% endfor %}
 {% else -%}
 {% for param in platform.test_params %}
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
@@ -172,6 +171,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - .yamato/upm-ci-webapp.yml#test_{{ platform.name }}
 {% endfor %}
 {% endif -%}
+{% endfor %}
 {% endfor %}
 
 {% for editor in editors %}

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -23,6 +23,8 @@ pack_{{ package.name }}:
 
 {% for editor in editors %}
 {% for platform in platforms %}
+{% if target.name != "macos" -%}
+
 {% for param in platform.test_params %}
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
   name : Test {{ package.packagename }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}
@@ -88,6 +90,48 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
 
 {% endfor %}
 {% endfor %}
+
+{% else -%}
+
+{% for param in platform.test_params %}
+test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
+  name : Test {{ package.packagename }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  variables:
+      TEMPLATE_FILE: BuildScripts~/template/remote.sh.template
+      PACKAGE_DIR: UnityRenderStreaming
+      TEST_PROJECT_DIR: UnityRenderStreaming/RenderStreaming~
+      TEST_RESULT_DIR: upm-ci~/test-results/
+      WEBAPP_DIR: UnityRenderStreaming/WebApp/bin~
+      WEBAPP_NAME: {{ platform.packed_webapp_name }}
+      TEST_TARGET: {{ target.name }}
+      TEST_PLATFORM: {{ param.platform }}
+      SCRIPTING_BACKEND: {{ param.backend }}  
+      EDITOR_VERSION: {{ editor.version }}
+      EXTRA_UTR_ARG: --timeout=3000 --testfilter=!HttpSignaling
+  commands:
+    - find upm-ci~/packages/ -name "*.tgz" | xargs -I file tar xvf file -C upm-ci~
+    - BuildScripts~/test_package_mac.sh
+  triggers:
+    branches:
+      only:
+      - "/.*/"
+      except:
+      - "master"  
+  artifacts:
+    {{ package.name }}_{{ editor.version }}_{{ platform.name }}_test_results: 
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
+    - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
+    - .yamato/upm-ci-webapp.yml#test_{{ platform.name }}
+{% endfor %}
+
+{% endif -%}
 {% endfor %}
 
 {% for editor in editors %}

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -93,7 +93,6 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   dependencies:
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
-    - .yamato/upm-ci-webapp.yml#test_{{ platform.name }}
 
 {% for project in test_projects %}
 test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
@@ -156,7 +155,6 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   dependencies:
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
-    - .yamato/upm-ci-webapp.yml#test_{{ platform.name }}
 
 {% for project in test_projects %}
 test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -94,6 +94,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
     - .yamato/upm-ci-webapp.yml#test_{{ platform.name }}
+
 {% for project in test_projects %}
 test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
   name : Test {{ project.name }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}
@@ -123,6 +124,7 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   dependencies:
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
 {% endfor %}
+
 {% endfor %}
 {% else -%}
 {% for param in platform.test_params %}
@@ -155,6 +157,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
     - .yamato/upm-ci-webapp.yml#test_{{ platform.name }}
+
 {% for project in test_projects %}
 test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
   name : Test {{ project.name }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}
@@ -162,21 +165,21 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
+  variables:
+    TEMPLATE_FILE: BuildScripts~/template/remote.sh.template
+    PACKAGE_DIR: UnityRenderStreaming
+    TEST_PROJECT_DIR: UnityRenderStreaming/{{ project.path }}
+    TEST_RESULT_DIR: upm-ci~/test-results/
+    WEBAPP_DIR: UnityRenderStreaming/WebApp/bin~
+    WEBAPP_NAME: {{ platform.packed_webapp_name }}
+    TEST_TARGET: {{ platform.name }}
+    TEST_PLATFORM: {{ param.platform }}
+    SCRIPTING_BACKEND: {{ param.backend }}  
+    EDITOR_VERSION: {{ editor.version }}
+    EXTRA_UTR_ARG: --timeout=3000 --testfilter=!HttpSignaling
   commands:
-    - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
-    {% if platform.name != "win" %}
     - find ./{{ package.packagename }} -type l -exec bash -c 'sh BuildScripts~/convert_symlinks.sh "$0"' {} \;
-    {% endif %}
-    - upm-ci project pack --project-path {{ project.path }}
-    {% if platform.name == "win" %}
-    - | 
-      set WEBAPP_PATH=%cd%\Webapp\bin~\{{ platform.packed_webapp_name }}
-      upm-ci project test -u {{ editor.version }} --project-path {{ project.path }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
-    {% else %}
-    - | 
-      export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
-      upm-ci project test -u {{ editor.version }} --project-path {{ project.path }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!HttpSignaling"
-    {% endif %}
+    - BuildScripts~/test_package_mac.sh
   artifacts:
     {{ package.name }}_{{ editor.version }}_{{ platform.name }}_test_results: 
       paths:
@@ -184,6 +187,7 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   dependencies:
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
 {% endfor %}
+
 {% endfor %}
 {% endif -%}
 {% endfor %}

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -239,9 +239,7 @@ publish_dry_run_{{ package.name }}:
   dependencies:
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
     {% for editor in editors %}
-    {% for platform in platforms %}
-    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}
-    {% endfor %}
+    - .yamato/upm-ci-renderstreaming-packages.yml#trigger_package_test_{{ package.name }}_{{ editor.version }}
     {% endfor %}
 
 publish_{{ package.name }}:
@@ -264,8 +262,6 @@ publish_{{ package.name }}:
   dependencies:
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
     {% for editor in editors %}
-    {% for platform in platforms %}
-    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ package.name }}_{{ platform.name }}_{{ editor.version }}
-    {% endfor %}
+    - .yamato/upm-ci-renderstreaming-packages.yml#trigger_package_test_{{ package.name }}_{{ editor.version }}
     {% endfor %}
 {% endfor %}

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -22,7 +22,7 @@ pack_{{ package.name }}:
         - "upm-ci~/packages/**/*"
 
 {% for editor in editors %}
-build_{{ package.name }}_{{ editor.version }}_ios:
+build_{{ package.name }}_ios_{{ editor.version }}:
   name : Build {{ package.packagename }} with {{ editor.version }} for ios device
   agent:
     type: Unity::VM::osx
@@ -45,15 +45,13 @@ build_{{ package.name }}_{{ editor.version }}_ios:
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
 
-test_{{ package.name }}_{{ editor.version }}_ios:
+test_{{ package.name }}_ios_{{ editor.version }}:
   name: Test {{ package.packagename }} with {{ editor.version }} on ios device
   agent:
     type: Unity::mobile::iPhone
     image: mobile/macos-10.13-testing:stable
     flavor: b1.medium
   skip_checkout: true
-  dependencies:
-    - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ editor.version }}_ios
   commands:
     # Download standalone UnityTestRunner
     - curl -s https://artifactory.internal.unity3d.com/core-automation/tools/utr-standalone/utr --output utr
@@ -65,6 +63,8 @@ test_{{ package.name }}_{{ editor.version }}_ios:
     logs:
       paths:
         - "build/test-results/**"
+  dependencies:
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_ios_{{ editor.version }}
 
 {% for platform in platforms %}
 {% if platform.name != "mac" -%}
@@ -86,12 +86,6 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
       export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
       upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!HttpSignaling"
     {% endif %}
-  triggers:
-    branches:
-      only:
-      - "/.*/"
-      except:
-      - "master"
   artifacts:
     {{ package.name }}_{{ editor.version }}_{{ platform.name }}_test_results: 
       paths:
@@ -100,7 +94,6 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
     - .yamato/upm-ci-webapp.yml#test_{{ platform.name }}
-
 {% for project in test_projects %}
 test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
   name : Test {{ project.name }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}
@@ -130,7 +123,6 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   dependencies:
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
 {% endfor %}
-
 {% endfor %}
 {% else -%}
 {% for param in platform.test_params %}
@@ -155,12 +147,6 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   commands:
     - find upm-ci~/packages/ -name "*.tgz" | xargs -I file tar xvf file -C upm-ci~
     - BuildScripts~/test_package_mac.sh
-  triggers:
-    branches:
-      only:
-      - "/.*/"
-      except:
-      - "master"  
   artifacts:
     {{ package.name }}_{{ editor.version }}_{{ platform.name }}_test_results: 
       paths:
@@ -169,12 +155,55 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
     - .yamato/upm-ci-webapp.yml#test_{{ platform.name }}
+{% for project in test_projects %}
+test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
+  name : Test {{ project.name }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+    - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
+    {% if platform.name != "win" %}
+    - find ./{{ package.packagename }} -type l -exec bash -c 'sh BuildScripts~/convert_symlinks.sh "$0"' {} \;
+    {% endif %}
+    - upm-ci project pack --project-path {{ project.path }}
+    {% if platform.name == "win" %}
+    - | 
+      set WEBAPP_PATH=%cd%\Webapp\bin~\{{ platform.packed_webapp_name }}
+      upm-ci project test -u {{ editor.version }} --project-path {{ project.path }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
+    {% else %}
+    - | 
+      export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
+      upm-ci project test -u {{ editor.version }} --project-path {{ project.path }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!HttpSignaling"
+    {% endif %}
+  artifacts:
+    {{ package.name }}_{{ editor.version }}_{{ platform.name }}_test_results: 
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
+{% endfor %}
 {% endfor %}
 {% endif -%}
 {% endfor %}
-{% endfor %}
 
-{% for editor in editors %}
+trigger_package_test_{{ package.name }}_{{ editor.version }}:
+  name : Trigger all Package test {{ package.packagename }} {{ editor.version }}
+  triggers:
+    branches:
+      only:
+      - "/.*/"
+      except:
+      - "master"
+  dependencies:
+    {% for platform in platforms %}
+    {% for param in platform.test_params %}
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}
+    {% endfor %}
+    {% endfor %}
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_ios_{{ editor.version }}
+
 trigger_renderpipeline_test_{{ package.name }}_{{ editor.version }}:
   name : Trigger all RenderPipeline test {{ package.packagename }} {{ editor.version }}
   dependencies:
@@ -185,6 +214,7 @@ trigger_renderpipeline_test_{{ package.name }}_{{ editor.version }}:
     {% endfor %}
     {% endfor %}
     {% endfor %}
+
 {% endfor %}
 
 publish_dry_run_{{ package.name }}:

--- a/.yamato/upm-ci-template.yml
+++ b/.yamato/upm-ci-template.yml
@@ -66,12 +66,6 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
 
 trigger_template_test_{{ project.name }}_{{ editor.version }}:
   name : Trigger all Template test {{ project.packagename }} {{ editor.version }}
-  triggers:
-    branches:
-      only:
-      - "/.*/"
-      except:
-      - "master"
   dependencies:
     {% for platform in platforms %}
     {% if platform.name == "win" -%}

--- a/.yamato/upm-ci-template.yml
+++ b/.yamato/upm-ci-template.yml
@@ -17,12 +17,9 @@ pack_{{ project.name }}:
     packages:
       paths:
         - "upm-ci~/**/*"
-  dependencies:
-    {% for platform in platforms %}
-    - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
-    {% endfor %}
 
 {% for editor in editors %}
+
 {% for platform in platforms %}
 {% if platform.name == "win" -%}
 {% for param in platform.test_params %}
@@ -35,18 +32,13 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   commands:
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
     - upm-ci template test -u {{ editor.version }} --project-path {{ project.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
-  triggers:
-    branches:
-      only:
-      - "/.*/"
-      except:
-      - "master"
   artifacts:
     logs:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/upm-ci-template.yml#pack_{{ project.name }}
+    - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
 {% endfor %}
 {% else -%}
 {% for param in platform.test_params %}
@@ -60,22 +52,41 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   commands:
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
     - upm-ci template test -u {{ editor.version }} --project-path {{ project.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
-  triggers:
-    branches:
-      only:
-      - "/.*/"
-      except:
-      - "master"
   artifacts:
     logs:
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/upm-ci-template.yml#pack_{{ project.name }}
+    - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
 {% endif -%}
 {% endfor %}
 {% endif -%}
 {% endfor %}
+
+trigger_template_test_{{ project.name }}_{{ editor.version }}:
+  name : Trigger all Template test {{ project.packagename }} {{ editor.version }}
+  triggers:
+    branches:
+      only:
+      - "/.*/"
+      except:
+      - "master"
+  dependencies:
+    {% for platform in platforms %}
+    {% if platform.name == "win" -%}
+    {% for param in platform.test_params %}
+    - .yamato/upm-ci-template.yml#test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}
+    {% endfor %}
+    {% else -%}
+    {% for param in platform.test_params %}
+    {% if project.name != "renderstreaming-rtx" -%}
+    - .yamato/upm-ci-template.yml#test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}
+    {% endif -%}
+    {% endfor %}
+    {% endif -%}
+    {% endfor %}
+
 {% endfor %}
 
 publish_{{ project.name }}:

--- a/.yamato/upm-ci-template.yml
+++ b/.yamato/upm-ci-template.yml
@@ -80,9 +80,9 @@ trigger_template_test_{{ project.name }}_{{ editor.version }}:
     {% endfor %}
     {% else -%}
     {% for param in platform.test_params %}
-    {% if project.name != "renderstreaming-rtx" -%}
+    {% if project.name != "renderstreaming-rtx" %}
     - .yamato/upm-ci-template.yml#test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}
-    {% endif -%}
+    {% endif %}
     {% endfor %}
     {% endif -%}
     {% endfor %}
@@ -111,7 +111,7 @@ publish_{{ project.name }}:
         - "upm-ci~/packages/*.tgz"
         - "upm-ci~/templates/*.tgz"
   dependencies:
-    - .yamato/upm-ci-template.yml#pack
+    - .yamato/upm-ci-template.yml#pack_{{ project.name }}
     {% for editor in editors %}
     - .yamato/upm-ci-template.yml#trigger_template_test_{{ project.name }}_{{ editor.version }}
     {% endfor %}
@@ -138,7 +138,7 @@ publish_dryrun_{{ project.name }}:
         - "upm-ci~/packages/*.tgz"
         - "upm-ci~/templates/*.tgz"
   dependencies:
-    - .yamato/upm-ci-template.yml#pack
+    - .yamato/upm-ci-template.yml#pack_{{ project.name }}
     {% for editor in editors %}
     - .yamato/upm-ci-template.yml#trigger_template_test_{{ project.name }}_{{ editor.version }}
     {% endfor %}

--- a/.yamato/upm-ci-template.yml
+++ b/.yamato/upm-ci-template.yml
@@ -113,11 +113,7 @@ publish_{{ project.name }}:
   dependencies:
     - .yamato/upm-ci-template.yml#pack
     {% for editor in editors %}
-    {% for platform in platforms %}
-    {% for param in platform.test_params %}
-    - .yamato/upm-ci-template.yml#test_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}
-    {% endfor %}
-    {% endfor %}
+    - .yamato/upm-ci-template.yml#trigger_template_test_{{ project.name }}_{{ editor.version }}
     {% endfor %}
 
 publish_dryrun_{{ project.name }}:
@@ -144,10 +140,6 @@ publish_dryrun_{{ project.name }}:
   dependencies:
     - .yamato/upm-ci-template.yml#pack
     {% for editor in editors %}
-    {% for platform in platforms %}
-    {% for param in platform.test_params %}
-    - .yamato/upm-ci-template.yml#test_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}
+    - .yamato/upm-ci-template.yml#trigger_template_test_{{ project.name }}_{{ editor.version }}
     {% endfor %}
-    {% endfor %}
-    {% endfor %}    
 {% endfor %}

--- a/.yamato/upm-ci-webapp.yml
+++ b/.yamato/upm-ci-webapp.yml
@@ -45,12 +45,6 @@ test_{{ platform.name }}:
     flavor: {{ platform.flavor }}
   commands:
     - {{ platform.test_command }}
-  triggers:
-    branches:
-      only:
-      - "/.*/"
-      except:
-      - "master"
   artifacts:
     logs:
       paths:
@@ -59,4 +53,18 @@ test_{{ platform.name }}:
   dependencies:
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
 {% endfor %}
+
+trigger_webapp_test_{{ project.name }}:
+  name : Trigger all WebApp test {{ project.packagename }}
+  triggers:
+    branches:
+      only:
+      - "/.*/"
+      except:
+      - "master"
+  dependencies:
+    {% for platform in platforms %}
+    - .yamato/upm-ci-webapp.yml#test_{{ platform.name }}
+    {% endfor %}
+
 {% endfor %}

--- a/BuildScripts~/template/remote.sh.template
+++ b/BuildScripts~/template/remote.sh.template
@@ -1,0 +1,71 @@
+#!/bin/bash
+# This is a template file to execute remote machine.
+
+# python version is random on each VM
+export PATH=$PATH:/usr/local/bin:/Users/bokken/Library/Python/3.7/bin:/Users/bokken/Library/Python/3.8/bin
+export ARTIFACT_DIR=${PWD}/test-results
+
+# TEST_TARGET = `ios` or `macos`
+# TEST_PLATFORM = `editmode` or `playmode` or `standalone`
+# SCRIPTING_BACKEND = `il2cpp` or `mono`
+additional_component_arg="-c editor"
+platform=Editor
+architecture=x64
+suite=playmode
+
+if [ ${TEST_PLATFORM} = "standalone" ]; then
+  if [ ${TEST_TARGET} = "ios" ]; then
+    additional_component_arg="-c editor -c iOS"
+    architecture=arm64
+    platform=iOS
+  elif [ ${TEST_TARGET} = "iossimulator" ]; then
+    additional_component_arg="-c editor -c iOS"
+    platform=iOS
+  elif [ ${TEST_TARGET} = "macos" ]; then
+    platform=StandaloneOSX
+    if [ ${SCRIPTING_BACKEND} = "il2cpp" ]; then
+      additional_component_arg="-c editor -c StandaloneSupport-IL2CPP"
+    else
+      additional_component_arg="-c editor -c StandaloneSupport-Mono"
+    fi
+  fi
+fi
+
+if [ ${TEST_PLATFORM} = "editmode" ]; then
+  suite=editor
+fi
+
+# install unity-downloader-cli
+pip3 install unity-downloader-cli                                                     \
+  --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple \
+  --upgrade                                                                           \
+  --user
+
+# install utr
+curl -s https://artifactory.internal.unity3d.com/core-automation/tools/utr-standalone/utr \
+  --output utr
+chmod +x ./utr
+
+# download unity editor
+unity-downloader-cli          \
+  -u ${EDITOR_VERSION}        \
+  ${additional_component_arg} \
+  --wait                      \
+  --published
+
+export WEBAPP_PATH=${HOME}/${WEBAPP_DIR}/${WEBAPP_NAME}
+
+# run utr
+./utr                                                       \
+  --suite=${suite}                                          \
+  --platform=${platform}                                    \
+  --scripting-backend=${SCRIPTING_BACKEND}                  \
+  --testproject=${HOME}/${TEST_PROJECT_DIR}                 \
+  --editor-location=${HOME}/.Editor                         \
+  --artifacts_path=${ARTIFACT_DIR}                          \
+  --architecture=${architecture}                            \
+  ${EXTRA_UTR_ARG}
+result=$?
+
+# return exit-code
+exit $result

--- a/BuildScripts~/test_package_mac.sh
+++ b/BuildScripts~/test_package_mac.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#
+# BOKKEN_DEVICE_IP: 
+# TEMPLATE_FILE: 
+# TEST_TARGET:
+# TEST_PLATFORM:
+# SCRIPTING_BACKEND:
+# EXTRA_UTR_ARG:
+# PACKAGE_DIR:
+# TEST_PROJECT_DIR:
+# TEST_RESULT_DIR:
+# EDITOR_VERSION:
+#
+# 
+# brew install gettext
+#
+
+export IDENTITY=~/.ssh/id_rsa_macmini
+
+# install envsubst command
+brew install gettext
+
+# render template
+envsubst '                                    \
+  $WEBAPP_DIR                                 \
+  $WEBAPP_NAME                                \
+  $SCRIPTING_BACKEND                          \
+  $EXTRA_UTR_ARG                              \
+  $TEST_PROJECT_DIR                           \
+  $TEST_TARGET                                \
+  $TEST_PLATFORM                              \
+  $EDITOR_VERSION'                            \
+  < ${TEMPLATE_FILE}                          \
+  > ~/remote.sh
+chmod +x ~/remote.sh
+
+# copy package to remote machine
+scp -i ${IDENTITY} -r ${YAMATO_SOURCE_DIR} bokken@${BOKKEN_DEVICE_IP}:~/${PACKAGE_DIR}
+
+# copy shell script to remote machine
+scp -i ${IDENTITY} -r ~/remote.sh bokken@${BOKKEN_DEVICE_IP}:~/remote.sh
+
+# run remote.sh on the remote machine
+ssh -i ${IDENTITY} bokken@${BOKKEN_DEVICE_IP} ~/remote.sh
+result=$?
+if [ $result -ne 0 ]; then
+  exit $result
+fi
+
+mkdir -p ${TEST_RESULT_DIR}
+scp -i ${IDENTITY} -r bokken@${BOKKEN_DEVICE_IP}:~/test-results ${TEST_RESULT_DIR}

--- a/RenderStreaming~/ProjectSettings/ProjectSettings.asset
+++ b/RenderStreaming~/ProjectSettings/ProjectSettings.asset
@@ -13,7 +13,7 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: DefaultCompany
-  productName: EmptyProject
+  productName: RenderStreaming~
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
@@ -80,7 +80,7 @@ PlayerSettings:
   bakeCollisionMeshes: 0
   forceSingleInstance: 0
   useFlipModelSwapchain: 1
-  resizableWindow: 0
+  resizableWindow: 1
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 1
@@ -91,7 +91,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0
@@ -156,7 +156,7 @@ PlayerSettings:
       dashSupport: 1
       lowOverheadMode: 0
       protectedContext: 0
-      v2Signing: 1
+      v2Signing: 0
     enable360StereoCapture: 0
   isWsaHolographicRemotingEnabled: 0
   enableFrameTimingStats: 0
@@ -174,7 +174,7 @@ PlayerSettings:
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
-  stripEngineCode: 1
+  stripEngineCode: 0
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
   ForceInternetPermission: 0
@@ -185,10 +185,10 @@ PlayerSettings:
   StripUnusedMeshComponents: 1
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 10.0
+  iOSTargetOSVersionString: 11.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
-  tvOSTargetOSVersionString: 10.0
+  tvOSTargetOSVersionString: 11.0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
@@ -237,12 +237,12 @@ PlayerSettings:
   tvOSManualSigningProvisioningProfileID: 
   iOSManualSigningProvisioningProfileType: 0
   tvOSManualSigningProvisioningProfileType: 0
-  appleEnableAutomaticSigning: 0
+  appleEnableAutomaticSigning: 2
   iOSRequireARKit: 0
   iOSAutomaticallyDetectAndAddCapabilities: 1
   appleEnableProMotion: 0
   clonedFromGUID: c0afd0d1d80e3634a9dac47e8a0426ea
-  templatePackageId: com.unity.template.3d@2.3.3
+  templatePackageId: com.unity.template.3d@3.1.2
   templateDefaultScene: Assets/Scenes/SampleScene.unity
   AndroidTargetArchitectures: 1
   AndroidSplashScreenScale: 0
@@ -321,7 +321,7 @@ PlayerSettings:
     m_Automatic: 0
   - m_BuildTarget: iOSSupport
     m_APIs: 10000000
-    m_Automatic: 1
+    m_Automatic: 0
   - m_BuildTarget: AppleTVSupport
     m_APIs: 10000000
     m_Automatic: 0
@@ -468,7 +468,7 @@ PlayerSettings:
   switchDataLossConfirmation: 0
   switchUserAccountLockEnabled: 0
   switchSystemResourceMemory: 16777216
-  switchSupportedNpadStyles: 3
+  switchSupportedNpadStyles: 22
   switchNativeFsCacheSize: 32
   switchIsHoldTypeHorizontal: 0
   switchSupportedNpadCount: 8
@@ -666,6 +666,6 @@ PlayerSettings:
   projectName: 
   organizationId: 
   cloudEnabled: 0
-  enableNativePlatformBackendsForNewInputSystem: 1
-  disableOldInputManagerSupport: 1
+  enableNativePlatformBackendsForNewInputSystem: 0
+  disableOldInputManagerSupport: 0
   legacyClampBlendShapeWeights: 0

--- a/com.unity.renderstreaming/Runtime/Unity.RenderStreaming.Runtime.asmdef
+++ b/com.unity.renderstreaming/Runtime/Unity.RenderStreaming.Runtime.asmdef
@@ -9,6 +9,7 @@
     ],
     "includePlatforms": [
         "Editor",
+        "iOS",
         "LinuxStandalone64",
         "macOSStandalone",
         "WindowsStandalone64"

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -17,7 +17,6 @@ namespace Unity.RenderStreaming.RuntimeTest
     [TestFixture(typeof(WebSocketSignaling))]
     [TestFixture(typeof(HttpSignaling))]
     [TestFixture(typeof(MockSignaling))]
-    [UnityPlatform(exclude = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.OSXPlayer })]
     [ConditionalIgnore(ConditionalIgnore.IL2CPP, "Process.Start does not implement in IL2CPP.")]
     public class PrivateSignalingTest : IPrebuildSetup
     {

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -17,6 +17,7 @@ namespace Unity.RenderStreaming.RuntimeTest
     [TestFixture(typeof(WebSocketSignaling))]
     [TestFixture(typeof(HttpSignaling))]
     [TestFixture(typeof(MockSignaling))]
+    [UnityPlatform(exclude = new[] {RuntimePlatform.IPhonePlayer})]
     [ConditionalIgnore(ConditionalIgnore.IL2CPP, "Process.Start does not implement in IL2CPP.")]
     public class PrivateSignalingTest : IPrebuildSetup
     {

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -14,7 +14,6 @@ namespace Unity.RenderStreaming.RuntimeTest
         PublicMode
     }
 
-    [UnityPlatform(exclude = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.OSXPlayer })]
     [ConditionalIgnore(ConditionalIgnore.IL2CPP, "Process.Start does not implement in IL2CPP.")]
     class RenderStreamingInternalTest
     {

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
@@ -16,7 +16,6 @@ namespace Unity.RenderStreaming.RuntimeTest
     [TestFixture(typeof(WebSocketSignaling))]
     [TestFixture(typeof(HttpSignaling))]
     [TestFixture(typeof(MockSignaling))]
-    [UnityPlatform(exclude = new[] { RuntimePlatform.OSXEditor, RuntimePlatform.OSXPlayer })]
     [ConditionalIgnore(ConditionalIgnore.IL2CPP, "Process.Start does not implement in IL2CPP.")]
     public class SignalingTest : IPrebuildSetup
     {

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
@@ -16,6 +16,7 @@ namespace Unity.RenderStreaming.RuntimeTest
     [TestFixture(typeof(WebSocketSignaling))]
     [TestFixture(typeof(HttpSignaling))]
     [TestFixture(typeof(MockSignaling))]
+    [UnityPlatform(exclude = new[] {RuntimePlatform.IPhonePlayer})]
     [ConditionalIgnore(ConditionalIgnore.IL2CPP, "Process.Start does not implement in IL2CPP.")]
     public class SignalingTest : IPrebuildSetup
     {

--- a/com.unity.renderstreaming/Tests/Runtime/Unity.RenderStreaming.RuntimeTests.asmdef
+++ b/com.unity.renderstreaming/Tests/Runtime/Unity.RenderStreaming.RuntimeTests.asmdef
@@ -10,6 +10,7 @@
     ],
     "includePlatforms": [
         "Editor",
+        "iOS",
         "LinuxStandalone64",
         "macOSStandalone",
         "WindowsStandalone64"


### PR DESCRIPTION
- Enabled ci on macos/ios
- `remote.sh.templete` and `test_package_mac.sh` refer webrtc package https://github.com/Unity-Technologies/com.unity.webrtc/tree/develop/BuildScripts~
- Notice: signaling test ignore on ios device test
- add trigger job for (package/template/webapp) test 