### PR TITLE
fix: Fixed webbrowserinput bugs

### DIFF
--- a/RenderStreaming~/Packages/packages-lock.json
+++ b/RenderStreaming~/Packages/packages-lock.json
@@ -54,7 +54,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.unity.webrtc": "2.3.2-preview",
+        "com.unity.webrtc": "2.3.3-preview",
         "com.unity.inputsystem": "1.0.0"
       }
     },
@@ -79,7 +79,7 @@
       }
     },
     "com.unity.webrtc": {
-      "version": "2.3.2-preview",
+      "version": "2.3.3-preview",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/com.unity.renderstreaming/CHANGELOG.md
+++ b/com.unity.renderstreaming/CHANGELOG.md
@@ -17,7 +17,7 @@ Version 3.0.0 has a big change in the package design. This mainly addresses movi
 ### Changed
 
 - Moved scripts from the sample folder to Package Manager.
-- Upgrading WebRTC package to `2.3.2-preview`.
+- Upgrading WebRTC package to `2.3.3-preview`.
 
 ## [2.2.2] - 2020-12-15
 

--- a/com.unity.renderstreaming/Runtime/Scripts/CameraStreamer.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/CameraStreamer.cs
@@ -8,7 +8,7 @@ namespace Unity.RenderStreaming
     {
         [SerializeField] private RenderTextureDepth depth;
         [SerializeField, Tooltip("This property is needed to choose from 1,2,4 or 8")]
-        private int antiAliasing; //ToDO(kannan):using enum
+        private int antiAliasing = 1; //ToDO(kannan):using enum
 
 
         protected Camera m_camera;

--- a/com.unity.renderstreaming/Runtime/Scripts/WebBrowserInputChannelReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/WebBrowserInputChannelReceiver.cs
@@ -47,18 +47,23 @@ namespace Unity.RenderStreaming
         /// <param name="track"></param>
         public override void SetChannel(string connectionId, RTCDataChannel channel)
         {
-            if (channel == null && remoteInput != null)
+            if (channel == null)
             {
-                onDeviceChange.Invoke(remoteInput.RemoteGamepad, InputDeviceChange.Removed);
-                onDeviceChange.Invoke(remoteInput.RemoteKeyboard, InputDeviceChange.Removed);
-                onDeviceChange.Invoke(remoteInput.RemoteMouse, InputDeviceChange.Removed);
-                onDeviceChange.Invoke(remoteInput.RemoteTouchscreen, InputDeviceChange.Removed);
-                remoteInput?.Dispose();
+                if (remoteInput != null)
+                {
+                    onDeviceChange.Invoke(remoteInput.RemoteGamepad, InputDeviceChange.Removed);
+                    onDeviceChange.Invoke(remoteInput.RemoteKeyboard, InputDeviceChange.Removed);
+                    onDeviceChange.Invoke(remoteInput.RemoteMouse, InputDeviceChange.Removed);
+                    onDeviceChange.Invoke(remoteInput.RemoteTouchscreen, InputDeviceChange.Removed);
+                    remoteInput.Dispose();
+                    remoteInput = null;
+                }
             }
             else
             {
                 remoteInput = RemoteInputReceiver.Create();
                 remoteInput.ActionButtonClick = OnButtonClick;
+                Debug.Log(channel == null);
                 channel.OnMessage += remoteInput.ProcessInput;
                 onDeviceChange.Invoke(remoteInput.RemoteGamepad, InputDeviceChange.Added);
                 onDeviceChange.Invoke(remoteInput.RemoteKeyboard, InputDeviceChange.Added);

--- a/com.unity.renderstreaming/Runtime/Scripts/WebBrowserInputChannelReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/WebBrowserInputChannelReceiver.cs
@@ -63,7 +63,6 @@ namespace Unity.RenderStreaming
             {
                 remoteInput = RemoteInputReceiver.Create();
                 remoteInput.ActionButtonClick = OnButtonClick;
-                Debug.Log(channel == null);
                 channel.OnMessage += remoteInput.ProcessInput;
                 onDeviceChange.Invoke(remoteInput.RemoteGamepad, InputDeviceChange.Added);
                 onDeviceChange.Invoke(remoteInput.RemoteKeyboard, InputDeviceChange.Added);

--- a/com.unity.renderstreaming/package.json
+++ b/com.unity.renderstreaming/package.json
@@ -5,7 +5,7 @@
   "unity": "2019.4",
   "description": "This is a package for using Unity Render Streaming technology. It contains two samples to use the technology.",
   "dependencies": {
-    "com.unity.webrtc": "2.3.2-preview",
+    "com.unity.webrtc": "2.3.3-preview",
     "com.unity.inputsystem": "1.0.0"
   },
   "samples": [


### PR DESCRIPTION
- Upgrade WebRTC package version 2.3.3
- Changed `antiAliasing` in `CameraStreamer` class default value to `1`
- Fixed `NullPointerException` on UnityEditor when reloading a web browser 