### PR TITLE
chore: Enable test for standalone il2cpp on mac

### DIFF
--- a/.yamato/meta/environments.yml
+++ b/.yamato/meta/environments.yml
@@ -22,7 +22,7 @@ platforms:
         platform: standalone
       - backend: il2cpp
         platform: standalone
-  - name: mac
+  - name: macos
     type: Unity::metal::macmini
     image: package-ci/mac:stable
     flavor: m1.mac

--- a/.yamato/upm-ci-publish-github-release.yml
+++ b/.yamato/upm-ci-publish-github-release.yml
@@ -3,7 +3,7 @@
 
 platforms:
   - name: win
-  - name: mac
+  - name: macos
 packages:
   - name: renderstreaming
 ---

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -67,7 +67,7 @@ test_{{ package.name }}_ios_{{ editor.version }}:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_ios_{{ editor.version }}
 
 {% for platform in platforms %}
-{% if platform.name != "mac" -%}
+{% if platform.name != "macos" -%}
 {% for param in platform.test_params %}
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
   name : Test {{ package.packagename }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -151,7 +151,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   artifacts:
     {{ package.name }}_{{ editor.version }}_{{ platform.name }}_test_results: 
       paths:
-        - "upm-ci~/test-results/**/*"
+        - "upm-ci~/test-results/**"
   dependencies:
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
@@ -181,7 +181,7 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   artifacts:
     {{ package.name }}_{{ editor.version }}_{{ platform.name }}_test_results: 
       paths:
-        - "upm-ci~/test-results/**/*"
+        - "upm-ci~/test-results/**"
   dependencies:
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
 {% endfor %}

--- a/.yamato/upm-ci-webapp.yml
+++ b/.yamato/upm-ci-webapp.yml
@@ -5,7 +5,7 @@ platforms:
     flavor: b1.xlarge
     pack_command: pack_webapp.cmd
     test_command: test_webapp.cmd
-  - name: mac
+  - name: macos
     type: Unity::VM::osx
     image: package-ci/mac:stable
     flavor: m1.mac


### PR DESCRIPTION
`TEST_TARGET` variable should be `ios` or `macos`.
https://github.com/Unity-Technologies/UnityRenderStreaming/blob/develop/BuildScripts~/template/remote.sh.template#L8