### PR TITLE
fixed: Fixed edtior menu

### DIFF
--- a/com.unity.renderstreaming/Editor/WebAppDownloader.cs
+++ b/com.unity.renderstreaming/Editor/WebAppDownloader.cs
@@ -35,7 +35,8 @@ namespace Unity.RenderStreaming.Editor
             {
                 version = LatestKnownVersion;
             }
-            string path = string.Format("releases/download/{0}", version);
+
+            string path = $"releases/download/{version}";
             string fileName = GetFileName();
             return $"{URLRoot}/{path}/{fileName}";
         }
@@ -81,7 +82,7 @@ namespace Unity.RenderStreaming.Editor
                     if (version != LatestKnownVersion) {
                         DownloadWebApp(LatestKnownVersion, dstPath, callback);
                     } else {
-                        Debug.LogError("Failed downloading webserver from: " + url + " . Error: " + e.Error.ToString());
+                        Debug.LogError($"Failed downloading web server from:{url}. Error: {e.Error}");
                     }
                     callback?.Invoke(false);
                     return;
@@ -89,7 +90,7 @@ namespace Unity.RenderStreaming.Editor
 
                 if (!System.IO.File.Exists(tmpFilePath))
                 {
-                    Debug.LogErrorFormat("Download failed. url:{0}", url);
+                    Debug.LogError($"Download failed. url:{url}");
                     callback?.Invoke(false);
                     return;
                 }
@@ -122,7 +123,7 @@ namespace Unity.RenderStreaming.Editor
                 var packageInfo = req.FindPackage(packageName);
                 if (null == packageInfo)
                 {
-                    Debug.LogErrorFormat("Not found package \"{0}\"", packageName);
+                    Debug.LogError($"Not found package \"{packageName}\"");
                     return;
                 }
                 callback(packageInfo.version);


### PR DESCRIPTION
Fix this issue
https://issuetracker.unity3d.com/product/unity/issues/guid/1286452

We had got errors below.

```
Unity.RenderStreaming.Editor.WebAppDownloader:DownloadWebApp(String, String, Action`1) (at Packages/com.unity.renderstreaming/Editor/WebAppDownloader.cs:126)
Unity.RenderStreaming.Editor.<>c:<DownloadWebAppFromMenu>b__0_0(String) (at Packages/com.unity.renderstreaming/Editor/RenderStreamingMenu.cs:13)
Unity.RenderStreaming.Editor.<>c__DisplayClass13_0:<GetPackageVersion>b__0(Request`1) (at Packages/com.unity.renderstreaming/Editor/WebAppDownloader.cs:146)
Unity.RenderStreaming.Editor.RequestJob`1:OnSuccess() (at Packages/com.unity.renderstreaming/Editor/RequestJob.cs:104)
Unity.RenderStreaming.Editor.RequestJob`1:Update() (at Packages/com.unity.renderstreaming/Editor/RequestJob.cs:85)
Unity.RenderStreaming.Editor.RequestJobManager:UpdateRequestJobs() (at Packages/com.unity.renderstreaming/Editor/RequestJobManager.cs:167)
UnityEditor.EditorApplication:Internal_CallUpdateFunctions()
```