### PR TITLE
feat: Better ISignaling listing + improvment + doc

### DIFF
--- a/com.unity.renderstreaming/Editor/RenderStreamingEditor.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingEditor.cs
@@ -51,15 +51,14 @@ namespace Unity.RenderStreaming.Editor
 
         static void ShowSignalingTypes(SerializedProperty signalingType){
 
-            System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
             List<string> options = new List<string>();
             List<string> types = new List<string>();
 
             int selected = 0;
             int i = 0;
 
-            foreach (var referencedAssembly in assembly.GetReferencedAssemblies()) {
-                foreach (System.Type type in System.Reflection.Assembly.Load(referencedAssembly).GetTypes()) {
+            foreach (var assembly in System.AppDomain.CurrentDomain.GetAssemblies()){
+                foreach (System.Type type in assembly.GetTypes()) {
                     if (type.IsVisible && type.IsClass && typeof(ISignaling).IsAssignableFrom(type)) {
                         if(type.FullName == signalingType.stringValue){
                             selected = i;


### PR DESCRIPTION
Fixed the conflict between the PR and the develop branch.
https://github.com/Unity-Technologies/UnityRenderStreaming/pull/537

- Added the ability to list ISignaling child classes in the whole project (this will be important for next version of Furioos connection)
- Included the UUID function to avoid external js import
- Added "Renderstreaming on Furioos" tutorial in documentation