### PR TITLE
chore: Replace `github-release-cli` to `gh`

### DIFF
--- a/.yamato/upm-ci-publish-github-release.yml
+++ b/.yamato/upm-ci-publish-github-release.yml
@@ -30,7 +30,7 @@ publish_github_release_webapp:
   variables:
     GIT_TAG: Foo
   commands:
-    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+    - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0
     - sudo apt-add-repository https://cli.github.com/packages
     - sudo apt update
     - sudo apt install gh
@@ -52,7 +52,7 @@ publish_github_release_template_{{ project.name }}:
   variables:
     GIT_TAG: Foo
   commands:
-    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+    - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0
     - sudo apt-add-repository https://cli.github.com/packages
     - sudo apt update
     - sudo apt install gh

--- a/.yamato/upm-ci-publish-github-release.yml
+++ b/.yamato/upm-ci-publish-github-release.yml
@@ -30,10 +30,10 @@ publish_github_release_webapp:
   variables:
     GIT_TAG: Foo
   commands:
-    - npm install github-release-cli -g
-    - github-release upload -o "Unity-Technologies" -r "UnityRenderStreaming" -t "%GIT_TAG%" -n "%GIT_TAG%" "WebApp/bin~/webserver"
-    - github-release upload -o "Unity-Technologies" -r "UnityRenderStreaming" -t "%GIT_TAG%" -n "%GIT_TAG%" "WebApp/bin~/webserver_mac"
-    - github-release upload -o "Unity-Technologies" -r "UnityRenderStreaming" -t "%GIT_TAG%" -n "%GIT_TAG%" "WebApp/bin~/webserver.exe"
+    - choco install -y gh
+    - gh release upload %GIT_TAG% 'WebApp/bin~/webserver' --clobber -R Unity-Technologies/UnityRenderStreaming
+    - gh release upload %GIT_TAG% 'WebApp/bin~/webserver_mac' --clobber -R Unity-Technologies/UnityRenderStreaming
+    - gh release upload %GIT_TAG% 'WebApp/bin~/webserver.exe' --clobber -R Unity-Technologies/UnityRenderStreaming
   dependencies:
    {% for platform in platforms %}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
@@ -49,8 +49,8 @@ publish_github_release_template_{{ project.name }}:
   variables:
     GIT_TAG: Foo
   commands:
-    - npm install github-release-cli -g
-    - github-release upload -o "Unity-Technologies" -r "UnityRenderStreaming" -t "%GIT_TAG%" -n "%GIT_TAG%" "upm-ci~/packages/{{ project.packagename }}-%GIT_TAG%.tgz"
+    - choco install -y gh
+    - gh release upload %GIT_TAG% 'upm-ci~/packages/{{ project.packagename }}-%GIT_TAG%.tgz' --clobber -R Unity-Technologies/UnityRenderStreaming
   dependencies:
     - .yamato/upm-ci-template.yml#pack_{{ project.name }}
 {% endfor %}

--- a/.yamato/upm-ci-publish-github-release.yml
+++ b/.yamato/upm-ci-publish-github-release.yml
@@ -25,15 +25,18 @@ publish_github_release_webapp:
   name: Publish Webapp to Github Release
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/ubuntu:stable
     flavor: b1.large
   variables:
     GIT_TAG: Foo
   commands:
-    - choco install -y gh
-    - gh release upload %GIT_TAG% 'WebApp/bin~/webserver' --clobber -R Unity-Technologies/UnityRenderStreaming
-    - gh release upload %GIT_TAG% 'WebApp/bin~/webserver_mac' --clobber -R Unity-Technologies/UnityRenderStreaming
-    - gh release upload %GIT_TAG% 'WebApp/bin~/webserver.exe' --clobber -R Unity-Technologies/UnityRenderStreaming
+    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+    - sudo apt-add-repository https://cli.github.com/packages
+    - sudo apt update
+    - sudo apt install gh
+    - gh release upload $GIT_TAG 'WebApp/bin~/webserver' --clobber -R Unity-Technologies/UnityRenderStreaming
+    - gh release upload $GIT_TAG 'WebApp/bin~/webserver_mac' --clobber -R Unity-Technologies/UnityRenderStreaming
+    - gh release upload $GIT_TAG 'WebApp/bin~/webserver.exe' --clobber -R Unity-Technologies/UnityRenderStreaming
   dependencies:
    {% for platform in platforms %}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
@@ -44,13 +47,16 @@ publish_github_release_template_{{ project.name }}:
   name: Publish Template to Github Release {{ project.name }}
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/ubuntu:stable
     flavor: b1.large
   variables:
     GIT_TAG: Foo
   commands:
-    - choco install -y gh
-    - gh release upload %GIT_TAG% 'upm-ci~/packages/{{ project.packagename }}-%GIT_TAG%.tgz' --clobber -R Unity-Technologies/UnityRenderStreaming
+    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+    - sudo apt-add-repository https://cli.github.com/packages
+    - sudo apt update
+    - sudo apt install gh
+    - gh release upload $GIT_TAG 'upm-ci~/packages/{{ project.packagename }}-%GIT_TAG%.tgz' --clobber -R Unity-Technologies/UnityRenderStreaming
   dependencies:
     - .yamato/upm-ci-template.yml#pack_{{ project.name }}
 {% endfor %}


### PR DESCRIPTION
Replaced to `github cli` for a tool to upload binaries to the github release page.
https://github.com/cli/cli