### PR TITLE
fix: Compile error when importing the package sample

### DIFF
--- a/com.unity.renderstreaming/Samples~/Example/Gyro/Unity.RenderStreaming.GyroSample.asmdef
+++ b/com.unity.renderstreaming/Samples~/Example/Gyro/Unity.RenderStreaming.GyroSample.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Unity.RenderStreaming.GyroSample",
+    "references": [
+        "Unity.InputSystem",
+        "Unity.RenderStreaming.Runtime"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/com.unity.renderstreaming/Samples~/Example/Gyro/Unity.RenderStreaming.GyroSample.asmdef.meta
+++ b/com.unity.renderstreaming/Samples~/Example/Gyro/Unity.RenderStreaming.GyroSample.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d2a0563a601204045910d3dc8d88ea99
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This compile error occurs when importing the package sample

```
Assets\Samples\Unity Render Streaming\3.0.0-preview.1\Example\Gyro\GyroSample.cs(5,31): error CS0234: The type or namespace name 'InputSystem' does not exist in the namespace 'UnityEngine' (are you missing an assembly reference?)

```
![image](https://user-images.githubusercontent.com/1132081/109746364-9c673180-7c18-11eb-9570-45d0cdbdf4ed.png)
