### PR TITLE
fix: Reset InputControl when unloading Gyro sample scene

### DIFF
--- a/com.unity.renderstreaming/Samples~/Example/Gyro/GyroSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Gyro/GyroSample.cs
@@ -34,6 +34,8 @@ namespace Unity.RenderStreaming.Samples
 
         void OnDestroy()
         {
+            // Reset InputControl of Gyroscope surely.
+            InputSystem.ResetDevice(Gyroscope.current, true);
             InputSystem.DisableDevice(Gyroscope.current);
         }
 


### PR DESCRIPTION
`InputControl` of Input sensor device is not reset even if calling `InputSystem.DisableDevice`. Therefore it causes unexpected behavior after unloading the Gyro sample scene.