### PR TITLE
chore: Update Input System package version 1.3.0

### DIFF
--- a/RenderStreaming~/Packages/packages-lock.json
+++ b/RenderStreaming~/Packages/packages-lock.json
@@ -52,10 +52,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.inputsystem": {
-      "version": "1.0.2",
+      "version": "1.3.0",
       "depth": 1,
       "source": "registry",
-      "dependencies": {},
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.renderstreaming": {
@@ -64,7 +66,7 @@
       "source": "embedded",
       "dependencies": {
         "com.unity.webrtc": "2.4.0-exp.5",
-        "com.unity.inputsystem": "1.0.2"
+        "com.unity.inputsystem": "1.3.0"
       }
     },
     "com.unity.subsystemregistration": {

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/SimpleCameraControllerV2.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/SimpleCameraControllerV2.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
-using Unity.RenderStreaming.InputSystem;
+using UnityEngine.InputSystem.EnhancedTouch;
 
 namespace Unity.RenderStreaming.Samples
 {
@@ -91,6 +91,9 @@ namespace Unity.RenderStreaming.Samples
         {
             playerInput.onDeviceChange += OnDeviceChange;
             m_InitialCameraState.SetFromTransform(transform);
+
+            // Need to set enable the flag to receive touch screen event from mobile devices.
+            EnhancedTouchSupport.Enable();
         }
 
         void OnDeviceChange(InputDevice device, InputDeviceChange change)

--- a/com.unity.renderstreaming/package.json
+++ b/com.unity.renderstreaming/package.json
@@ -6,7 +6,7 @@
   "description": "This is a package for using Unity Render Streaming technology. It contains two samples to use the technology.",
   "dependencies": {
     "com.unity.webrtc": "2.4.0-exp.5",
-    "com.unity.inputsystem": "1.0.2"
+    "com.unity.inputsystem": "1.3.0"
   },
   "samples": [
     {


### PR DESCRIPTION
Unity Render Streaming package depends on Input System, and have used the version 1.0.2. 
The latest version 1.3.0 is released last December, so we needed to follow the updating.