### PR TITLE
fix: Fixed error in Multiplay sample on Unity2019

### DIFF
--- a/com.unity.renderstreaming/Samples~/Example/Multiplay/Multiplay.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Multiplay/Multiplay.cs
@@ -60,6 +60,8 @@ namespace Unity.RenderStreaming.Samples
             var multiplayChannel = newObj.GetComponentInChildren<MultiplayChannel>();
             var playerController = newObj.GetComponentInChildren<PlayerController>();
 
+            if (multiplayChannel.OnChangeLabel == null)
+                multiplayChannel.OnChangeLabel = new ChangeLabelEvent();
             multiplayChannel.OnChangeLabel.AddListener(playerController.SetLabel);
 
             AddSender(data.connectionId, sender);

--- a/com.unity.renderstreaming/Samples~/Example/Multiplay/MultiplayChannel.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Multiplay/MultiplayChannel.cs
@@ -19,10 +19,15 @@ namespace Unity.RenderStreaming
     /// <summary>
     /// 
     /// </summary>
+    [Serializable]
+    public class ChangeLabelEvent : UnityEvent<string> {};
+
+    /// <summary>
+    ///
+    /// </summary>
     public class MultiplayChannel : DataChannelBase
     {
-        public UnityEvent<string> OnChangeLabel;
-
+        public ChangeLabelEvent OnChangeLabel;
 
         protected override void OnMessage(byte[] bytes)
         {
@@ -38,7 +43,7 @@ namespace Unity.RenderStreaming
 
         public void ChangeLabel(string text)
         {
-            var msg = new Message()
+            var msg = new Message
             {
                 type = ActionType.ChangeLabel,
                 argument = text


### PR DESCRIPTION
`UnityEvent` is not allocated automatically on Unity2019.4. This behavior is not same with Unity2020 or later.