### PR TITLE
Let multiple keys be held at once

### DIFF
--- a/WebApp/client/public/js/inputdevice.js
+++ b/WebApp/client/public/js/inputdevice.js
@@ -103,7 +103,7 @@ export class Keyboard extends InputDevice {
    * @param {KeyboardEvent} event 
    */
   queueEvent(event) {
-    this.updateState(new KeyboardState(event));
+    this.updateState(new KeyboardState(event, this.currentState));
   }
 }
 
@@ -283,9 +283,13 @@ export class KeyboardState extends IInputState {
   /**
    * @param {KeyboardEvent} event 
    */
-  constructor(event) {
+  constructor(event, state) {
     super();
-    this.keys = new ArrayBuffer(KeyboardState.sizeInBytes);
+    if (state == null || state.keys == null) {
+      this.keys = new ArrayBuffer(KeyboardState.sizeInBytes);
+    } else {
+      this.keys = state.keys;
+    }
     let value = false;
     switch(event.type) {
       case 'keydown':


### PR DESCRIPTION
See context in issue #619.

This change bases the current key state array on the previous key state array, if there is one.  This allows multiple keys to be sent as input simultaneously, rather than only one at a time as was the previous limitation.