### PR TITLE
fix: unittest and negotiation process

### DIFF
--- a/WebApp/public/bidirectional/js/sendvideo.js
+++ b/WebApp/public/bidirectional/js/sendvideo.js
@@ -89,7 +89,7 @@ export class SendVideo {
       }
 
       const direction = trackEvent.transceiver.direction;
-      if (direction == "sendrecv" || direction == "sendonly") {
+      if (direction == "sendrecv" || direction == "recvonly") {
         _this.remoteVideo.srcObject = new MediaStream();
         _this.remoteVideo.srcObject.addTrack(trackEvent.track);
       }

--- a/WebApp/public/bidirectional/js/sendvideo.js
+++ b/WebApp/public/bidirectional/js/sendvideo.js
@@ -89,7 +89,7 @@ export class SendVideo {
       }
 
       const direction = trackEvent.transceiver.direction;
-      if (direction == "sendrecv" || direction == "recvonly") {
+      if (direction == "sendrecv" || direction == "sendonly") {
         _this.remoteVideo.srcObject = new MediaStream();
         _this.remoteVideo.srcObject.addTrack(trackEvent.track);
       }
@@ -130,7 +130,7 @@ export class SendVideo {
   async stop() {
     if (this.signaling) {
       await this.signaling.stop();
-      this.signaling = null;  
+      this.signaling = null;
     }
   }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/PeerConnection.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/PeerConnection.cs
@@ -12,7 +12,7 @@ namespace Unity.RenderStreaming
         public bool waitingAnswer;
         public bool ignoreOffer;
         public bool srdAnswerPending;
-        public bool sldGetBackStable;
+        public bool makingAnswer;
 
         public PeerConnection(RTCPeerConnection peer, bool polite)
         {

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -513,7 +513,7 @@ namespace Unity.RenderStreaming
             var isStable =
                 pc.peer.SignalingState == RTCSignalingState.Stable ||
                 (pc.peer.SignalingState == RTCSignalingState.HaveLocalOffer && pc.srdAnswerPending);
-            pc.ignoreOffer = description.type == RTCSdpType.Offer && !pc.polite && (pc.makingOffer || !isStable);
+            pc.ignoreOffer = !pc.polite && (pc.makingOffer || !isStable);
             if (pc.ignoreOffer || pc.makingAnswer)
             {
                 Debug.LogWarning($"{pc} glare - ignoreOffer {nameof(pc.peer.SignalingState)}:{pc.peer.SignalingState}");

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -208,7 +208,7 @@ namespace Unity.RenderStreaming
             if (!_mapConnectionIdAndPeer.TryGetValue(connectionId, out var peer))
                 return false;
 
-            if (peer.makingOffer || peer.srdAnswerPending || peer.waitingAnswer)
+            if (peer.makingOffer || peer.waitingAnswer)
             {
                 return false;
             }

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -472,6 +472,7 @@ namespace Unity.RenderStreaming
             Assert.AreEqual(pc.peer.RemoteDescription.type, RTCSdpType.Answer, $"{pc} Answer was set");
             Assert.AreEqual(pc.peer.SignalingState, RTCSignalingState.Stable, $"{pc} answered");
             pc.srdAnswerPending = false;
+            Debug.Log($"{pc} is negotiated in connectionId:{connectionId}");
 
             onGotAnswer?.Invoke(connectionId, sdp);
         }
@@ -515,7 +516,7 @@ namespace Unity.RenderStreaming
                 pc.peer.SignalingState == RTCSignalingState.Stable ||
                 (pc.peer.SignalingState == RTCSignalingState.HaveLocalOffer && pc.srdAnswerPending);
             pc.ignoreOffer =
-                description.type == RTCSdpType.Offer && !pc.polite && (pc.makingOffer || !isStable);
+                description.type == RTCSdpType.Offer && !pc.polite && (pc.makingOffer || pc.sldGetBackStable || !isStable);
             if (pc.ignoreOffer)
             {
                 Debug.Log($"{pc} glare - ignoring offer");

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -439,7 +439,7 @@ namespace Unity.RenderStreaming
         {
             if (!_mapConnectionIdAndPeer.TryGetValue(e.connectionId, out var pc))
             {
-                Debug.LogError($"connectionId:{e.connectionId}, peerConnection not exist");
+                Debug.LogWarning($"connectionId:{e.connectionId}, peerConnection not exist");
                 return;
             }
 

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -519,12 +519,14 @@ namespace Unity.RenderStreaming.RuntimeTest
             signaling2.OnOffer += (s, e) => { offerRaised2 = true; };
             signaling1.SendOffer(connectionId1, m_DescOffer);
             yield return new WaitUntil(() => offerRaised2);
+            yield return new WaitForSeconds(0.1f);
             Assert.That(offerRaised1, Is.False, () => "Receive own offer on private mode");
 
             signaling1.OnAnswer += (s, e) => { answerRaised1 = true; };
             signaling2.OnAnswer += (s, e) => { answerRaised2 = true; };
             signaling2.SendAnswer(connectionId1, m_DescAnswer);
             yield return new WaitUntil(() => answerRaised1);
+            yield return new WaitForSeconds(0.1f);
             Assert.That(answerRaised2, Is.False, () => "Receive own answer on private mode");
 
             signaling2.OnIceCandidate += (s, e) => { candidateRaised1 = true; };

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -518,18 +518,16 @@ namespace Unity.RenderStreaming.RuntimeTest
             signaling1.OnOffer += (s, e) => { offerRaised1 = true; };
             signaling2.OnOffer += (s, e) => { offerRaised2 = true; };
             signaling1.SendOffer(connectionId1, m_DescOffer);
-            yield return new WaitUntil(() => offerRaised1 || offerRaised2);
             // check each signaling invoke onOffer
-            yield return new WaitForSeconds(1);
+            yield return new WaitForSeconds(signaling1.Interval * 5);
             Assert.That(offerRaised1, Is.False, () => "Receive own offer on private mode");
             Assert.That(offerRaised2, Is.True);
 
             signaling1.OnAnswer += (s, e) => { answerRaised1 = true; };
             signaling2.OnAnswer += (s, e) => { answerRaised2 = true; };
             signaling2.SendAnswer(connectionId1, m_DescAnswer);
-            yield return new WaitUntil(() => answerRaised1 || answerRaised2);
             // check each signaling invoke onAnswer
-            yield return new WaitForSeconds(1);
+            yield return new WaitForSeconds(signaling2.Interval * 5);
             Assert.That(answerRaised1, Is.True);
             Assert.That(answerRaised2, Is.False, () => "Receive own answer on private mode");
 

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -518,15 +518,19 @@ namespace Unity.RenderStreaming.RuntimeTest
             signaling1.OnOffer += (s, e) => { offerRaised1 = true; };
             signaling2.OnOffer += (s, e) => { offerRaised2 = true; };
             signaling1.SendOffer(connectionId1, m_DescOffer);
-            yield return new WaitUntil(() => offerRaised2);
-            yield return new WaitForSeconds(0.1f);
+            yield return new WaitUntil(() => offerRaised1 || offerRaised2);
+            // check each signaling invoke onOffer
+            yield return new WaitForSeconds(1);
             Assert.That(offerRaised1, Is.False, () => "Receive own offer on private mode");
+            Assert.That(offerRaised2, Is.True);
 
             signaling1.OnAnswer += (s, e) => { answerRaised1 = true; };
             signaling2.OnAnswer += (s, e) => { answerRaised2 = true; };
             signaling2.SendAnswer(connectionId1, m_DescAnswer);
-            yield return new WaitUntil(() => answerRaised1);
-            yield return new WaitForSeconds(0.1f);
+            yield return new WaitUntil(() => answerRaised1 || answerRaised2);
+            // check each signaling invoke onAnswer
+            yield return new WaitForSeconds(1);
+            Assert.That(answerRaised1, Is.True);
             Assert.That(answerRaised2, Is.False, () => "Receive own answer on private mode");
 
             signaling2.OnIceCandidate += (s, e) => { candidateRaised1 = true; };

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -627,9 +627,8 @@ namespace Unity.RenderStreaming.RuntimeTest
             target1.AddTrack(connectionId, TrackKind.Audio);
             target2.AddTrack(connectionId, TrackKind.Audio);
 
-            yield return new WaitUntil(() => isGotOffer1 || isGotOffer2);
             // check each target invoke onGotOffer
-            yield return new WaitForSeconds(0.1f);
+            yield return new WaitForSeconds(ResendOfferInterval * 5);
 
             // ignore offer because impolite peer
             Assert.That(isGotOffer1, Is.False, $"{nameof(isGotOffer1)} is not False.");

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -652,5 +652,65 @@ namespace Unity.RenderStreaming.RuntimeTest
             target1.Dispose();
             target2.Dispose();
         }
+
+        [TestCase(TestMode.PublicMode, ExpectedResult = null)]
+        [TestCase(TestMode.PrivateMode, ExpectedResult = null)]
+        [UnityTest, Timeout(10000)]
+        public IEnumerator ResendOfferUntilGotAnswer(TestMode mode)
+        {
+            MockSignaling.Reset(mode == TestMode.PrivateMode);
+
+            var dependencies1 = CreateDependencies();
+            var dependencies2 = CreateDependencies();
+            var target1 = new RenderStreamingInternal(ref dependencies1);
+            var target2 = new RenderStreamingInternal(ref dependencies2);
+
+            bool isStarted1 = false;
+            bool isStarted2 = false;
+            target1.onStart += () => { isStarted1 = true; };
+            target2.onStart += () => { isStarted2 = true; };
+            yield return new WaitUntil(() => isStarted1 && isStarted2);
+
+            bool isCreatedConnection1 = false;
+            bool isCreatedConnection2 = false;
+            target1.onCreatedConnection += _ => { isCreatedConnection1 = true; };
+            target2.onCreatedConnection += _ => { isCreatedConnection2 = true; };
+
+            var connectionId = "12345";
+
+            target1.CreateConnection(connectionId);
+            yield return new WaitUntil(() => isCreatedConnection1);
+            target2.CreateConnection(connectionId);
+            yield return new WaitUntil(() => isCreatedConnection2);
+
+            int countGotOffer2 = 0;
+            target2.onGotOffer += (_, sdp) => { countGotOffer2++; };
+            target1.SendOffer(connectionId);
+            yield return new WaitUntil(() => countGotOffer2 > 1);
+
+            bool isGotAnswer1 = false;
+            target1.onGotAnswer += (_, sdp) => { isGotAnswer1 = true; };
+            target2.SendAnswer(connectionId);
+            yield return new WaitUntil(() => isGotAnswer1);
+
+            yield return new WaitForSeconds(0.2f);
+            var currentCount = countGotOffer2;
+            yield return new WaitForSeconds(0.2f);
+            Assert.That(countGotOffer2, Is.EqualTo(currentCount), $"{nameof(currentCount)} is not Equal {nameof(countGotOffer2)}");
+
+            target1.DeleteConnection(connectionId);
+            target2.DeleteConnection(connectionId);
+
+            bool isDeletedConnection1 = false;
+            bool isDeletedConnection2 = false;
+            target1.onDeletedConnection += _ => { isDeletedConnection1 = true; };
+            target2.onDeletedConnection += _ => { isDeletedConnection2 = true; };
+            yield return new WaitUntil(() => isDeletedConnection1 && isDeletedConnection2);
+            Assert.That(isDeletedConnection1, Is.True, $"{nameof(isDeletedConnection1)} is not True.");
+            Assert.That(isDeletedConnection2, Is.True, $"{nameof(isDeletedConnection1)} is not True.");
+
+            target1.Dispose();
+            target2.Dispose();
+        }
     }
 }

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -39,6 +39,9 @@ namespace Unity.RenderStreaming.RuntimeTest
             UnityEngine.Object.Destroy(test.gameObject);
         }
 
+        // workaround: More time for SetDescription process
+        const float ResendOfferInterval = 1.0f;
+
         private RenderStreamingDependencies CreateDependencies()
         {
             return new RenderStreamingDependencies
@@ -50,7 +53,7 @@ namespace Unity.RenderStreaming.RuntimeTest
                 },
                 encoderType = EncoderType.Software,
                 startCoroutine = test.component.StartCoroutine,
-                resentOfferInterval = 1.0f,
+                resentOfferInterval = ResendOfferInterval,
             };
         }
 
@@ -693,9 +696,9 @@ namespace Unity.RenderStreaming.RuntimeTest
             target2.SendAnswer(connectionId);
             yield return new WaitUntil(() => isGotAnswer1);
 
-            yield return new WaitForSeconds(0.2f);
+            yield return new WaitForSeconds(ResendOfferInterval * 2);
             var currentCount = countGotOffer2;
-            yield return new WaitForSeconds(0.2f);
+            yield return new WaitForSeconds(ResendOfferInterval * 2);
             Assert.That(countGotOffer2, Is.EqualTo(currentCount), $"{nameof(currentCount)} is not Equal {nameof(countGotOffer2)}");
 
             target1.DeleteConnection(connectionId);

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -517,7 +517,6 @@ namespace Unity.RenderStreaming.RuntimeTest
             target2.Dispose();
         }
 
-        [Ignore("not stable")]
         [UnityTest, Timeout(10000)]
         public IEnumerator SendOfferThrowExceptionPrivateMode()
         {
@@ -563,11 +562,10 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(() => target1.SendOffer(connectionId), Throws.TypeOf<InvalidOperationException>());
 
             target1.SendAnswer(connectionId);
-
             yield return new WaitUntil(() => isGotAnswer2);
             Assert.That(isGotAnswer2, Is.True);
 
-            Assert.That(target1.IsStable(connectionId), Is.True);
+            // If target1 processes resent　Offer from target2, target1 is not stable.
             Assert.That(target2.IsStable(connectionId), Is.True);
 
             target1.DeleteConnection(connectionId);
@@ -586,7 +584,6 @@ namespace Unity.RenderStreaming.RuntimeTest
         }
 
         [UnityTest, Timeout(10000)]
-        [Ignore("not stable")]
         public IEnumerator SwapTransceiverPrivateMode()
         {
             MockSignaling.Reset(true);
@@ -628,6 +625,8 @@ namespace Unity.RenderStreaming.RuntimeTest
             target2.AddTrack(connectionId, TrackKind.Audio);
 
             yield return new WaitUntil(() => isGotOffer1 || isGotOffer2);
+            // check each target invoke onGotOffer
+            yield return new WaitForSeconds(0.1f);
 
             // ignore offer because impolite peer
             Assert.That(isGotOffer1, Is.False, $"{nameof(isGotOffer1)} is not False.");

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
@@ -162,7 +162,7 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
                 }
 
                 data.polite = true;
-                foreach (var signaling in list)
+                foreach (var signaling in list.Where(x => x != owner))
                 {
                     signaling.OnOffer?.Invoke(signaling, data);
                 }
@@ -178,7 +178,7 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
                     return;
                 }
 
-                foreach (var signaling in list)
+                foreach (var signaling in list.Where(x => x != owner))
                 {
                     signaling.OnAnswer?.Invoke(signaling, data);
                 }

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
@@ -217,7 +217,7 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
 
         public string Url { get { return string.Empty; } }
 
-        public float Interval { get { return 0; } }
+        public float Interval { get { return 0.1f; } }
 
         static MockSignaling()
         {


### PR DESCRIPTION
- rename `sldGetBackStable` to `maikingAnswer`
- keep only one process about `setLocalDescription` and `setRemoteDescription`
- ignore offer if `makingAnswer` is true, because that's offer is already receiving.