### PR TITLE
Fix: delete connection process on httpsignaling

### DIFF
--- a/WebApp/client/public/js/signaling.js
+++ b/WebApp/client/public/js/signaling.js
@@ -45,14 +45,16 @@ export class Signaling extends EventTarget {
       const connections = data.connections;
       Logger.log('get connections:', connections);
 
-      const newSet = new Set([...connections]);
+      const newSet = new Set();
+      connections.forEach(e => newSet.add(e.connectionId));
       const deleteConnection = new Set([...currentConnections].filter(e => (!newSet.has(e))));
 
       deleteConnection.forEach(connection => {
-        this.dispatchEvent(new CustomEvent('disconnect', { detail: connection }));
+        this.dispatchEvent(new CustomEvent('disconnect', { detail: { connectionId: connection } }));
+        currentConnections.delete(connection);
       });
 
-      currentConnections = newSet;
+      newSet.forEach(e => currentConnections.add(e));
 
       await this.sleep(this.interval);
     }

--- a/WebApp/client/test/signaling.test.js
+++ b/WebApp/client/test/signaling.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import * as Path from 'path';
 import { setup, teardown } from 'jest-dev-server';
 import { Signaling, WebSocketSignaling } from "../public/js/signaling";
@@ -63,6 +64,7 @@ describe.each([
   });
 
   test(`onConnect using ${mode}`, async () => {
+    const signaling1Spy = jest.spyOn(signaling1, 'dispatchEvent');
     let connectRes;
     let disconnectRes;
     signaling1.addEventListener('connect', (e) => connectRes = e.detail);
@@ -76,6 +78,11 @@ describe.each([
     await signaling1.deleteConnection(connectionId1);
     await waitFor(() => disconnectRes != null);
     expect(disconnectRes.connectionId).toBe(connectionId1);
+
+    const disconnectCalledCount = signaling1Spy.mock.calls.map(x => x[0].type).filter(x => x == "disconnect").length;
+    expect(disconnectCalledCount).toBe(1);
+
+    signaling1Spy.mockRestore();
   });
 
   test(`onOffer using ${mode}`, async () => {

--- a/WebApp/client/test/signaling.test.js
+++ b/WebApp/client/test/signaling.test.js
@@ -6,6 +6,7 @@ import { MockSignaling, reset } from "./mocksignaling";
 import { waitFor, sleep, serverExeName } from "./testutils";
 
 const portNumber = 8081;
+jest.setTimeout(10000);
 
 describe.each([
   { mode: "mock" },


### PR DESCRIPTION
Bugs: The current connection list was managed by an object

before `currentConnections` manage Object ( example `{connectionId: "12345"}`)
after only `connectionId` managed.

`dispatchEvent` argument change because `deleteConnection` contain only `connectionId`.
