### PR TITLE
fix: Fix resource leak of sender track 

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -38,6 +38,18 @@ namespace Unity.RenderStreaming
             {
                 _sampleRate = AudioSettings.outputSampleRate;
             }
+
+            OnStartedStream += _OnStartedStream;
+            OnStoppedStream += _OnStoppedStream;
+        }
+
+        void _OnStartedStream(string connectionId)
+        {
+        }
+
+        void _OnStoppedStream(string connectionId)
+        {
+            track = null;
         }
 
         protected override MediaStreamTrack CreateTrack()

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -449,14 +449,16 @@ namespace Unity.RenderStreaming
         IEnumerator OnNegotiationNeeded(string connectionId)
         {
             yield return new WaitWhile(() => !IsStable(connectionId));
-            if(ExistConnection(connectionId))
-                SendOffer(connectionId);
+            SendOffer(connectionId);
         }
 
         IEnumerator SendOfferCoroutine(string connectionId, PeerConnection pc)
         {
             // waiting other setLocalDescription process
             yield return new WaitWhile(() => !IsStable(connectionId));
+
+            if (!ExistConnection(connectionId))
+                yield break;
 
             Assert.AreEqual(pc.peer.SignalingState, RTCSignalingState.Stable,
                 $"{pc} negotiationneeded always fires in stable state");

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -326,7 +326,8 @@ namespace Unity.RenderStreaming
         /// <param name="connectionId"></param>
         public void SendOffer(string connectionId)
         {
-            var pc = _mapConnectionIdAndPeer[connectionId];
+            if (!_mapConnectionIdAndPeer.TryGetValue(connectionId, out var pc))
+                return;
             if (!IsStable(connectionId))
             {
                 if (!pc.waitingAnswer)
@@ -338,7 +339,6 @@ namespace Unity.RenderStreaming
                 _signaling.SendOffer(connectionId, pc.peer.LocalDescription);
                 return;
             }
-
             _startCoroutine(SendOfferCoroutine(connectionId, pc));
         }
 

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -449,7 +449,8 @@ namespace Unity.RenderStreaming
         IEnumerator OnNegotiationNeeded(string connectionId)
         {
             yield return new WaitWhile(() => !IsStable(connectionId));
-            SendOffer(connectionId);
+            if(ExistConnection(connectionId))
+                SendOffer(connectionId);
         }
 
         IEnumerator SendOfferCoroutine(string connectionId, PeerConnection pc)

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -62,17 +62,6 @@ namespace Unity.RenderStreaming
         ///
         /// </summary>
         /// <param name="connectionId"></param>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public virtual RTCDataChannel CreateChannel(string connectionId, string name = null)
-        {
-            return m_handler.CreateChannel(connectionId, name);
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="connectionId"></param>
         /// <param name="sender"></param>
         /// <returns></returns>
         public virtual void AddSender(string connectionId, IStreamSender sender)

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -79,7 +79,8 @@ namespace Unity.RenderStreaming
         {
             sender.Track.Stop();
             sender.SetSender(connectionId, null);
-            RemoveTrack(connectionId, sender.Track);
+            if(ExistConnection(connectionId))
+                RemoveTrack(connectionId, sender.Track);
         }
 
         /// <summary>

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -90,6 +90,7 @@ namespace Unity.RenderStreaming
         {
             sender.Track.Stop();
             sender.SetSender(connectionId, null);
+            RemoveTrack(connectionId, sender.Track);
         }
 
         /// <summary>
@@ -145,7 +146,7 @@ namespace Unity.RenderStreaming
         /// </summary>
         /// <param name="connectionId"></param>
         /// <param name="track"></param>
-        public virtual void RemoveTrack(string connectionId, MediaStreamTrack track)
+        protected virtual void RemoveTrack(string connectionId, MediaStreamTrack track)
         {
             m_handler.RemoveSenderTrack(connectionId, track);
         }

--- a/com.unity.renderstreaming/Samples~/Example/Multiplay/Multiplay.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Multiplay/Multiplay.cs
@@ -40,6 +40,9 @@ namespace Unity.RenderStreaming.Samples
             RemoveSender(connectionId, sender);
             RemoveChannel(connectionId, inputChannel);
             RemoveChannel(connectionId, multiplayChannel);
+
+            if (ExistConnection(connectionId))
+                DeleteConnection(connectionId);
         }
 
         public void OnOffer(SignalingEventData data)

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
@@ -212,6 +212,11 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(isStoppedStream1, Is.True);
             Assert.That(isStoppedStream2, Is.True);
 
+            Assert.That(container1.instance.GetSenders(connectionId), Is.Empty);
+            Assert.That(container1.instance.GetReceivers(connectionId), Is.Empty);
+            Assert.That(container2.instance.GetSenders(connectionId), Is.Empty);
+            Assert.That(container2.instance.GetReceivers(connectionId), Is.Empty);
+
             container1.Dispose();
             container2.Dispose();
         }

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
@@ -212,10 +212,9 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(isStoppedStream1, Is.True);
             Assert.That(isStoppedStream2, Is.True);
 
-            Assert.That(container1.instance.GetSenders(connectionId), Is.Empty);
-            Assert.That(container1.instance.GetReceivers(connectionId), Is.Empty);
-            Assert.That(container2.instance.GetSenders(connectionId), Is.Empty);
-            Assert.That(container2.instance.GetReceivers(connectionId), Is.Empty);
+            Assert.That(container1.test.component.ExistConnection(connectionId), Is.False);
+            Assert.That(container2.test.component.ExistConnection(connectionId), Is.False);
+
 
             container1.Dispose();
             container2.Dispose();


### PR DESCRIPTION
Related issue #506, #462 

There was a bug that tracks are leaked when disposing peers in Render Streaming.
This fix is removing tracks when firing peer disconnection event.