### PR TITLE
fix: Fixed ScreenStreamSender inspector UI

### DIFF
--- a/com.unity.renderstreaming/Editor/CameraStreamSenderEditor.cs
+++ b/com.unity.renderstreaming/Editor/CameraStreamSenderEditor.cs
@@ -1,48 +1,17 @@
+#if UNITY_EDITOR
 using UnityEditor;
-using UnityEngine;
 
 namespace Unity.RenderStreaming.Editor
 {
     [CustomEditor(typeof(CameraStreamSender))]
     public class CameraStreamSenderEditor : UnityEditor.Editor
     {
-        readonly GUIContent[] renderTextureAntiAliasing = new GUIContent[4]
-        {
-            EditorGUIUtility.TrTextContent("None"),
-            EditorGUIUtility.TrTextContent("2 samples"),
-            EditorGUIUtility.TrTextContent("4 samples"),
-            EditorGUIUtility.TrTextContent("8 samples")
-        };
-
-        readonly int[] renderTextureAntiAliasingValues = new int[4] {1, 2, 4, 8};
-
-        readonly GUIContent antiAliasing =
-            EditorGUIUtility.TrTextContent("Anti-aliasing", "Number of anti-aliasing samples.");
-
-        readonly GUIContent[] renderTextureDepthBuffer = new GUIContent[3]
-        {
-            EditorGUIUtility.TrTextContent("No depth buffer"),
-            EditorGUIUtility.TrTextContent("At least 16 bits depth (no stencil)"),
-            EditorGUIUtility.TrTextContent("At least 24 bits depth (with stencil)")
-        };
-
-        readonly int[] renderTextureDepthBufferValues = new int[3] {0, 16, 24};
-
-        readonly GUIContent depthBuffer = EditorGUIUtility.TrTextContent("Depth Buffer", "Format of the depth buffer.");
-
         public override void OnInspectorGUI()
         {
-            serializedObject.Update();
-
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("streamingSize"));
-            var antiAliasingProperty = serializedObject.FindProperty("antiAliasing");
-            EditorGUILayout.IntPopup(antiAliasingProperty, renderTextureAntiAliasing, renderTextureAntiAliasingValues, antiAliasing);
-            var depthBufferProperty = serializedObject.FindProperty("depth");
-            EditorGUILayout.IntPopup(depthBufferProperty, renderTextureDepthBuffer, renderTextureDepthBufferValues, depthBuffer);
-
-            serializedObject.ApplyModifiedProperties();
+            base.OnInspectorGUI();
 
             EditorGUILayout.HelpBox("If TargetTexture is attached on Camera, use that RenderTexture setting first.", MessageType.Info);
         }
     }
 }
+#endif

--- a/com.unity.renderstreaming/Editor/PropertyDrawers.meta
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4589c32b4d61d9c4bb30434f8b970aa1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/RenderTextureDepthBufferDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/RenderTextureDepthBufferDrawer.cs
@@ -1,0 +1,28 @@
+#if UNITY_EDITOR
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.IMGUI.Controls;
+
+namespace Unity.RenderStreaming.Editor
+{
+    [CustomPropertyDrawer(typeof(RenderTextureDepthBufferAttribute))]
+    public class RenderTextureDepthBufferDrawer : PropertyDrawer
+    {
+        readonly GUIContent[] renderTextureDepthBuffer = new GUIContent[3]
+        {
+            EditorGUIUtility.TrTextContent("No depth buffer"),
+            EditorGUIUtility.TrTextContent("At least 16 bits depth (no stencil)"),
+            EditorGUIUtility.TrTextContent("At least 24 bits depth (with stencil)")
+        };
+
+        readonly int[] renderTextureDepthBufferValues = new int[3] { 0, 16, 24 };
+
+        readonly GUIContent depthBuffer = EditorGUIUtility.TrTextContent("Depth Buffer", "Format of the depth buffer.");
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.IntPopup(position, property, renderTextureDepthBuffer, renderTextureDepthBufferValues, depthBuffer);
+        }
+    }
+}
+#endif

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/RenderTextureDepthBufferDrawer.cs.meta
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/RenderTextureDepthBufferDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b77038fafaaade4f9519bc72ec35511
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/RenderTexureAntiAliasingDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/RenderTexureAntiAliasingDrawer.cs
@@ -1,0 +1,30 @@
+#if UNITY_EDITOR
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.IMGUI.Controls;
+
+namespace Unity.RenderStreaming.Editor
+{
+    [CustomPropertyDrawer(typeof(RenderTextureAntiAliasingAttribute))]
+    public class RenderTexureAntiAliasingDrawer : PropertyDrawer
+    {
+        readonly GUIContent[] renderTextureAntiAliasing = new GUIContent[4]
+        {
+            EditorGUIUtility.TrTextContent("None"),
+            EditorGUIUtility.TrTextContent("2 samples"),
+            EditorGUIUtility.TrTextContent("4 samples"),
+            EditorGUIUtility.TrTextContent("8 samples")
+        };
+
+        readonly int[] renderTextureAntiAliasingValues = new int[4] { 1, 2, 4, 8 };
+
+        readonly GUIContent antiAliasing =
+            EditorGUIUtility.TrTextContent("Anti-aliasing", "Number of anti-aliasing samples.");
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.IntPopup(position, property, renderTextureAntiAliasing, renderTextureAntiAliasingValues, antiAliasing);
+        }
+    }
+}
+#endif

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/RenderTexureAntiAliasingDrawer.cs.meta
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/RenderTexureAntiAliasingDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea5dce5112c6d20449435a7e261939a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Runtime/Scripts/CameraStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/CameraStreamSender.cs
@@ -4,15 +4,30 @@ using UnityEngine.Experimental.Rendering;
 
 namespace Unity.RenderStreaming
 {
+    /// <summary>
+    /// 
+    /// </summary>
     [RequireComponent(typeof(Camera))]
     public class CameraStreamSender : VideoStreamSender
     {
-        [SerializeField] private int depth = 0;
-        [SerializeField] private int antiAliasing = 1;
+        /// <summary>
+        /// 
+        /// </summary>
+        [SerializeField, RenderTextureDepthBuffer]
+        private int depth = 0;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        [SerializeField, RenderTextureAntiAliasing]
+        private int antiAliasing = 1;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public override Texture SendTexture => m_camera.targetTexture;
 
         private Camera m_camera;
-        public override Texture SendTexture => m_camera.targetTexture;
 
         protected virtual void Awake()
         {

--- a/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
@@ -5,10 +5,22 @@ using UnityEngine.Experimental.Rendering;
 
 namespace Unity.RenderStreaming
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class ScreenStreamSender : VideoStreamSender
     {
-        [SerializeField] private int depth = 0;
-        [SerializeField] private int antiAliasing = 1;
+        /// <summary>
+        /// 
+        /// </summary>
+        [SerializeField, RenderTextureDepthBuffer]
+        private int depth = 0;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [SerializeField, RenderTextureAntiAliasing]
+        private int antiAliasing = 1;
 
         public override Texture SendTexture => m_sendTexture;
         private RenderTexture m_sendTexture;

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -6,6 +6,16 @@ namespace Unity.RenderStreaming
     /// <summary>
     /// 
     /// </summary>
+    public sealed class RenderTextureAntiAliasingAttribute : PropertyAttribute {}
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed class RenderTextureDepthBufferAttribute : PropertyAttribute { }
+
+    /// <summary>
+    /// 
+    /// </summary>
     public abstract class VideoStreamSender : StreamSenderBase
     {
         /// <summary>


### PR DESCRIPTION
Added `PropertyDrawer` for `RenderTextureAntiAliacing` and `RenderTextureDepthBuffer`.

![image](https://user-images.githubusercontent.com/1132081/140857797-e96ad086-46e3-4afc-b399-9e576806032b.png)
