### PR TITLE
Fix: close websocket instance when called stop

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/FurioosSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/FurioosSignaling.cs
@@ -65,6 +65,8 @@ namespace Unity.RenderStreaming.Signaling
             if (m_running)
             {
                 m_running = false;
+                m_webSocket.Close();
+
                 if (m_signalingThread.ThreadState == ThreadState.WaitSleepJoin)
                 {
                     m_signalingThread.Abort();

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
@@ -51,6 +51,8 @@ namespace Unity.RenderStreaming.Signaling
             if (m_running)
             {
                 m_running = false;
+                m_webSocket.Close();
+
                 if (m_signalingThread.ThreadState == ThreadState.WaitSleepJoin)
                 {
                     m_signalingThread.Abort();


### PR DESCRIPTION
Fix this issue https://github.com/Unity-Technologies/UnityRenderStreaming/issues/526

Need call close method on stop.