### PR TITLE
fix: Remove warning CS0168

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
@@ -138,7 +138,7 @@ namespace Unity.RenderStreaming.Signaling
                 {
                     Thread.Sleep((int)(m_timeout * 1000));
                 }
-                catch (ThreadAbortException e)
+                catch (ThreadAbortException)
                 {
                     // Thread.Abort() called from main thread. Ignore
                     return;
@@ -157,7 +157,7 @@ namespace Unity.RenderStreaming.Signaling
 
                     Thread.Sleep((int)(m_timeout * 1000));
                 }
-                catch (ThreadAbortException e)
+                catch (ThreadAbortException)
                 {
                     // Thread.Abort() called from main thread. Ignore
                     return;
@@ -188,7 +188,7 @@ namespace Unity.RenderStreaming.Signaling
                     response.Close();
                 }
             }
-            catch (ThreadAbortException e)
+            catch (ThreadAbortException)
             {
                 // Thread.Abort() called from main thread. Ignore
             }

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
@@ -141,7 +141,7 @@ namespace Unity.RenderStreaming.Signaling
 
                     Thread.Sleep((int)(m_timeout * 1000));
                 }
-                catch (ThreadAbortException e)
+                catch (ThreadAbortException)
                 {
                     // Thread.Abort() called from main thread. Ignore
                     return;


### PR DESCRIPTION
Remove these warning logs.
```
warning CS0168: The variable 'e' is declared but never used
```