### PR TITLE
fix: Remove warning CS0168

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamer.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamer.cs
@@ -59,7 +59,7 @@ namespace Unity.RenderStreaming
                 if (track != null)
                     track.Enabled = false;
             }
-            catch (InvalidOperationException e)
+            catch (InvalidOperationException)
             {
                 track = null;
             }
@@ -71,7 +71,7 @@ namespace Unity.RenderStreaming
             {
                 track?.SetData(data, channels, _sampleRate);
             }
-            catch (InvalidOperationException e)
+            catch (InvalidOperationException)
             {
                 track = null;
             }


### PR DESCRIPTION
Previous PR for same purpose https://github.com/Unity-Technologies/UnityRenderStreaming/pull/565

Remove these warning logs.
```
warning CS0168: The variable 'e' is declared but never used
```