### PR TITLE
refactor: Remove AudioSource member from AudioStreamSender class

### DIFF
--- a/RenderStreaming~/ProjectSettings/AudioManager.asset
+++ b/RenderStreaming~/ProjectSettings/AudioManager.asset
@@ -9,11 +9,12 @@ AudioManager:
   Doppler Factor: 1
   Default Speaker Mode: 2
   m_SampleRate: 0
-  m_DSPBufferSize: 1024
+  m_DSPBufferSize: 256
   m_VirtualVoiceCount: 512
   m_RealVoiceCount: 32
+  m_EnableOutputSuspension: 1
   m_SpatializerPlugin: 
   m_AmbisonicDecoderPlugin: 
   m_DisableAudio: 0
   m_VirtualizeEffects: 1
-  m_RequestedDSPBufferSize: 1024
+  m_RequestedDSPBufferSize: 256

--- a/com.unity.renderstreaming/Runtime/Scripts/MicrophoneStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/MicrophoneStreamSender.cs
@@ -6,14 +6,13 @@ namespace Unity.RenderStreaming
 {
     public class MicrophoneStreamSender : AudioStreamSender
     {
+        [SerializeField, Tooltip("Play microphone input (Required)")]
+        protected AudioSource audioSource;
+
         [SerializeField, Tooltip("Device index of microphone")]
         private int deviceIndex = 0;
 
         public IEnumerable<string> MicrophoneNameList => Microphone.devices;
-
-        protected override void Awake()
-        {
-        }
 
         protected override void OnEnable()
         {
@@ -35,6 +34,17 @@ namespace Unity.RenderStreaming
             audioSource.clip = micClip;
             audioSource.loop = true;
             audioSource.Play();
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+
+            if (audioSource == null)
+                return;
+
+            audioSource.Stop();
+            audioSource.clip = null;
         }
 
         public void SetDeviceIndex(int index)

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/Broadcast.unity
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/Broadcast.unity
@@ -1059,7 +1059,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 28e4557ba7cb056499034647b21b6361, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  audioSource: {fileID: 0}
 --- !u!114 &725451156
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1287,6 +1286,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_MoveRepeatDelay: 0.5
   m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
   m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018,
     type: 3}
   m_PointAction: {fileID: 1054132383583890850, guid: ca9f5fa95ffab41fb9a615ab714db018,


### PR DESCRIPTION
The `AudioStreamSender` class can stream audio from the audio source. The component type as an audio source is able to use `AudioSource` or `AudioListener`. Developers can use the class by attaching these components to the same `GameObject`.