### PR TITLE
test: Add InputSystem settings file for testing

### DIFF
--- a/RenderStreaming~/Assets/InputSystem.inputsettings.asset
+++ b/RenderStreaming~/Assets/InputSystem.inputsettings.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c46f07b5ed07e4e92aa78254188d3d10, type: 3}
+  m_Name: InputSystem.inputsettings
+  m_EditorClassIdentifier: 
+  m_SupportedDevices: []
+  m_UpdateMode: 1
+  m_MaxEventBytesPerUpdate: 5242880
+  m_MaxQueuedEventsPerUpdate: 1000
+  m_CompensateForScreenOrientation: 1
+  m_FilterNoiseOnCurrent: 0
+  m_BackgroundBehavior: 2
+  m_EditorInputBehaviorInPlayMode: 2
+  m_DefaultDeadzoneMin: 0.125
+  m_DefaultDeadzoneMax: 0.925
+  m_DefaultButtonPressPoint: 0.5
+  m_ButtonReleaseThreshold: 0.75
+  m_DefaultTapTime: 0.2
+  m_DefaultSlowTapTime: 0.5
+  m_DefaultHoldTime: 0.4
+  m_TapRadius: 5
+  m_MultiTapDelayTime: 0.75
+  m_DisableRedundantEventsMerging: 0
+  m_iOSSettings:
+    m_MotionUsage:
+      m_Enabled: 0
+      m_Description: 

--- a/RenderStreaming~/Assets/InputSystem.inputsettings.asset.meta
+++ b/RenderStreaming~/Assets/InputSystem.inputsettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d3afefa5e1574ee38fb1d298122dbc7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Related [this document](https://github.com/Unity-Technologies/UnityRenderStreaming/blob/develop/com.unity.renderstreaming/Documentation~/use-inputsystem.md).

We need to config the InputSystem when we use input devices in Unity Render Streaming.
The Unity project under the `RenderStreaming~` folder is used for testing samples by developers. This pull request save trouble of having to config themselves when they test samples.