### PR TITLE
fix: The delta value of MouseState is invalid when the browser send the mouse event to Unity

### DIFF
--- a/WebApp/client/public/js/sender.js
+++ b/WebApp/client/public/js/sender.js
@@ -34,7 +34,7 @@ export class Sender extends LocalInputManager {
       m_Version: "",
       m_Capabilities: ""  
     };    
-    this.mouse = new Mouse("Mouse", "Mouse", 1, "Default", descriptionMouse);
+    this.mouse = new Mouse("Mouse", "Mouse", 1, "", descriptionMouse);
     this._devices.push(this.mouse);
 
     this._elem.addEventListener('click', this._onMouseEvent.bind(this), false);
@@ -54,7 +54,7 @@ export class Sender extends LocalInputManager {
       m_Version: "",
       m_Capabilities: ""  
     };
-    this.keyboard = new Keyboard("Keyboard", "Keyboard", 2, "Default", descriptionKeyboard);
+    this.keyboard = new Keyboard("Keyboard", "Keyboard", 2, "", descriptionKeyboard);
     this._devices.push(this.keyboard);
 
     document.addEventListener('keyup', this._onKeyEvent.bind(this), false);
@@ -71,7 +71,7 @@ export class Sender extends LocalInputManager {
       m_Version: "",
       m_Capabilities: ""
     };
-    this.gamepad = new Gamepad("Gamepad", "Gamepad", 3, "Default", descriptionGamepad);
+    this.gamepad = new Gamepad("Gamepad", "Gamepad", 3, "", descriptionGamepad);
     this._devices.push(this.gamepad);
 
     window.addEventListener("gamepadconnected", this._onGamepadEvent.bind(this), false);
@@ -90,7 +90,7 @@ export class Sender extends LocalInputManager {
       m_Version: "",
       m_Capabilities: ""  
     };
-    this.touchscreen = new Touchscreen("Touchscreen", "Touchscreen", 4, "Default", descriptionTouch);
+    this.touchscreen = new Touchscreen("Touchscreen", "Touchscreen", 4, "", descriptionTouch);
     this._devices.push(this.touchscreen);
 
     this._elem.addEventListener('touchend', this._onTouchEvent.bind(this), false);


### PR DESCRIPTION
Since InputSystem 1.3, `FastMouse` type is used instead of `Mouse` for the mouse device. However, when the `layoutVariants` is not null or empty, InputSystem create `Mouse`, not `FastMouse`. 

There is a difference that the way of computing the delta value of input event between `Mouse` and `FastMouse`. So we need to force to use `FastMouse` for the mouse device.