### PR TITLE
feat: camera streamer use camera component target texture first

### DIFF
--- a/com.unity.renderstreaming/Editor/CameraStreamerEditor.cs
+++ b/com.unity.renderstreaming/Editor/CameraStreamerEditor.cs
@@ -20,14 +20,26 @@ namespace Unity.RenderStreaming.Editor
         readonly GUIContent antiAliasing =
             EditorGUIUtility.TrTextContent("Anti-aliasing", "Number of anti-aliasing samples.");
 
+        readonly GUIContent[] renderTextureDepthBuffer = new GUIContent[3]
+        {
+            EditorGUIUtility.TrTextContent("No depth buffer"),
+            EditorGUIUtility.TrTextContent("At least 16 bits depth (no stencil)"),
+            EditorGUIUtility.TrTextContent("At least 24 bits depth (with stencil)")
+        };
+
+        readonly int[] renderTextureDepthBufferValues = new int[3] {0, 16, 24};
+
+        readonly GUIContent depthBuffer = EditorGUIUtility.TrTextContent("Depth Buffer", "Format of the depth buffer.");
+
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
 
             EditorGUILayout.PropertyField(serializedObject.FindProperty("streamingSize"));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("depth"));
             var antiAliasingProperty = serializedObject.FindProperty("antiAliasing");
             EditorGUILayout.IntPopup(antiAliasingProperty, renderTextureAntiAliasing, renderTextureAntiAliasingValues, antiAliasing);
+            var depthBufferProperty = serializedObject.FindProperty("depth");
+            EditorGUILayout.IntPopup(depthBufferProperty, renderTextureDepthBuffer, renderTextureDepthBufferValues, depthBuffer);
 
             serializedObject.ApplyModifiedProperties();
 

--- a/com.unity.renderstreaming/Editor/CameraStreamerEditor.cs
+++ b/com.unity.renderstreaming/Editor/CameraStreamerEditor.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Unity.RenderStreaming.Editor
+{
+    [CustomEditor(typeof(CameraStreamer))]
+    public class CameraStreamerEditor : UnityEditor.Editor
+    {
+        readonly GUIContent[] renderTextureAntiAliasing = new GUIContent[4]
+        {
+            EditorGUIUtility.TrTextContent("None"),
+            EditorGUIUtility.TrTextContent("2 samples"),
+            EditorGUIUtility.TrTextContent("4 samples"),
+            EditorGUIUtility.TrTextContent("8 samples")
+        };
+
+        readonly int[] renderTextureAntiAliasingValues = new int[4] {1, 2, 4, 8};
+
+        readonly GUIContent antiAliasing =
+            EditorGUIUtility.TrTextContent("Anti-aliasing", "Number of anti-aliasing samples.");
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("streamingSize"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("depth"));
+            var antiAliasingProperty = serializedObject.FindProperty("antiAliasing");
+            EditorGUILayout.IntPopup(antiAliasingProperty, renderTextureAntiAliasing, renderTextureAntiAliasingValues, antiAliasing);
+
+            serializedObject.ApplyModifiedProperties();
+
+            EditorGUILayout.HelpBox("If TargetTexture is attached on Camera, use that RenderTexture setting first.", MessageType.Info);
+        }
+    }
+}

--- a/com.unity.renderstreaming/Editor/CameraStreamerEditor.cs.meta
+++ b/com.unity.renderstreaming/Editor/CameraStreamerEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2d01da8f1ad4418bae842b1dc3ecd65a
+timeCreated: 1614647816

--- a/com.unity.renderstreaming/Runtime/Scripts/CameraStreamer.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/CameraStreamer.cs
@@ -7,7 +7,7 @@ namespace Unity.RenderStreaming
     [RequireComponent(typeof(Camera))]
     public class CameraStreamer : VideoStreamBase
     {
-        [SerializeField] private RenderTextureDepth depth;
+        [SerializeField] private int depth = 0;
         [SerializeField] private int antiAliasing = 1;
 
 
@@ -25,10 +25,10 @@ namespace Unity.RenderStreaming
             if (m_camera.targetTexture != null)
             {
                 rt = m_camera.targetTexture;
-                var supportFormat = WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+                RenderTextureFormat supportFormat = WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
                 GraphicsFormat graphicsFormat = GraphicsFormatUtility.GetGraphicsFormat(supportFormat, RenderTextureReadWrite.Default);
                 GraphicsFormat compatibleFormat = SystemInfo.GetCompatibleFormat(graphicsFormat, FormatUsage.Render);
-                var format = graphicsFormat == compatibleFormat ? graphicsFormat : compatibleFormat;
+                GraphicsFormat format = graphicsFormat == compatibleFormat ? graphicsFormat : compatibleFormat;
 
                 if (rt.graphicsFormat != format)
                 {
@@ -43,9 +43,8 @@ namespace Unity.RenderStreaming
             }
             else
             {
-                int depthValue = (int)depth;
-                var format = WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
-                rt = new RenderTexture(streamingSize.x, streamingSize.y, depthValue, format)
+                RenderTextureFormat format = WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+                rt = new RenderTexture(streamingSize.x, streamingSize.y, depth, format)
                 {
                     antiAliasing = antiAliasing
                 };

--- a/com.unity.renderstreaming/Runtime/Scripts/CameraStreamer.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/CameraStreamer.cs
@@ -1,5 +1,6 @@
 using Unity.WebRTC;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 
 namespace Unity.RenderStreaming
 {
@@ -7,11 +8,10 @@ namespace Unity.RenderStreaming
     public class CameraStreamer : VideoStreamBase
     {
         [SerializeField] private RenderTextureDepth depth;
-        [SerializeField, Tooltip("This property is needed to choose from 1,2,4 or 8")]
-        private int antiAliasing = 1; //ToDO(kannan):using enum
+        [SerializeField] private int antiAliasing = 1;
 
 
-        protected Camera m_camera;
+        private Camera m_camera;
         public override Texture SendTexture => m_camera.targetTexture;
 
         protected virtual void Awake()
@@ -21,14 +21,38 @@ namespace Unity.RenderStreaming
 
         protected override MediaStreamTrack CreateTrack()
         {
-            int depthValue = (int)depth;
-            var format = WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
-            var rt = new RenderTexture(streamingSize.x, streamingSize.y, depthValue, format)
+            RenderTexture rt;
+            if (m_camera.targetTexture != null)
             {
-                antiAliasing = antiAliasing
-            };
-            rt.Create();
-            m_camera.targetTexture = rt;
+                rt = m_camera.targetTexture;
+                var supportFormat = WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+                GraphicsFormat graphicsFormat = GraphicsFormatUtility.GetGraphicsFormat(supportFormat, RenderTextureReadWrite.Default);
+                GraphicsFormat compatibleFormat = SystemInfo.GetCompatibleFormat(graphicsFormat, FormatUsage.Render);
+                var format = graphicsFormat == compatibleFormat ? graphicsFormat : compatibleFormat;
+
+                if (rt.graphicsFormat != format)
+                {
+                    Debug.LogWarning(
+                        $"This color format:{rt.graphicsFormat} not support in unity.webrtc. Change to supported color format:{format}.");
+                    rt.Release();
+                    rt.graphicsFormat = format;
+                    rt.Create();
+                }
+
+                m_camera.targetTexture = rt;
+            }
+            else
+            {
+                int depthValue = (int)depth;
+                var format = WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+                rt = new RenderTexture(streamingSize.x, streamingSize.y, depthValue, format)
+                {
+                    antiAliasing = antiAliasing
+                };
+                rt.Create();
+                m_camera.targetTexture = rt;
+            }
+
             return new VideoStreamTrack(m_camera.name, rt);
         }
     }


### PR DESCRIPTION
If targettexture is set on camera component, use it first
However, the color formats that can be used are limited, so check it and change it if necessary.

Implemented a custom inspector for notes

![image](https://user-images.githubusercontent.com/26959415/109588419-08c82f00-7b4c-11eb-8aae-8f517de686af.png)
