### PR TITLE
Fix: fullscreen button on ios

### DIFF
--- a/WebApp/public/videoplayer/js/main.js
+++ b/WebApp/public/videoplayer/js/main.js
@@ -79,12 +79,18 @@ function onClickPlayButton() {
   elementFullscreenButton.src = 'images/FullScreen.png';
   playerDiv.appendChild(elementFullscreenButton);
   elementFullscreenButton.addEventListener("click", function () {
-    if (!document.fullscreenElement) {
+    if (document.fullscreenElement != undefined && !document.fullscreenElement) {
       if (document.documentElement.requestFullscreen) {
         document.documentElement.requestFullscreen();
       }
       else if (document.documentElement.webkitRequestFullscreen) {
         document.documentElement.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
+      }
+    } else {
+      if (playerDiv.style.position == "absolute") {
+        playerDiv.style.position = "relative";
+      } else {
+        playerDiv.style.position = "absolute";
       }
     }
   });

--- a/WebApp/public/videoplayer/js/main.js
+++ b/WebApp/public/videoplayer/js/main.js
@@ -79,18 +79,18 @@ function onClickPlayButton() {
   elementFullscreenButton.src = 'images/FullScreen.png';
   playerDiv.appendChild(elementFullscreenButton);
   elementFullscreenButton.addEventListener("click", function () {
-    if (document.fullscreenElement != undefined && !document.fullscreenElement) {
+    if (!document.fullscreenElement || !document.webkitFullscreenElement) {
       if (document.documentElement.requestFullscreen) {
         document.documentElement.requestFullscreen();
       }
       else if (document.documentElement.webkitRequestFullscreen) {
         document.documentElement.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
-      }
-    } else {
-      if (playerDiv.style.position == "absolute") {
-        playerDiv.style.position = "relative";
       } else {
-        playerDiv.style.position = "absolute";
+        if (playerDiv.style.position == "absolute") {
+          playerDiv.style.position = "relative";
+        } else {
+          playerDiv.style.position = "absolute";
+        }
       }
     }
   });


### PR DESCRIPTION
Not working fullscreen button on iOS 14 Safari. (it's working on iPad OS)

If it can't be full screen, 
Changed to show Player on whole Canvas.


![IMG_0586](https://user-images.githubusercontent.com/26959415/108155007-65c1ef00-7121-11eb-8a9c-7e2181c6184d.PNG)
