### PR TITLE
fix: Add InputPositionCorrector class to correct the input position

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/InputPositionCorrector.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputPositionCorrector.cs
@@ -1,0 +1,60 @@
+using System;
+using Unity.Collections.LowLevel.Unsafe;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.LowLevel;
+
+namespace Unity.RenderStreaming
+{
+    class InputPositionCorrector
+    {
+        public Rect inputRegion { set; get; }
+
+        public Rect outputRegion { set; get; }
+
+        private Action<InputEventPtr, InputDevice> _onEvent;
+
+        public InputPositionCorrector(Action<InputEventPtr, InputDevice> onEvent)
+        {
+            _onEvent = onEvent;
+        }
+
+        public unsafe void Invoke(InputEventPtr ptr, InputDevice device)
+        {
+            // Allocate memory and copy InputEventPtr
+            InputEventPtr dst = (InputEventPtr)
+                UnsafeUtility.Malloc(ptr.sizeInBytes, 4, Collections.Allocator.Temp);
+            UnsafeUtility.MemCpy(dst, ptr, ptr.sizeInBytes);
+
+            // Mapping 
+            PointerMap((StateEvent*)dst.data, device);
+
+            _onEvent?.Invoke(dst, device);
+
+            // Free memory
+            UnsafeUtility.Free(dst, Collections.Allocator.Temp);
+        }
+
+        unsafe void PointerMap(StateEvent* data, InputDevice device)
+        {
+            switch (device)
+            {
+                case Mouse mouse:
+                    MouseState* mouseState = (MouseState*)data->state;
+                    mouseState->position = Map(mouseState->position, inputRegion, outputRegion);
+                    break;
+                case Touchscreen touch:
+                    // todo(kazuki): multi touch is not supported yet.
+                    TouchState* touchState = (TouchState*)data->state;
+                    touchState->position = Map(touchState->position, inputRegion, outputRegion);
+                    break;
+            }
+        }
+
+        static Vector2 Map(Vector2 pos, Rect inputRegion, Rect outputRegion)
+        {
+            Vector2 normalized = Rect.PointToNormalized(inputRegion, pos);
+            return Rect.NormalizedToPoint(outputRegion, normalized);
+        }
+    }
+}

--- a/com.unity.renderstreaming/Runtime/Scripts/InputPositionCorrector.cs.meta
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputPositionCorrector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f28e3e5eb23050469ff498aa7d75934
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSender.cs
@@ -35,15 +35,23 @@ namespace Unity.RenderStreaming
             base.SetChannel(connectionId, channel);
         }
 
-        public void SetCorrectPointerPositionInfo(Vector2Int frameSize, Rect region)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="size">Texture Size.</param>
+        /// <param name="region">Region of the texture in world coordinate system.</param>
+        public void SetInputRange(Rect region, Vector2Int size)
         {
-            sender.FrameSize = frameSize;
-            sender.Region = region;
+            sender.SetInputRange(region, new Rect(Vector2.zero, size));
         }
 
-        public void EnableCorrectPointerPosition(bool enabled)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="enabled"></param>
+        public void EnableInputPositionCorrection(bool enabled)
         {
-            sender.EnableCorrectPointerPosition = enabled;
+            sender.EnableInputPositionCorrection = enabled;
         }
 
         void OnOpen()

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSender.cs
@@ -1,5 +1,6 @@
 using System;
 using Unity.WebRTC;
+using UnityEngine;
 using Unity.RenderStreaming.InputSystem;
 
 namespace Unity.RenderStreaming
@@ -32,6 +33,17 @@ namespace Unity.RenderStreaming
                 channel.OnClose += OnClose;
             }
             base.SetChannel(connectionId, channel);
+        }
+
+        public void SetCorrectPointerPositionInfo(Vector2Int frameSize, Rect region)
+        {
+            sender.FrameSize = frameSize;
+            sender.Region = region;
+        }
+
+        public void EnableCorrectPointerPosition(bool enabled)
+        {
+            sender.EnableCorrectPointerPosition = enabled;
         }
 
         void OnOpen()

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputReceiver.cs
@@ -238,6 +238,26 @@ namespace Unity.RenderStreaming
         /// <summary>
         /// 
         /// </summary>
+        /// <param name="size">Texture Size.</param>
+        /// <param name="region">Region of the texture in world coordinate system.</param>
+        public void SetInputRange(Vector2Int size, Rect region)
+        {
+            receiver.SetInputRange(new Rect(Vector2.zero, size), region);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="enabled"></param>
+        public void SetEnableInputPositionCorrection(bool enabled)
+        {
+            receiver.EnableInputPositionCorrection = enabled;
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
         protected virtual void OnDestroy()
         {
             Dispose();

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Receiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Receiver.cs
@@ -194,40 +194,6 @@ namespace Unity.RenderStreaming.InputSystem
             _corrector.inputRegion = inputRegion;
             _corrector.outputRegion = outputRegion;
         }
-
-        //unsafe void OnPointerEvent(ref InputEventPtr ptr, InputDevice device)
-        //{
-        //    // Allocate memory and copy InputEventPtr
-        //    InputEventPtr dst = (InputEventPtr)
-        //        UnsafeUtility.Malloc(ptr.sizeInBytes, 4, Collections.Allocator.Temp);
-        //    UnsafeUtility.MemCpy(dst, ptr, ptr.sizeInBytes);
-
-        //    // Mapping 
-        //    PointerMap((StateEvent*)dst.data, device);
-
-        //    base.QueueEvent(dst);
-
-        //    // Free memory
-        //    UnsafeUtility.Free(dst, Collections.Allocator.Temp);
-        //}
-
-        //Vector2 Translate(ref Vector2 position)
-        //{
-        //    Rect region = new Rect(0, 0, 1280, 720);
-        //    Vector2 frameSize = new Vector2(Screen.width, Screen.height);
-        //    return Rect.PointToNormalized(region, position) * frameSize;
-        //}
-
-        //unsafe void PointerMap(StateEvent* data, InputDevice device)
-        //{
-        //    switch (device)
-        //    {
-        //        case Mouse mouse:
-        //            MouseState* mouseState = (MouseState*)data->state;
-        //            mouseState->position = Translate(ref mouseState->position);
-        //            break;
-        //    }
-        //}
     }
 }
 // #endif

--- a/com.unity.renderstreaming/Runtime/Scripts/StreamReceiverBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/StreamReceiverBase.cs
@@ -8,12 +8,24 @@ namespace Unity.RenderStreaming
     /// </summary>
     public abstract class StreamReceiverBase : MonoBehaviour, IStreamReceiver
     {
+        /// <summary>
+        /// 
+        /// </summary>
         public RTCRtpReceiver Receiver => m_receiver;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public OnStartedStreamHandler OnStartedStream { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public OnStoppedStreamHandler OnStoppedStream { get; set; }
+
 
         private RTCRtpReceiver m_receiver;
 
-        public OnStartedStreamHandler OnStartedStream { get; set; }
-        public OnStoppedStreamHandler OnStoppedStream { get; set; }
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -27,7 +27,7 @@ namespace Unity.RenderStreaming
         ///
         /// </summary>
         [SerializeField, StreamingSize]
-        protected Vector2Int streamingSize = new Vector2Int(1280, 720);
+        public Vector2Int streamingSize = new Vector2Int(1280, 720);
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/Broadcast.unity
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/Broadcast.unity
@@ -2343,6 +2343,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   renderStreaming: {fileID: 1623734776}
+  inputReceiver: {fileID: 725451153}
+  videoStreamSender: {fileID: 725451156}
 --- !u!1 &2061595961
 GameObject:
   m_ObjectHideFlags: 0

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.UI;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.XR;
 
@@ -6,9 +7,19 @@ namespace Unity.RenderStreaming.Samples
 {
     using InputSystem = UnityEngine.InputSystem.InputSystem;
 
+    static class InputReceiverExtension
+    {
+        public static void SetInputRange(this InputReceiver reveiver, Vector2Int size)
+        {
+            reveiver.SetInputRange(size, new Rect(0, 0, Screen.width, Screen.height));
+        }
+    }
+
     class BroadcastSample : MonoBehaviour
     {
         [SerializeField] RenderStreaming renderStreaming;
+        [SerializeField] InputReceiver inputReceiver;
+        [SerializeField] VideoStreamSender videoStreamSender;
 
         private void Awake()
         {
@@ -28,6 +39,14 @@ namespace Unity.RenderStreaming.Samples
             renderStreaming.Run(
                 hardwareEncoder: RenderStreamingSettings.EnableHWCodec,
                 signaling: RenderStreamingSettings.Signaling);
+
+            inputReceiver.OnStartedChannel += OnStartedChannel;
+        }
+
+        void OnStartedChannel(string connectionId)
+        {
+            inputReceiver.SetInputRange(videoStreamSender.streamingSize);
+            inputReceiver.SetEnableInputPositionCorrection(true);
         }
     }
 }

--- a/com.unity.renderstreaming/Samples~/Example/Receiver/ReceiverSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Receiver/ReceiverSample.cs
@@ -73,18 +73,18 @@ namespace Unity.RenderStreaming.Samples
         void OnUpdateReceiveTexture(Texture texture)
         {
             remoteVideoImage.texture = texture;
-            if (inputSender.IsConnected)
-                SetInputChange();
+            SetInputChange();
         }
 
         void OnStartedChannel(string connectionId)
         {
-            if (remoteVideoImage.texture != null)
-                SetInputChange();
+            SetInputChange();
         }
 
         void SetInputChange()
         {
+            if (!inputSender.IsConnected || remoteVideoImage.texture == null)
+                return;
             inputSender.SetInputRange(remoteVideoImage);
             inputSender.EnableInputPositionCorrection(true);
         }


### PR DESCRIPTION
Related issue #454

This change fix the gap of the input position (mouse, touchscreen).

Added `InputPositionCorrector` class for correcting the position between two coordinate systems.
The process of correction is ran once on the sender side and the receiver side.