### PR TITLE
fix: Fixed errors when disposing the scene while streaming video

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputRemoting.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputRemoting.cs
@@ -518,6 +518,7 @@ namespace Unity.RenderStreaming
                 public string name;
                 public string layout;
                 public int deviceId;
+                public string variants;
                 public InputDeviceDescription description;
             }
 
@@ -530,6 +531,7 @@ namespace Unity.RenderStreaming
                     name = device.name,
                     layout = device.layout,
                     deviceId = device.deviceId,
+                    variants = device.variants,
                     description = device.description
                 };
 
@@ -568,7 +570,7 @@ namespace Unity.RenderStreaming
                 try
                 {
                     ////REVIEW: this gives remote devices names the same way that local devices receive them; should we make remote status visible in the name?
-                    device = Receiver.m_LocalManager.AddDevice(data.layout);
+                    device = Receiver.m_LocalManager.AddDevice(data.layout, data.name, data.variants);
 
                     // todo(kazuki)::Avoid to use reflection
                     // device.m_ParticipantId = msg.participantId;

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Receiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Receiver.cs
@@ -14,7 +14,7 @@ namespace Unity.RenderStreaming
     /// <summary>
     ///
     /// </summary>
-    class Receiver : InputManager
+    class Receiver : InputManager, IDisposable
     {
         public override event Action<InputRemoting.Message> onMessage;
         public new event Action<InputDevice, InputDeviceChange> onDeviceChange;
@@ -34,6 +34,11 @@ namespace Unity.RenderStreaming
         }
 
         ~Receiver()
+        {
+            this.Dispose();
+        }
+
+        public void Dispose()
         {
             RemoveAllDevices();
         }

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Sender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Sender.cs
@@ -12,7 +12,7 @@ using UnityEngine.InputSystem.Utilities;
 // namespace Unity.WebRTC.InputSystem
 namespace Unity.RenderStreaming
 {
-    class Sender : InputManager
+    class Sender : InputManager, IDisposable
     {
         public override event Action<InputEventPtr, InputDevice> onEvent;
         public override event Action<InputDevice, InputDeviceChange> onDeviceChange;
@@ -26,6 +26,11 @@ namespace Unity.RenderStreaming
         }
 
         ~Sender()
+        {
+            this.Dispose();
+        }
+
+        public void Dispose()
         {
             InputSystem.onEvent -= OnEvent;
             InputSystem.onDeviceChange -= OnDeviceChange;

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystemChannelReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystemChannelReceiver.cs
@@ -4,6 +4,9 @@ using UnityEngine.InputSystem;
 
 namespace Unity.RenderStreaming
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class InputSystemChannelReceiver : InputChannelReceiverBase
     {
         /// <summary>
@@ -13,7 +16,7 @@ namespace Unity.RenderStreaming
 
         private Receiver receiver;
         private InputRemoting receiverInput;
-        private IDisposable receiverDisposer;
+        private IDisposable subscriberDisposer;
 
         /// <summary>
         ///
@@ -23,26 +26,33 @@ namespace Unity.RenderStreaming
         {
             if (channel == null)
             {
-                receiverInput?.StopSending();
-                receiverDisposer?.Dispose();
-                receiver?.RemoveAllDevices();
-                receiver = null;
+                Dispose();
             }
             else
             {
                 receiver = new Receiver(channel);
                 receiver.onDeviceChange += onDeviceChange;
                 receiverInput = new InputRemoting(receiver);
-                receiverDisposer = receiverInput.Subscribe(receiverInput);
+                subscriberDisposer = receiverInput.Subscribe(receiverInput);
                 receiverInput.StartSending();
             }
             base.SetChannel(connectionId, channel);
         }
 
-        public void OnDestroy()
+        /// <summary>
+        /// 
+        /// </summary>
+        protected virtual void OnDestroy()
+        {
+            Dispose();
+        }
+
+        protected void Dispose()
         {
             receiverInput?.StopSending();
-            receiverDisposer?.Dispose();
+            subscriberDisposer?.Dispose();
+            receiver?.Dispose();
+            receiver = null;
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystemChannelSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystemChannelSender.cs
@@ -3,11 +3,14 @@ using Unity.WebRTC;
 
 namespace Unity.RenderStreaming
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class InputSystemChannelSender : DataChannelBase
     {
         private Sender sender;
         private InputRemoting senderInput;
-        private IDisposable senderDisposer;
+        private IDisposable suscriberDisposer;
 
         /// <summary>
         ///
@@ -17,23 +20,17 @@ namespace Unity.RenderStreaming
         {
             if (channel == null)
             {
-                senderInput?.StopSending();
-                senderDisposer?.Dispose();
-                sender = null;
-                return;
+                Dispose();
             }
-            sender = new Sender();
-            senderInput = new InputRemoting(sender);
-            senderDisposer = senderInput.Subscribe(new Observer(channel));
-            channel.OnOpen += OnOpen;
-            channel.OnClose += OnClose;
+            else
+            {
+                sender = new Sender();
+                senderInput = new InputRemoting(sender);
+                suscriberDisposer = senderInput.Subscribe(new Observer(channel));
+                channel.OnOpen += OnOpen;
+                channel.OnClose += OnClose;
+            }
             base.SetChannel(connectionId, channel);
-        }
-
-        public void OnDestroy()
-        {
-            senderInput?.StopSending();
-            senderDisposer?.Dispose();
         }
 
         void OnOpen()
@@ -45,5 +42,17 @@ namespace Unity.RenderStreaming
             senderInput.StopSending();
         }
 
+        protected virtual void OnDestroy()
+        {
+            this.Dispose();
+        }
+
+        protected void Dispose()
+        {
+            senderInput?.StopSending();
+            suscriberDisposer?.Dispose();
+            sender?.Dispose();
+            sender = null;
+        }
     }
 }


### PR DESCRIPTION
When transferring between scenes while streaming video, the error occurs below.
The issue is caused by remaining resources when ending the scene.

```
Assertion failed on expression: 'gCurrentManagedTempMem != NULL' UnityEngine.StackTraceUtility:ExtractStackTrace () 
Unity.Collections.NativeArray`1<ulong>:Allocate (int,Unity.Collections.Allocator,Unity.Collections.NativeArray`1<ulong>&) (at /Users/bokken/buildslave/unity/build/Runtime/Export/NativeArray/NativeArray.cs:87) 
Unity.Collections.NativeArray`1<ulong>:.ctor (int,Unity.Collections.Allocator,Unity.Collections.NativeArrayOptions) (at /Users/bokken/buildslave/unity/build/Runtime/Export/NativeArray/NativeArray.cs:44) 
UnityEngine.InputSystem.InputSystem:RemoveDevice (UnityEngine.InputSystem.InputDevice) 
Unity.RenderStreaming.InputManager:RemoveDevice (UnityEngine.InputSystem.InputDevice) (at Packages/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs:132) 
Unity.RenderStreaming.Receiver:RemoveDevice (UnityEngine.InputSystem.InputDevice) (at Packages/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Receiver.cs:104) 
Unity.RenderStreaming.Receiver:RemoveAllDevices () (at Packages/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Receiver.cs:90) Unity.RenderStreaming.Receiver:Finalize () (at Packages/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Receiver.cs:38)
```