### PR TITLE
Fix: fix screenstream sender on Unity 2019 Win

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/ScreenStreamSender.cs
@@ -33,7 +33,7 @@ namespace Unity.RenderStreaming
         {
             var format = WebRTC.WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
             m_screenTexture =
-                new RenderTexture(Screen.width, Screen.height, depth, format) { antiAliasing = antiAliasing };
+                new RenderTexture(Screen.width, Screen.height, depth, RenderTextureFormat.Default) { antiAliasing = antiAliasing };
             m_screenTexture.Create();
 
             StartCoroutine(RecordScreenFrame());
@@ -104,15 +104,8 @@ namespace Unity.RenderStreaming
                     continue;
                 }
 
-                if (m_screenTexture.width == m_sendTexture.width && m_screenTexture.height == m_sendTexture.height)
-                {
-                    ScreenCapture.CaptureScreenshotIntoRenderTexture(m_sendTexture);
-                }
-                else
-                {
-                    ScreenCapture.CaptureScreenshotIntoRenderTexture(m_screenTexture);
-                    Graphics.Blit(m_screenTexture, m_sendTexture);
-                }
+                ScreenCapture.CaptureScreenshotIntoRenderTexture(m_screenTexture);
+                Graphics.Blit(m_screenTexture, m_sendTexture);
             }
         }
     }


### PR DESCRIPTION
Bugs: can't write into rendertexture if using `BGRA32` format on Unity 2019 Windows.

Writing rendertexture format fixed `RenderTextureForamt.Default`
and always use Blit for convert texture format.