### PR TITLE
fix: Avoid crash if using specified Screen resolution

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
@@ -6,52 +6,102 @@ using UnityEngine.Experimental.Rendering;
 namespace Unity.RenderStreaming
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class ScreenStreamSender : VideoStreamSender
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [SerializeField, RenderTextureDepthBuffer]
         private int depth = 0;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [SerializeField, RenderTextureAntiAliasing]
         private int antiAliasing = 1;
 
         public override Texture SendTexture => m_sendTexture;
         private RenderTexture m_sendTexture;
+        private RenderTexture m_screenTexture;
 
         protected virtual void Awake()
         {
-            RenderTextureFormat supportFormat =
-                WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
-            GraphicsFormat graphicsFormat =
-                GraphicsFormatUtility.GetGraphicsFormat(supportFormat, RenderTextureReadWrite.Default);
-            GraphicsFormat compatibleFormat = SystemInfo.GetCompatibleFormat(graphicsFormat, FormatUsage.Render);
-            GraphicsFormat format = graphicsFormat == compatibleFormat ? graphicsFormat : compatibleFormat;
-
-            m_sendTexture =
+            var format = WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            m_screenTexture =
                 new RenderTexture(Screen.width, Screen.height, depth, format) { antiAliasing = antiAliasing };
+            m_screenTexture.Create();
+        }
+
+        protected void OnDestroy()
+        {
+            if (m_sendTexture != null)
+            {
+                DestroyImmediate(m_sendTexture);
+                m_sendTexture = null;
+            }
+
+            if (m_screenTexture != null)
+            {
+                DestroyImmediate(m_screenTexture);
+                m_screenTexture = null;
+            }
         }
 
         protected override MediaStreamTrack CreateTrack()
         {
-            return new VideoStreamTrack(m_sendTexture.GetNativeTexturePtr(), m_sendTexture.width, m_sendTexture.height, m_sendTexture.graphicsFormat);
+            RenderTexture rt;
+            if (m_sendTexture != null)
+            {
+                rt = m_sendTexture;
+                RenderTextureFormat supportFormat =
+                    WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+                GraphicsFormat graphicsFormat =
+                    GraphicsFormatUtility.GetGraphicsFormat(supportFormat, RenderTextureReadWrite.Default);
+                GraphicsFormat compatibleFormat = SystemInfo.GetCompatibleFormat(graphicsFormat, FormatUsage.Render);
+                GraphicsFormat format = graphicsFormat == compatibleFormat ? graphicsFormat : compatibleFormat;
+
+                if (rt.graphicsFormat != format)
+                {
+                    Debug.LogWarning(
+                        $"This color format:{rt.graphicsFormat} not support in unity.webrtc. Change to supported color format:{format}.");
+                    rt.Release();
+                    rt.graphicsFormat = format;
+                    rt.Create();
+                }
+
+                m_sendTexture = rt;
+            }
+            else
+            {
+                RenderTextureFormat format =
+                    WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+                rt = new RenderTexture(streamingSize.x, streamingSize.y, depth, format) { antiAliasing = antiAliasing };
+                rt.Create();
+                m_sendTexture = rt;
+            }
+
+            return new VideoStreamTrack(rt.GetNativeTexturePtr(), rt.width, rt.height, rt.graphicsFormat);
         }
 
         protected void LateUpdate()
         {
-            StartCoroutine(RecordFrame());
+            if (m_screenTexture != null && m_screenTexture.IsCreated())
+            {
+                StartCoroutine(RecordFrame());
+            }
         }
 
         IEnumerator RecordFrame()
         {
             yield return new WaitForEndOfFrame();
-            ScreenCapture.CaptureScreenshotIntoRenderTexture(m_sendTexture);
+            ScreenCapture.CaptureScreenshotIntoRenderTexture(m_screenTexture);
+
+            if (m_sendTexture != null && m_sendTexture.IsCreated())
+            {
+                Graphics.Blit(m_screenTexture, m_sendTexture);
+            }
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
@@ -34,6 +34,15 @@ namespace Unity.RenderStreaming
             m_screenTexture.Create();
 
             StartCoroutine(RecordScreenFrame());
+
+            OnStoppedStream += _ =>
+            {
+                if (m_sendTexture != null)
+                {
+                    DestroyImmediate(m_sendTexture);
+                    m_sendTexture = null;
+                }
+            };
         }
 
         protected void OnDestroy()

--- a/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
@@ -1,4 +1,6 @@
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Unity.WebRTC;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
@@ -25,7 +27,7 @@ namespace Unity.RenderStreaming
         public override Texture SendTexture => m_sendTexture;
         private RenderTexture m_sendTexture;
         private RenderTexture m_screenTexture;
-        private bool isStreaming = false;
+        private HashSet<string> connections = new HashSet<string>();
 
         protected virtual void Awake()
         {
@@ -36,8 +38,8 @@ namespace Unity.RenderStreaming
 
             StartCoroutine(RecordScreenFrame());
 
-            OnStartedStream += _ => isStreaming = true;
-            OnStoppedStream += _ => isStreaming = false;
+            OnStartedStream += id => connections.Add(id);
+            OnStoppedStream += id => connections.Remove(id);
         }
 
         protected void OnDestroy()
@@ -97,7 +99,7 @@ namespace Unity.RenderStreaming
             {
                 yield return new WaitForEndOfFrame();
 
-                if (!isStreaming || m_sendTexture == null || !m_sendTexture.IsCreated())
+                if (!connections.Any() || m_sendTexture == null || !m_sendTexture.IsCreated())
                 {
                     continue;
                 }

--- a/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
@@ -25,6 +25,7 @@ namespace Unity.RenderStreaming
         public override Texture SendTexture => m_sendTexture;
         private RenderTexture m_sendTexture;
         private RenderTexture m_screenTexture;
+        private bool isStreaming = false;
 
         protected virtual void Awake()
         {
@@ -35,14 +36,8 @@ namespace Unity.RenderStreaming
 
             StartCoroutine(RecordScreenFrame());
 
-            OnStoppedStream += _ =>
-            {
-                if (m_sendTexture != null)
-                {
-                    DestroyImmediate(m_sendTexture);
-                    m_sendTexture = null;
-                }
-            };
+            OnStartedStream += _ => isStreaming = true;
+            OnStoppedStream += _ => isStreaming = false;
         }
 
         protected void OnDestroy()
@@ -102,7 +97,7 @@ namespace Unity.RenderStreaming
             {
                 yield return new WaitForEndOfFrame();
 
-                if (m_sendTexture == null || !m_sendTexture.IsCreated())
+                if (!isStreaming || m_sendTexture == null || !m_sendTexture.IsCreated())
                 {
                     continue;
                 }


### PR DESCRIPTION
- Fixed streaming size by inspector

if streaming size is FullHD (1920, 1080) , crash application using hardware encoder.

todo:
- add preset on inspector
- add warning if using free form