### PR TITLE
fix: PeerConnection.Dispose method is called twice when unloading the scene

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/PeerConnection.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/PeerConnection.cs
@@ -13,6 +13,8 @@ namespace Unity.RenderStreaming
         public bool srdAnswerPending;
         public bool makingAnswer;
 
+        bool disposed = false;
+
         /// <summary>
         /// 
         /// </summary>
@@ -64,6 +66,8 @@ namespace Unity.RenderStreaming
             {
                 return;
             }
+            if (disposed)
+                return;
 
             peer.OnTrack = null;
             peer.OnDataChannel = null;
@@ -73,6 +77,9 @@ namespace Unity.RenderStreaming
             peer.OnIceConnectionChange = null;
             peer.OnIceGatheringStateChange = null;
             peer.Dispose();
+
+            disposed = true;
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
`PeerConnection.Dispose` method is public and call from outside. 
However, the `Dispose` method doesn't suppress the finalizer, so the finalizer is called from garbage collector and cause disposing twice.