### PR TITLE
fix: Not waiting for the thread when disposing the signaling instance 

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/FurioosSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/FurioosSignaling.cs
@@ -62,8 +62,19 @@ namespace Unity.RenderStreaming.Signaling
 
         public void Stop()
         {
-            m_running = false;
-            m_webSocket?.Close();
+            if (m_running)
+            {
+                m_running = false;
+                if (m_signalingThread.ThreadState == ThreadState.WaitSleepJoin)
+                {
+                    m_signalingThread.Abort();
+                }
+                else
+                {
+                    m_signalingThread.Join(1000);
+                }
+                m_signalingThread = null;
+            }
         }
 
         //todo(kazuki):: remove warning CS0067
@@ -250,7 +261,7 @@ namespace Unity.RenderStreaming.Signaling
 
         private void WSClosed(object sender, CloseEventArgs e)
         {
-            Debug.LogError($"Signaling: WS connection closed, code: {e.Code}");
+            Debug.Log($"Signaling: WS connection closed, code: {e.Code}");
 
             m_wsCloseEvent.Set();
             m_webSocket = null;

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
@@ -63,7 +63,14 @@ namespace Unity.RenderStreaming.Signaling
             if (m_running)
             {
                 m_running = false;
-                m_signalingThread?.Join();
+                if (m_signalingThread.ThreadState == ThreadState.WaitSleepJoin)
+                {
+                    m_signalingThread.Abort();
+                }
+                else
+                {
+                    m_signalingThread.Join(1000);
+                }
                 m_signalingThread = null;
             }
         }
@@ -127,7 +134,15 @@ namespace Unity.RenderStreaming.Signaling
             while (m_running && string.IsNullOrEmpty(m_sessionId))
             {
                 HTTPCreate();
-                Thread.Sleep((int)(m_timeout * 1000));
+                try
+                {
+                    Thread.Sleep((int)(m_timeout * 1000));
+                }
+                catch (ThreadAbortException e)
+                {
+                    // Thread.Abort() called from main thread. Ignore
+                    return;
+                }
             }
 
             while (m_running)
@@ -144,7 +159,15 @@ namespace Unity.RenderStreaming.Signaling
                     Debug.LogError("Signaling: HTTP polling error : " + e);
                 }
 
-                Thread.Sleep((int)(m_timeout * 1000));
+                try
+                {
+                    Thread.Sleep((int)(m_timeout * 1000));
+                }
+                catch (ThreadAbortException e)
+                {
+                    // Thread.Abort() called from main thread. Ignore
+                    return;
+                }
             }
 
             HTTPDelete();
@@ -167,6 +190,10 @@ namespace Unity.RenderStreaming.Signaling
                     Debug.LogError($"Signaling: {response.ResponseUri} HTTP request failed ({response.StatusCode})");
                     response.Close();
                 }
+            }
+            catch (ThreadAbortException e)
+            {
+                // Thread.Abort() called from main thread. Ignore
             }
             catch (Exception e)
             {

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
@@ -153,14 +153,7 @@ namespace Unity.RenderStreaming.Signaling
                     HTTPGetOffers();
                     HTTPGetAnswers();
                     HTTPGetCandidates();
-                }
-                catch (Exception e)
-                {
-                    Debug.LogError("Signaling: HTTP polling error : " + e);
-                }
 
-                try
-                {
                     Thread.Sleep((int)(m_timeout * 1000));
                 }
                 catch (ThreadAbortException e)
@@ -168,8 +161,11 @@ namespace Unity.RenderStreaming.Signaling
                     // Thread.Abort() called from main thread. Ignore
                     return;
                 }
+                catch (Exception e)
+                {
+                    Debug.LogError("Signaling: HTTP polling error : " + e);
+                }
             }
-
             HTTPDelete();
 
             Debug.Log("Signaling: HTTP polling thread ended");

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
@@ -52,7 +52,15 @@ namespace Unity.RenderStreaming.Signaling
             {
                 m_running = false;
                 m_webSocket?.Close();
-                m_signalingThread.Join();
+
+                if (m_signalingThread.ThreadState == ThreadState.WaitSleepJoin)
+                {
+                    m_signalingThread.Abort();
+                }
+                else
+                {
+                    m_signalingThread.Join(1000);
+                }
                 m_signalingThread = null;
             }
         }
@@ -131,7 +139,15 @@ namespace Unity.RenderStreaming.Signaling
 
                 m_wsCloseEvent.WaitOne();
 
-                Thread.Sleep((int)(m_timeout * 1000));
+                try
+                {
+                    Thread.Sleep((int)(m_timeout * 1000));
+                }
+                catch (ThreadAbortException e)
+                {
+                    // Thread.Abort() called from main thread. Ignore
+                    return;
+                }
             }
 
             Debug.Log("Signaling: WS managing thread ended");

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
@@ -51,8 +51,6 @@ namespace Unity.RenderStreaming.Signaling
             if (m_running)
             {
                 m_running = false;
-                m_webSocket?.Close();
-
                 if (m_signalingThread.ThreadState == ThreadState.WaitSleepJoin)
                 {
                     m_signalingThread.Abort();


### PR DESCRIPTION
It is too long time to dispose of the signaling instance because of waiting for the worker thread and the WebSocket instance.
