### PR TITLE
fix: Add workaround for avoiding NullReferenceException from AudioAtreamSender.SetData

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -1,4 +1,5 @@
 using System;
+using Unity.Collections;
 using Unity.WebRTC;
 using UnityEngine;
 
@@ -66,13 +67,20 @@ namespace Unity.RenderStreaming
 
         protected virtual void OnAudioFilterRead(float[] data, int channels)
         {
+            NativeArray<float> nativeArray = new NativeArray<float>(data, Allocator.Temp);
             try
             {
-                track?.SetData(data, channels, m_sampleRate);
+                track?.SetData(ref nativeArray, channels, m_sampleRate);
             }
-            catch (InvalidOperationException)
+            // todo(kazuki):: Should catch only ObjectDisposedException but 
+            // AudioStreamTrack also throws NullReferenceException.
+            catch (Exception)
             {
                 track = null;
+            }
+            finally
+            {
+                nativeArray.Dispose();
             }
         }
     }

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
@@ -263,7 +263,6 @@ namespace Unity.RenderStreaming.Signaling
 
             m_wsCloseEvent.Set();
             m_webSocket = null;
-            m_running = false;
         }
 
         private void WSSend(object data)

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
@@ -263,6 +263,7 @@ namespace Unity.RenderStreaming.Signaling
 
             m_wsCloseEvent.Set();
             m_webSocket = null;
+            m_running = false;
         }
 
         private void WSSend(object data)


### PR DESCRIPTION
Fix two issues in this pull request.

- Catch the `NullReferenceException` thrown from `AudioStreamTrack.SetData` when destroying the `RenderStreaming` component.
- Fix `NullReferenceException` when closing the scene after occurring the unexpected disconnection with web server.
