### PR TITLE
Chore : fix compile error on unity2019

### DIFF
--- a/com.unity.renderstreaming/Samples~/Example/Multiplay/MultiplaySample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Multiplay/MultiplaySample.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
 using Unity.RenderStreaming.InputSystem;
@@ -43,7 +45,8 @@ namespace Unity.RenderStreaming.Samples
         void OnClickButtonStart()
         {
             var toggles = toggleGroupRole.GetComponentsInChildren<Toggle>();
-            var toggle = toggleGroupRole.GetFirstActiveToggle();
+            var activeToggles = toggleGroupRole.ActiveToggles();
+            var toggle = activeToggles.Any() ? activeToggles.First() : null;
             var indexRole = Array.FindIndex(toggles, _ => _ == toggle);
             Role role = (Role)indexRole;
 


### PR DESCRIPTION
Error occur only on Unity 2019.

This implementation is same as `GetFirstActiveToggle` method on Unity 2020 