### PR TITLE
doc: Remove docs for customizing the signaling protocol

### DIFF
--- a/com.unity.renderstreaming/Documentation~/faq.md
+++ b/com.unity.renderstreaming/Documentation~/faq.md
@@ -22,7 +22,7 @@ If you use the hardware encoder, Make sure you're using a graphics card that sup
 
 Make sure the port isn't being used by another service. 
 
-### uGUI can't be operated through a browser.
+### Unity UI can't be operated through a browser.
 
 It is only possible to operate when the focus is on the running application.
 On [This page](browser_input.md#using-unity-ui), you can see more info.

--- a/com.unity.renderstreaming/Documentation~/samples.md
+++ b/com.unity.renderstreaming/Documentation~/samples.md
@@ -1,10 +1,6 @@
-# Import Samples
-You can import Samples from the bottom of the `com.unity.renderstreaming` package in the PackageManager Window.
+# Samples
 
-![Sample List](images/renderstreaming_samples.png)
-
-
-# About Samples
+## About Samples
 
 * [Receiver](sample-receiver.md)
 * [Broadcast](sample-broadcast.md)
@@ -13,3 +9,8 @@ You can import Samples from the bottom of the `com.unity.renderstreaming` packag
 * [AR Foundation](sample-arfoundation.md)
 * [Gyroscope](sample-gyroscope.md)
 * [Web Browser Input](sample-browserinput.md)
+
+## Import Samples
+You can import Samples from the bottom of the `com.unity.renderstreaming` package in the PackageManager Window.
+
+![Sample List](images/renderstreaming_samples.png)

--- a/com.unity.renderstreaming/Documentation~/signalingprotocol.md
+++ b/com.unity.renderstreaming/Documentation~/signalingprotocol.md
@@ -2,17 +2,17 @@
 
 **The Unity Render Streaming** package provides two different signaling protocols as examples.
 
-- HttpSignaling
-- WebSocketSignaling
+- `HttpSignaling`
+- `WebSocketSignaling`
 
 In the example, the schema given to `URL Signaling` is used to determine which protocol to use.
 
 ![Render Streaming backend](images/websocket_signaling_inspector.png)
 
-If it starts with `http`, HttpSignaling is used. If it starts with `ws`, WebSocketSignaling is used.
+If it starts with `http`, `HttpSignaling` is used. If it starts with `ws`, `WebSocketSignaling` is used.
 
 ## HttpSignaling
-Signaling is handled by Http Request.
+Signaling is handled by HTTP Request.
 The signalling server is polled at specified intervals to obtain the Offer and Candidate of the difference from the last time.
 
 ## WebSocketSignaling
@@ -20,56 +20,4 @@ Signaling is handled by WebSocket.
 When the signaling server receives the Offer or Candidate, the server distributes it to the connected clients.
 > [!WARNING]
 > WebSocket does not work in iOS Safari on servers that use self-signed certificates.
-> If you want to verify the behavior of WebSocket signaling in iOS Safari, use a certificate issued by a trusted certification authority. Or try signaling with Http.
-
-## Proprietary Signaling Class
-Both of the signaling classes implement `ISignaling`.
-If you want to create your own signaling class, you can inherit `ISignaling` to use it directly from the UnityRenderStreaming class.
-The following is a description of each method.
-
-```
-void Start();
-```
-- A method to call when starting signaling.
-- In the sample, we are establishing a session with the server for each protocol.
-
-```
-void Stop();
-```
-A method to call when you want to stop signaling.
-In the sample, we are terminating the session with the server for each protocol.
-
-```
-public delegate void OnOfferHandler(ISignaling signaling, DescData e);
-event OnOfferHandler OnOffer;
-```
-- This is a delegate that registers the process to be performed when a new Offer is received by signaling.
-
-```
-public delegate void OnAnswerHandler(ISignaling signaling, DescData e);
-event OnAnswerHandler OnAnswer;
-```
-- This is a delegate that registers the process to be performed when a new Answer is received by signaling.
-- In the current version, it is not used in Unity because it does not receive Answers.
-
-```
-public delegate void OnIceCandidateHandler(ISignaling signaling, CandidateData e);
-event OnIceCandidateHandler OnIceCandidate;
-```
-- This is a delegate that registers the process to be performed when it receives a new Candidate by signaling.
-
-```
-void SendOffer();
-```
-- A method to call when sending an Offer in signaling.
-- In the current version, it is not implemented in the sample because it is not possible to send Offer from Unity.
-
-```
-void SendAnswer(string connectionId, RTCSessionDescription answer);
-```
-- A method to call when sending an Answer in signaling.
-
-```
-void SendCandidate(string connectionId, RTCIceCandidate candidate);
-```
-- A method to call when sending a Candidate in signaling.
+> If you want to verify the behavior of WebSocket signaling in iOS Safari, use a certificate issued by a trusted certification authority. Or try signaling with HTTP.

--- a/com.unity.renderstreaming/Documentation~/turnserver.md
+++ b/com.unity.renderstreaming/Documentation~/turnserver.md
@@ -94,7 +94,7 @@ Use the [webrtc sample](https://webrtc.github.io/samples/src/content/peerconnect
 | TURN username    | username                              |
 | TURN password    | password                              |
 
-<img src="images/turn-connection-testing.png" width=600 align=center>
+![TURN connection testing](images/turn-connection-testing.png)
 
 Click `Gather candidates` to show a list of potential communication paths. Verify that a log is also printed on the TURN server side. 
 

--- a/com.unity.renderstreaming/Documentation~/tutorial.md
+++ b/com.unity.renderstreaming/Documentation~/tutorial.md
@@ -92,8 +92,8 @@ You can see the Unity scene on the browser, and control a camera in the Unity sc
 
 ## After tutorial
 
-About general questions, please see [FAQ](faq.md) page. About the operation of inspectors, please see [Components settings](components.md) page. 
+About general questions, please see [FAQ](faq.md) page. And you are available for discussions about Unity Render Streaming on [Unity Forum](https://forum.unity.com/forums/unity-render-streaming.413). 
 
+About the operation of inspectors, please see [Components settings](components.md) page. 
 About options of web application, please see [The web application](webapp.md) page.
-
 You can see more details for samples on the [Samples](samples.md) page.


### PR DESCRIPTION
The document for customizing signaling protocol had published but this is not supported right now.
In near future, we should make a new sample to show how to customize it.