### PR TITLE
fix: Add the AudioStreamReceiver.SetSource method to receive streaming audio 

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamReceiver.cs
@@ -12,12 +12,12 @@ namespace Unity.RenderStreaming
         ///
         /// </summary>
         /// <param name="clip"></param>
-        public delegate void OnUpdateReceiveAudioClipHandler(AudioClip clip);
+        public delegate void OnUpdateReceiveAudioSourceHandler(AudioSource source);
 
         /// <summary>
         ///
         /// </summary>
-        public OnUpdateReceiveAudioClipHandler OnUpdateReceiveAudioClip;
+        public OnUpdateReceiveAudioSourceHandler OnUpdateReceiveAudioSource;
 
         /// <summary>
         ///
@@ -27,9 +27,18 @@ namespace Unity.RenderStreaming
         /// <summary>
         ///
         /// </summary>
-        public AudioClip Clip => m_renderer;
+        public AudioSource Source => m_source;
 
-        private AudioClip m_renderer;
+        private AudioSource m_source;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="source"></param>
+        public void SetSource(AudioSource source)
+        {
+            m_source = source;
+        }
 
         protected virtual void Start()
         {
@@ -41,15 +50,15 @@ namespace Unity.RenderStreaming
         {
             if (Track is AudioStreamTrack audioTrack)
             {
-                m_renderer = audioTrack.Renderer.clip;
-                OnUpdateReceiveAudioClip?.Invoke(m_renderer);
+                m_source?.SetTrack(audioTrack);
+                OnUpdateReceiveAudioSource?.Invoke(m_source);
             }
         }
 
         private void StoppedStream(string connectionId)
         {
-            m_renderer = null;
-            OnUpdateReceiveAudioClip?.Invoke(null);
+            m_source?.SetTrack(null);
+            OnUpdateReceiveAudioSource?.Invoke(null);
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamReceiver.cs
@@ -57,7 +57,7 @@ namespace Unity.RenderStreaming
 
         private void StoppedStream(string connectionId)
         {
-            m_source?.SetTrack(null);
+            m_source = null;
             OnUpdateReceiveAudioSource?.Invoke(null);
         }
     }

--- a/com.unity.renderstreaming/Samples~/Example/Bidirectional/Bidirectional.unity
+++ b/com.unity.renderstreaming/Samples~/Example/Bidirectional/Bidirectional.unity
@@ -3207,7 +3207,7 @@ AudioSource:
   m_Volume: 1
   m_Pitch: 1
   Loop: 0
-  Mute: 1
+  Mute: 0
   Spatialize: 0
   SpatializePostEffects: 0
   Priority: 128

--- a/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
@@ -56,11 +56,11 @@ namespace Unity.RenderStreaming.Samples
             microphoneSelectDropdown.options =
                 microphoneStreamer.MicrophoneNameList.Select(x => new Dropdown.OptionData(x)).ToList();
             microphoneStreamer.OnStartedStream += id => receiveAudioViewer.enabled = true;
-            receiveAudioViewer.OnUpdateReceiveAudioClip += clip =>
+            receiveAudioViewer.SetSource(receiveAudioSource);
+            receiveAudioViewer.OnUpdateReceiveAudioSource += source =>
             {
-                receiveAudioSource.clip = clip;
-                receiveAudioSource.loop = true;
-                receiveAudioSource.Play();
+                source.loop = true;
+                source.Play();
             };
         }
 

--- a/com.unity.renderstreaming/Samples~/Example/Receiver/ReceiverSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Receiver/ReceiverSample.cs
@@ -28,11 +28,11 @@ namespace Unity.RenderStreaming.Samples
             if(connectionIdInput != null)
                 connectionIdInput.onValueChanged.AddListener(input => connectionId = input);
             receiveVideoViewer.OnUpdateReceiveTexture += texture => remoteVideoImage.texture = texture;
-            receiveAudioViewer.OnUpdateReceiveAudioClip += clip =>
+            receiveAudioViewer.SetSource(remoteAudioSource);
+            receiveAudioViewer.OnUpdateReceiveAudioSource += source =>
             {
-                remoteAudioSource.clip = clip;
-                remoteAudioSource.loop = true;
-                remoteAudioSource.Play();
+                source.loop = true;
+                source.Play();
             };
         }
 


### PR DESCRIPTION
This change is for handling the API changes of `AudioStreamTrack` which contained in the new version of WebRTC package.