### PR TITLE
fix: Fix AudioStreamer bug

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamer.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamer.cs
@@ -30,7 +30,13 @@ namespace Unity.RenderStreaming
         protected virtual void Awake()
         {
             if(audioSource != null && audioSource.clip != null)
+            {
                 _sampleRate = audioSource.clip.samples;
+            }
+            else
+            {
+                _sampleRate = AudioSettings.outputSampleRate;
+            }
         }
 
         protected override MediaStreamTrack CreateTrack()


### PR DESCRIPTION
`AudioStreamer` component uses `OnAudioFilterRead` method to get audio buffers and `sampleRate` parameter is needed to stream buffers. 

`sampleRate` is determined by the `AudioClip` but `AudioClip` doesn't exist when using `AuidoListener`. 