### PR TITLE
fix: Null reference exception when close websocket

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
@@ -51,7 +51,7 @@ namespace Unity.RenderStreaming.Signaling
             if (m_running)
             {
                 m_running = false;
-                m_webSocket.Close();
+                m_webSocket?.Close();
 
                 if (m_signalingThread.ThreadState == ThreadState.WaitSleepJoin)
                 {


### PR DESCRIPTION
- add check null conditional operator when `Stop`