### PR TITLE
Fix: fix bidirectional sample

### DIFF
--- a/WebApp/public/bidirectional/js/peer.js
+++ b/WebApp/public/bidirectional/js/peer.js
@@ -80,6 +80,14 @@ export default class Peer extends EventTarget {
     this.pc = null;
   }
 
+  addTrack(connectionId, track) {
+    if (this.connectionId != connectionId) {
+      return;
+    }
+
+    this.pc.addTrack(track);
+  }
+
   addTransceiver(connectionId, trackOrKind, init) {
     if (this.connectionId != connectionId) {
       return;

--- a/WebApp/public/bidirectional/js/sendvideo.js
+++ b/WebApp/public/bidirectional/js/sendvideo.js
@@ -110,7 +110,8 @@ export class SendVideo {
 
   addTracks(connectionId) {
     const _this = this;
-    _this.localVideo.srcObject.getTracks().forEach(track => _this.pc.addTransceiver(connectionId, track));
+    const track = _this.localVideo.srcObject.getTracks().find(x => x.kind == 'video');
+    _this.pc.addTrack(connectionId, track);
   }
 
   async hangUp(connectionId) {

--- a/com.unity.renderstreaming/Runtime/Scripts/IRenderStreamingHandler.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/IRenderStreamingHandler.cs
@@ -117,9 +117,19 @@ namespace Unity.RenderStreaming
         ///
         /// </summary>
         /// <param name="connectionId"></param>
-        /// <param name="kind"></param>
+        /// <param name="track"></param>
+        /// <param name="direction"></param>
         /// <returns></returns>
-        RTCRtpTransceiver AddTrack(string connectionId, TrackKind kind);
+        RTCRtpTransceiver AddTransceiver(string connectionId, MediaStreamTrack track, RTCRtpTransceiverDirection direction);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="connectionId"></param>
+        /// <param name="kind"></param>
+        /// <param name="direction"></param>
+        /// <returns></returns>
+        RTCRtpTransceiver AddTransceiver(string connectionId, TrackKind kind, RTCRtpTransceiverDirection direction);
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -238,13 +238,29 @@ namespace Unity.RenderStreaming
         ///
         /// </summary>
         /// <param name="connectionId"></param>
-        /// <param name="kind"></param>
+        /// <param name="track"></param>
+        /// <param name="direction"></param>
         /// <returns></returns>
-        public RTCRtpTransceiver AddTrack(string connectionId, TrackKind kind)
+        public RTCRtpTransceiver AddTransceiver(string connectionId, MediaStreamTrack track, RTCRtpTransceiverDirection direction)
         {
-            return _mapConnectionIdAndPeer[connectionId].peer.AddTransceiver(kind);
+            var transceiver = _mapConnectionIdAndPeer[connectionId].peer.AddTransceiver(track);
+            transceiver.Direction = direction;
+            return transceiver;
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="connectionId"></param>
+        /// <param name="kind"></param>
+        /// <param name="direction"></param>
+        /// <returns></returns>
+        public RTCRtpTransceiver AddTransceiver(string connectionId, TrackKind kind, RTCRtpTransceiverDirection direction)
+        {
+            var transceiver = _mapConnectionIdAndPeer[connectionId].peer.AddTransceiver(kind);
+            transceiver.Direction = direction;
+            return transceiver;
+        }
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -80,9 +80,14 @@ namespace Unity.RenderStreaming
             return m_handler.AddTrack(connectionId, track);
         }
 
-        public virtual RTCRtpTransceiver AddTrack(string connectionId, TrackKind kind)
+        public virtual RTCRtpTransceiver AddTransceiver(string connectionId, MediaStreamTrack track, RTCRtpTransceiverDirection direction = RTCRtpTransceiverDirection.SendRecv)
         {
-            return m_handler.AddTrack(connectionId, kind);
+            return m_handler.AddTransceiver(connectionId, track, direction);
+        }
+
+        public virtual RTCRtpTransceiver AddTransceiver(string connectionId, TrackKind kind, RTCRtpTransceiverDirection direction = RTCRtpTransceiverDirection.SendRecv)
+        {
+            return m_handler.AddTransceiver(connectionId, kind, direction);
         }
 
         /// <summary>
@@ -174,7 +179,7 @@ namespace Unity.RenderStreaming
         TrackKind Kind { get; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="track"></param>
         void SetReceiver(string connectionId, RTCRtpReceiver sender);

--- a/com.unity.renderstreaming/Runtime/Scripts/SingleConnection.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SingleConnection.cs
@@ -58,12 +58,12 @@ namespace Unity.RenderStreaming
 
             foreach (var source in streams.OfType<IStreamSource>())
             {
-                var transceiver = AddTrack(connectionId, source.Track);
+                var transceiver = AddTransceiver(connectionId, source.Track, RTCRtpTransceiverDirection.SendOnly);
                 source.SetSender(connectionId, transceiver.Sender);
             }
             foreach (var receiver in streams.OfType<IStreamReceiver>())
             {
-                AddTransceiver(data.connectionId, receiver.Kind);
+                AddTransceiver(data.connectionId, receiver.Kind, RTCRtpTransceiverDirection.RecvOnly);
             }
             foreach (var channel in streams.OfType<IDataChannel>().Where(c => c.IsLocal))
             {

--- a/com.unity.renderstreaming/Runtime/Scripts/SingleConnection.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SingleConnection.cs
@@ -63,7 +63,7 @@ namespace Unity.RenderStreaming
             }
             foreach (var receiver in streams.OfType<IStreamReceiver>())
             {
-                AddTrack(data.connectionId, receiver.Kind);
+                AddTransceiver(data.connectionId, receiver.Kind);
             }
             foreach (var channel in streams.OfType<IDataChannel>().Where(c => c.IsLocal))
             {

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -421,8 +421,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             yield return new WaitUntil(() => isCreatedConnection1);
             Assert.That(isCreatedConnection1, Is.True);
 
-            var transceiver = target1.AddTrack(connectionId, TrackKind.Video);
-            transceiver.Direction = RTCRtpTransceiverDirection.RecvOnly;
+            target1.AddTransceiver(connectionId, TrackKind.Video, RTCRtpTransceiverDirection.RecvOnly);
 
             // target2 is sender in private mode
             yield return new WaitUntil(() => isOnGotOffer2);
@@ -628,8 +627,8 @@ namespace Unity.RenderStreaming.RuntimeTest
             target2.onGotOffer += (_, sdp) => { isGotOffer2 = true; };
             target1.onGotAnswer += (_, sdp) => { isGotAnswer1 = true; };
 
-            target1.AddTrack(connectionId, TrackKind.Audio);
-            target2.AddTrack(connectionId, TrackKind.Audio);
+            target1.AddTransceiver(connectionId, TrackKind.Audio, RTCRtpTransceiverDirection.SendRecv);
+            target2.AddTransceiver(connectionId, TrackKind.Audio, RTCRtpTransceiverDirection.SendRecv);
 
             // check each target invoke onGotOffer
             yield return new WaitForSeconds(ResendOfferInterval * 5);


### PR DESCRIPTION
- working bidirectional sample on web browser and unity
- add `AddTransceiver(MediaStreamTrack)`  method on RenderStreamingInternal
- change argument that add `RTCRtpTransceiverDirection` about `AddTransceiver` method 
- use `addTrack` method on webclient (before use `addTranceiver` method)
- use `AddTransceiver` method on `SingleConnection` class.

I think we should use `AddTransceiver` if we have decided on the transceiver we need.
We should use `AddTrack` when transceiver is changing dynamically. 