### PR TITLE
chore: Exclude editor version 2021.2 from version list for testing

### DIFF
--- a/.yamato/meta/environments.yml
+++ b/.yamato/meta/environments.yml
@@ -5,7 +5,7 @@ intra_pypi_url: https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi
 editors:
   - version: 2019.4
   - version: 2020.3
-  - version: 2021.1
+  - version: 2021.2
 platforms:
   - name: win
     type: Unity::VM::GPU

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -400,6 +400,8 @@ publish_{{ package.name }}:
   dependencies:
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
 {% for editor in editors %}
+{% if editor.version != "2021.2" -%} # exclude editor version 2021.2
     - .yamato/upm-ci-renderstreaming-packages.yml#trigger_test_{{ package.name }}_{{ editor.version }}
+{% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
At the moment, this package is testing on the Unity Editor version 2021.2 but have been unstable yet.
This pull request excludes version 2021.2 from the editor version list of testing for publishing the package.