### PR TITLE
feat: Select video codec on WebApp

### DIFF
--- a/WebApp/client/public/bidirectional/css/style.css
+++ b/WebApp/client/public/bidirectional/css/style.css
@@ -26,6 +26,10 @@ div#preview>div {
   width: calc(50% - 20px);
 }
 
+div#connectionId {
+  margin: 1em;
+}
+
 h2 {
   margin: 0 0 0.5em 0;
 }
@@ -34,9 +38,10 @@ textarea {
   color: #444;
   font-size: 0.9em;
   font-weight: 300;
-  height: 2.0em;
-  padding: 5px;
   width: calc(20% - 10px);
+  height: 1.3em;
+  line-height: 1.3;
+  vertical-align: middle;
 }
 
 video {

--- a/WebApp/client/public/bidirectional/index.html
+++ b/WebApp/client/public/bidirectional/index.html
@@ -35,14 +35,28 @@
         <h2>Remote</h2>
         <video id="remote_video" playsinline autoplay></video>
       </div>
-      <p>ConnectionID:<br />
-        <textarea id="text_for_connection_id"></textarea>
-      </p>
-      <p>For more information about <code>Bidirectional</code> sample, see <a href="https://docs.unity3d.com/Packages/com.unity.renderstreaming@latest/sample-bidirectional.html">Bidirectional
-          sample</a> document page.</p>
     </div>
+
+    <div class="box">
+      <span>Connection ID:</span>
+      <textarea id="text_for_connection_id"></textarea>
+    </div>
+    <div class="box">
+      <span>Codec preferences:</span>
+      <select id="codecPreferences" disabled>
+        <option selected value="">Default</option>
+      </select>
+    </div>
+
+    <p>For more information about <code>Bidirectional</code> sample, see <a
+        href="https://docs.unity3d.com/Packages/com.unity.renderstreaming@3.1/manual/sample-bidirectional.html">Bidirectional
+        sample</a> document page.</p>
+
+    <div id="message"></div>
+
     <section>
-      <a href="https://github.com/Unity-Technologies/UnityRenderStreaming/tree/develop/WebApp/public/bidirectional" title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
+      <a href="https://github.com/Unity-Technologies/UnityRenderStreaming/tree/develop/WebApp/public/bidirectional"
+        title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>
     </section>
   </div>
 </body>

--- a/WebApp/client/public/bidirectional/js/main.js
+++ b/WebApp/client/public/bidirectional/js/main.js
@@ -8,10 +8,24 @@ textForConnectionId.value = getRandom();
 let videoSelect = document.querySelector('select#videoSource');
 let audioSelect = document.querySelector('select#audioSource');
 
+const codecPreferences = document.getElementById('codecPreferences');
+const supportsSetCodecPreferences = window.RTCRtpTransceiver &&
+  'setCodecPreferences' in window.RTCRtpTransceiver.prototype;
+const messageDiv = document.getElementById('message');
+messageDiv.style.display = 'none';
+
 setUpInputSelect();
+showCodecSelect();
 
 let sendVideo = new SendVideo();
-sendVideo.ondisconnect = () => hangUp();
+sendVideo.ondisconnect = async (message) => {
+  if (message) {
+    messageDiv.style.display = 'block';
+    messageDiv.innerText = message;
+  }
+
+  await hangUp();
+};
 
 let useWebSocket;
 let connectionId;
@@ -55,15 +69,33 @@ async function setUp() {
   setupButton.disabled = true;
   hangUpButton.disabled = false;
   connectionId = textForConnectionId.value;
-  await sendVideo.setupConnection(remoteVideo, connectionId, useWebSocket);
+
+  let selectedCodecs = null;
+  if (supportsSetCodecPreferences) {
+    const preferredCodec = codecPreferences.options[codecPreferences.selectedIndex];
+    if (preferredCodec.value !== '') {
+      const [mimeType, sdpFmtpLine] = preferredCodec.value.split(' ');
+      const { codecs } = RTCRtpSender.getCapabilities('video');
+      const selectedCodecIndex = codecs.findIndex(c => c.mimeType === mimeType && c.sdpFmtpLine === sdpFmtpLine);
+      const selectCodec = codecs[selectedCodecIndex];
+      selectedCodecs = [selectCodec];
+      console.log('Preferred video codec', selectedCodecs);
+    }
+  }
+  codecPreferences.disabled = true;
+
+  await sendVideo.setupConnection(remoteVideo, connectionId, useWebSocket, selectedCodecs);
 }
 
-function hangUp() {
+async function hangUp() {
   hangUpButton.disabled = true;
   setupButton.disabled = false;
-  sendVideo.hangUp(connectionId);
+  await sendVideo.hangUp(connectionId);
   textForConnectionId.value = getRandom();
   connectionId = null;
+  if (supportsSetCodecPreferences) {
+    codecPreferences.disabled = false;
+  }
 }
 
 function getRandom() {
@@ -80,14 +112,61 @@ async function setUpInputSelect() {
     const deviceInfo = deviceInfos[i];
     if (deviceInfo.kind === 'videoinput') {
       const option = document.createElement('option');
-      option.value = deviceInfo.deviceId;  
+      option.value = deviceInfo.deviceId;
       option.text = deviceInfo.label || `camera ${videoSelect.length + 1}`;
       videoSelect.appendChild(option);
     } else if (deviceInfo.kind === 'audioinput') {
       const option = document.createElement('option');
-      option.value = deviceInfo.deviceId;  
+      option.value = deviceInfo.deviceId;
       option.text = deviceInfo.label || `mic ${audioSelect.length + 1}`;
       audioSelect.appendChild(option);
     }
   }
+}
+
+function showCodecSelect() {
+  if (!supportsSetCodecPreferences) {
+    return;
+  }
+
+  const codecs = RTCRtpSender.getCapabilities('video').codecs;
+  codecs.forEach(codec => {
+    if (['video/red', 'video/ulpfec', 'video/rtx'].includes(codec.mimeType)) {
+      return;
+    }
+    const option = document.createElement('option');
+    option.value = (codec.mimeType + ' ' + (codec.sdpFmtpLine || '')).trim();
+    option.innerText = option.value;
+    codecPreferences.appendChild(option);
+  });
+  codecPreferences.disabled = false;
+
+  // Display the video codec that is actually used.
+  setInterval(async () => {
+    if (sendVideo == null || connectionId == null) {
+      return;
+    }
+
+    const stats = await sendVideo.getStats(connectionId);
+    if (stats == null) {
+      return;
+    }
+
+    let message = "";
+    stats.forEach(stat => {
+      if (stat.type === 'inbound-rtp' && stat.kind === 'video' && stat.codecId !== undefined) {
+        const codec = stats.get(stat.codecId);
+        message += `Using for receive video ${codec.mimeType} ${codec.sdpFmtpLine}, payloadType=${codec.payloadType}. Decoder: ${stat.decoderImplementation} \n`;
+      }
+      if (stat.type === 'outbound-rtp' && stat.kind === 'video' && stat.codecId !== undefined) {
+        const codec = stats.get(stat.codecId);
+        message += `Using for send video ${codec.mimeType} ${codec.sdpFmtpLine}, payloadType=${codec.payloadType}. Encoder: ${stat.encoderImplementation} \n`;
+      }
+    });
+
+    if (message != "") {
+      messageDiv.style.display = 'block';
+      messageDiv.innerText = message;
+    }
+  }, 1000);
 }

--- a/WebApp/client/public/bidirectional/js/main.js
+++ b/WebApp/client/public/bidirectional/js/main.js
@@ -79,7 +79,6 @@ async function setUp() {
       const selectedCodecIndex = codecs.findIndex(c => c.mimeType === mimeType && c.sdpFmtpLine === sdpFmtpLine);
       const selectCodec = codecs[selectedCodecIndex];
       selectedCodecs = [selectCodec];
-      console.log('Preferred video codec', selectedCodecs);
     }
   }
   codecPreferences.disabled = true;

--- a/WebApp/client/public/bidirectional/js/main.js
+++ b/WebApp/client/public/bidirectional/js/main.js
@@ -16,6 +16,7 @@ messageDiv.style.display = 'none';
 
 setUpInputSelect();
 showCodecSelect();
+showStatsMessage();
 
 let sendVideo = new SendVideo();
 sendVideo.ondisconnect = async (message) => {
@@ -125,6 +126,8 @@ async function setUpInputSelect() {
 
 function showCodecSelect() {
   if (!supportsSetCodecPreferences) {
+    messageDiv.style.display = 'block';
+    messageDiv.innerHTML = `Current Browser does not support <a href="https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/setCodecPreferences">RTCRtpTransceiver.setCodecPreferences</a>.`;
     return;
   }
 
@@ -139,8 +142,9 @@ function showCodecSelect() {
     codecPreferences.appendChild(option);
   });
   codecPreferences.disabled = false;
+}
 
-  // Display the video codec that is actually used.
+function showStatsMessage() {
   setInterval(async () => {
     if (sendVideo == null || connectionId == null) {
       return;

--- a/WebApp/client/public/bidirectional/js/sendvideo.js
+++ b/WebApp/client/public/bidirectional/js/sendvideo.js
@@ -7,7 +7,8 @@ export class SendVideo {
     this.pc = null;
     this.localVideo = null;
     this.remoteVideo = null;
-    this.ondisconnect = function () { };
+    this.preferedCodecs = null;
+    this.ondisconnect = function (message) { Logger.log(`Disconnect peer. message:${message}`) };
   }
 
   async startVideo(localVideo, videoSource, audioSource) {
@@ -25,9 +26,10 @@ export class SendVideo {
     }
   }
 
-  async setupConnection(remoteVideo, connectionId, useWebSocket) {
+  async setupConnection(remoteVideo, connectionId, useWebSocket, codecs) {
     const _this = this;
     this.remoteVideo = remoteVideo;
+    this.preferedCodecs = codecs;
 
     if (useWebSocket) {
       this.signaling = new WebSocketSignaling();
@@ -44,7 +46,7 @@ export class SendVideo {
     this.signaling.addEventListener('disconnect', async (e) => {
       const data = e.detail;
       if (_this.pc != null && _this.pc.connectionId == data.connectionId) {
-        _this.ondisconnect();
+        _this.ondisconnect(`Receive disconnect message from server. connectionId:${data.connectionId}`);
       }
     });
 
@@ -55,14 +57,22 @@ export class SendVideo {
         _this.addTracks(offer.connectionId);
       }
       const desc = new RTCSessionDescription({ sdp: offer.sdp, type: "offer" });
-      await _this.pc.onGotDescription(offer.connectionId, desc);
+      try {
+        await _this.pc.onGotDescription(offer.connectionId, desc);
+      } catch (error) {
+        _this.ondisconnect(`Error happen on GotDescription that description.\n Message: ${error}\n RTCSdpType:${desc.type}\n sdp:${desc.sdp}`);
+      }
     });
 
     this.signaling.addEventListener('answer', async (e) => {
       const answer = e.detail;
       const desc = new RTCSessionDescription({ sdp: answer.sdp, type: "answer" });
       if (_this.pc != null) {
-        await _this.pc.onGotDescription(answer.connectionId, desc);
+        try {
+          await _this.pc.onGotDescription(answer.connectionId, desc);
+        } catch (error) {
+          _this.ondisconnect(`Error happen on GotDescription that description.\n Message: ${error}\n RTCSdpType:${desc.type}\n sdp:${desc.sdp}`);
+        }
       }
     });
 
@@ -88,9 +98,9 @@ export class SendVideo {
     }
 
     // Create peerConnection with proxy server and set up handlers
-    this.pc = new Peer(connectionId, polite);
+    this.pc = new Peer(connectionId, polite, this.preferedCodecs);
     this.pc.addEventListener('disconnect', () => {
-      _this.ondisconnect();
+      _this.ondisconnect(`Receive disconnect message from peer.`);
     });
     this.pc.addEventListener('trackevent', (e) => {
       const trackEvent = e.detail;
@@ -119,9 +129,13 @@ export class SendVideo {
   addTracks(connectionId) {
     const _this = this;
     const tracks = _this.localVideo.srcObject.getTracks();
-    for(const track of tracks) {
+    for (const track of tracks) {
       _this.pc.addTrack(connectionId, track);
     }
+  }
+
+  async getStats(connectionId) {
+    return await this.pc.getStats(connectionId)
   }
 
   async hangUp(connectionId) {

--- a/WebApp/client/public/bidirectional/js/sendvideo.js
+++ b/WebApp/client/public/bidirectional/js/sendvideo.js
@@ -8,7 +8,7 @@ export class SendVideo {
     this.localVideo = null;
     this.remoteVideo = null;
     this.preferedCodecs = null;
-    this.ondisconnect = function (message) { Logger.log(`Disconnect peer. message:${message}`) };
+    this.ondisconnect = function (message) { Logger.log(`Disconnect peer. message:${message}`); };
   }
 
   async startVideo(localVideo, videoSource, audioSource) {
@@ -135,7 +135,7 @@ export class SendVideo {
   }
 
   async getStats(connectionId) {
-    return await this.pc.getStats(connectionId)
+    return await this.pc.getStats(connectionId);
   }
 
   async hangUp(connectionId) {

--- a/WebApp/client/public/css/main.css
+++ b/WebApp/client/public/css/main.css
@@ -79,6 +79,16 @@ div#warning {
   border: 1px solid transparent;
 }
 
+div.box {
+  margin: 1em;
+}
+
+div#message {
+  border-top: 1px solid #666;
+  margin: 1em;
+  padding: 1em;
+}
+
 @media screen and (max-width: 650px) {
   .highlight {
     font-size: 1em;

--- a/WebApp/client/public/multiplay/index.html
+++ b/WebApp/client/public/multiplay/index.html
@@ -26,7 +26,7 @@
     </div>
 
     <p>For more information about <code>Multiplay</code> sample, see <a
-        href="https://docs.unity3d.com/Packages/com.unity.renderstreaming@latest/sample-browserinput.html">Multiplay
+        href="https://docs.unity3d.com/Packages/com.unity.renderstreaming@3.1/manual/sample-browserinput.html">Multiplay
         sample</a> document page.</p>
 
     <div id="message"></div>

--- a/WebApp/client/public/multiplay/index.html
+++ b/WebApp/client/public/multiplay/index.html
@@ -18,8 +18,18 @@
 
     <div id="player"></div>
 
-    <p>For more information about <code>Multiplay</code> sample, see <a href="https://docs.unity3d.com/Packages/com.unity.renderstreaming@latest/sample-browserinput.html">Multiplay
-      sample</a> document page.</p>
+    <div class="box">
+      <span>Codec preferences:</span>
+      <select id="codecPreferences" disabled>
+        <option selected value="">Default</option>
+      </select>
+    </div>
+
+    <p>For more information about <code>Multiplay</code> sample, see <a
+        href="https://docs.unity3d.com/Packages/com.unity.renderstreaming@latest/sample-browserinput.html">Multiplay
+        sample</a> document page.</p>
+
+    <div id="message"></div>
 
     <section>
       <a href="https://github.com/Unity-Technologies/UnityRenderStreaming/tree/develop/WebApp/public/multiplay"

--- a/WebApp/client/public/multiplay/js/main.js
+++ b/WebApp/client/public/multiplay/js/main.js
@@ -178,7 +178,7 @@ function showStatsMessage() {
       return;
     }
     stats.forEach(stat => {
-      if (!(stat.type === 'inbound-rtp' && stat.kind === 'video')) {
+      if (!(stat.type === 'inbound-rtp' && stat.kind === 'video') || stat.codecId === undefined) {
         return;
       }
       const codec = stats.get(stat.codecId);

--- a/WebApp/client/public/multiplay/js/main.js
+++ b/WebApp/client/public/multiplay/js/main.js
@@ -127,7 +127,7 @@ async function setupVideoPlayer(elements) {
   return videoPlayer;
 }
 
-function onDisconnect() {
+function onDisconnect(message) {
   if (message) {
     messageDiv.style.display = 'block';
     messageDiv.innerText = message;

--- a/WebApp/client/public/multiplay/js/main.js
+++ b/WebApp/client/public/multiplay/js/main.js
@@ -36,6 +36,7 @@ async function setup() {
   useWebSocket = res.useWebSocket;
   showWarningIfNeeded(res.startupMode);
   showCodecSelect();
+  showStatsMessage();
   showPlayButton();
 }
 
@@ -148,6 +149,8 @@ function clearChildren(element) {
 
 function showCodecSelect() {
   if (!supportsSetCodecPreferences) {
+    messageDiv.style.display = 'block';
+    messageDiv.innerHTML = `Current Browser does not support <a href="https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/setCodecPreferences">RTCRtpTransceiver.setCodecPreferences</a>.`;
     return;
   }
 
@@ -162,8 +165,9 @@ function showCodecSelect() {
     codecPreferences.appendChild(option);
   });
   codecPreferences.disabled = false;
+}
 
-  // Display the video codec that is actually used.
+function showStatsMessage() {
   setInterval(async () => {
     if (videoPlayer == null) {
       return;

--- a/WebApp/client/public/multiplay/js/video-player.js
+++ b/WebApp/client/public/multiplay/js/video-player.js
@@ -137,7 +137,9 @@ export class VideoPlayer {
     // It can receive two video tracks and one audio track from Unity app.
     // This operation is required to generate offer SDP correctly.
     const transceiver = this.pc.addTransceiver('video', { direction: 'recvonly' });
-    transceiver.setCodecPreferences(codecs);
+    if (codecs) {
+      transceiver.setCodecPreferences(codecs);
+    }
 
     // create offer
     const offer = await this.pc.createOffer();

--- a/WebApp/client/public/multiplay/js/video-player.js
+++ b/WebApp/client/public/multiplay/js/video-player.js
@@ -115,7 +115,11 @@ export class VideoPlayer {
     this.signaling.addEventListener('candidate', async (e) => {
       const candidate = e.detail;
       const iceCandidate = new RTCIceCandidate({ candidate: candidate.candidate, sdpMid: candidate.sdpMid, sdpMLineIndex: candidate.sdpMLineIndex });
-      await _this.pc.addIceCandidate(iceCandidate);
+      try {
+        await _this.pc.addIceCandidate(iceCandidate);
+      } catch (e) {
+        Logger.warn(e);
+      }
     });
 
     // setup signaling

--- a/WebApp/client/public/multiplay/js/video-player.js
+++ b/WebApp/client/public/multiplay/js/video-player.js
@@ -59,7 +59,7 @@ export class VideoPlayer {
       _this.resizeVideo();
     }, true);
 
-    this.ondisconnect = function (message) { Logger.log(`Disconnect peer. message:${message}`) };
+    this.ondisconnect = function (message) { Logger.log(`Disconnect peer. message:${message}`); };
   }
 
   async setupConnection(useWebSocket, codecs) {
@@ -149,7 +149,7 @@ export class VideoPlayer {
   }
 
   async getStats() {
-    return await this.pc.getStats(this.connectionId)
+    return await this.pc.getStats(this.connectionId);
   }
 
   resizeVideo() {

--- a/WebApp/client/public/multiplay/js/video-player.js
+++ b/WebApp/client/public/multiplay/js/video-player.js
@@ -1,6 +1,6 @@
 import {
   Signaling,
-  WebSocketSignaling 
+  WebSocketSignaling
 } from "../../js/signaling.js";
 
 import {
@@ -8,8 +8,8 @@ import {
   Sender
 } from "../../js/sender.js";
 
-import { 
-  InputRemoting 
+import {
+  InputRemoting
 } from "../../js/inputremoting.js";
 
 
@@ -30,8 +30,8 @@ function uuid4() {
 
 function isTouchDevice() {
   return (('ontouchstart' in window) ||
-     (navigator.maxTouchPoints > 0) ||
-     (navigator.msMaxTouchPoints > 0));
+    (navigator.maxTouchPoints > 0) ||
+    (navigator.msMaxTouchPoints > 0));
 }
 
 export class VideoPlayer {
@@ -44,7 +44,7 @@ export class VideoPlayer {
     this.sender = new Sender(elements[0]);
     this.sender.addMouse();
     this.sender.addKeyboard();
-    if(isTouchDevice()) {
+    if (isTouchDevice()) {
       this.sender.addTouchscreen();
     }
     this.sender.addGamepad();
@@ -59,10 +59,10 @@ export class VideoPlayer {
       _this.resizeVideo();
     }, true);
 
-    this.ondisconnect = function () { };
+    this.ondisconnect = function (message) { Logger.log(`Disconnect peer. message:${message}`) };
   }
 
-  async setupConnection(useWebSocket) {
+  async setupConnection(useWebSocket, codecs) {
     const _this = this;
     // close current RTCPeerConnection
     if (this.pc) {
@@ -86,15 +86,15 @@ export class VideoPlayer {
       Logger.log('iceConnectionState changed:', e);
       Logger.log('pc.iceConnectionState:' + _this.pc.iceConnectionState);
       if (_this.pc.iceConnectionState === 'disconnected') {
-        _this.ondisconnect();
+        _this.ondisconnect(`Receive disconnect message from peer. connectionId:${this.connectionId}`);
       }
     };
     this.pc.onicegatheringstatechange = function (e) {
       Logger.log('iceGatheringState changed:', e);
     };
     this.pc.ontrack = function (e) {
-        this.localStream.addTrack(e.track);
-        this.video.srcObject = this.localStream;
+      this.localStream.addTrack(e.track);
+      this.video.srcObject = this.localStream;
     }.bind(this);
     this.pc.onicecandidate = function (e) {
       if (e.candidate != null) {
@@ -105,7 +105,11 @@ export class VideoPlayer {
     this.signaling.addEventListener('answer', async (e) => {
       const answer = e.detail;
       const desc = new RTCSessionDescription({ sdp: answer.sdp, type: "answer" });
-      await _this.pc.setRemoteDescription(desc);
+      try {
+        await _this.pc.setRemoteDescription(desc);
+      } catch (error) {
+        _this.ondisconnect(`Error happen on setRemoteDescription.\n Message: ${error}\n RTCSdpType:${desc.type}\n sdp:${desc.sdp}`);
+      }
     });
 
     this.signaling.addEventListener('candidate', async (e) => {
@@ -118,6 +122,9 @@ export class VideoPlayer {
     await this.signaling.start();
     this.connectionId = uuid4();
 
+    // register using connectionId
+    await this.signaling.createConnection(this.connectionId);
+
     // Create data channel with proxy server and set up handlers
     this.inputSenderChannel = this.pc.createDataChannel("input");
     this.inputSenderChannel.onopen = this._onOpenInputSenderChannel.bind(this);
@@ -129,7 +136,8 @@ export class VideoPlayer {
     // Add transceivers to receive multi stream.
     // It can receive two video tracks and one audio track from Unity app.
     // This operation is required to generate offer SDP correctly.
-    this.pc.addTransceiver('video', { direction: 'recvonly' });
+    const transceiver = this.pc.addTransceiver('video', { direction: 'recvonly' });
+    transceiver.setCodecPreferences(codecs);
 
     // create offer
     const offer = await this.pc.createOffer();
@@ -138,6 +146,10 @@ export class VideoPlayer {
     const desc = new RTCSessionDescription({ sdp: offer.sdp, type: "offer" });
     await this.pc.setLocalDescription(desc);
     await this.signaling.sendOffer(this.connectionId, offer.sdp);
+  }
+
+  async getStats() {
+    return await this.pc.getStats(this.connectionId)
   }
 
   resizeVideo() {
@@ -192,7 +204,7 @@ export class VideoPlayer {
   }
 
   _changeLabel(label) {
-    const json = JSON.stringify({type: ActionType.ChangeLabel, argument: label});
+    const json = JSON.stringify({ type: ActionType.ChangeLabel, argument: label });
     this.multiplayChannel.send(json);
   }
 

--- a/WebApp/client/public/receiver/css/style.css
+++ b/WebApp/client/public/receiver/css/style.css
@@ -2,6 +2,10 @@ body {
   margin: 0px;
 }
 
+div.box {
+  margin: 1em;
+}
+
 #player {
   position: relative;
   top: 0;

--- a/WebApp/client/public/receiver/css/style.css
+++ b/WebApp/client/public/receiver/css/style.css
@@ -2,10 +2,6 @@ body {
   margin: 0px;
 }
 
-div.box {
-  margin: 1em;
-}
-
 #player {
   position: relative;
   top: 0;

--- a/WebApp/client/public/receiver/index.html
+++ b/WebApp/client/public/receiver/index.html
@@ -14,17 +14,19 @@
   <div id="container">
     <h1>Receiver Sample</h1>
 
-    <div id="warning" hidden=true></div>
+    <div id="warning" hidden="true"></div>
 
     <div id="player"></div>
 
     <div class="box">
       <span>Codec preferences:</span>
       <select id="codecPreferences" disabled>
-          <option selected value="">Default</option>
+        <option selected value="">Default</option>
       </select>
       <div id="actualCodec"></div>
-  </div>
+    </div>
+
+    <div class="box" id="message"></div>
 
     <section>
       <a href="https://github.com/Unity-Technologies/UnityRenderStreaming/tree/develop/WebApp/client/public/receiver"

--- a/WebApp/client/public/receiver/index.html
+++ b/WebApp/client/public/receiver/index.html
@@ -18,6 +18,14 @@
 
     <div id="player"></div>
 
+    <div class="box">
+      <span>Codec preferences:</span>
+      <select id="codecPreferences" disabled>
+          <option selected value="">Default</option>
+      </select>
+      <div id="actualCodec"></div>
+  </div>
+
     <section>
       <a href="https://github.com/Unity-Technologies/UnityRenderStreaming/tree/develop/WebApp/client/public/receiver"
         title="View source for this page on GitHub" id="viewSource">View source on GitHub</a>

--- a/WebApp/client/public/receiver/index.html
+++ b/WebApp/client/public/receiver/index.html
@@ -23,10 +23,9 @@
       <select id="codecPreferences" disabled>
         <option selected value="">Default</option>
       </select>
-      <div id="actualCodec"></div>
     </div>
 
-    <div class="box" id="message"></div>
+    <div id="message"></div>
 
     <section>
       <a href="https://github.com/Unity-Technologies/UnityRenderStreaming/tree/develop/WebApp/client/public/receiver"

--- a/WebApp/client/public/receiver/js/main.js
+++ b/WebApp/client/public/receiver/js/main.js
@@ -32,6 +32,7 @@ async function setup() {
   showWarningIfNeeded(res.startupMode);
   showCodecSelect();
   showPlayButton();
+  showStatsMessage();
 }
 
 function showWarningIfNeeded(startupMode) {
@@ -146,6 +147,8 @@ function clearChildren(element) {
 
 function showCodecSelect() {
   if (!supportsSetCodecPreferences) {
+    messageDiv.style.display = 'block';
+    messageDiv.innerHTML = `Current Browser does not support <a href="https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/setCodecPreferences">RTCRtpTransceiver.setCodecPreferences</a>.`;
     return;
   }
 
@@ -160,8 +163,9 @@ function showCodecSelect() {
     codecPreferences.appendChild(option);
   });
   codecPreferences.disabled = false;
+}
 
-  // Display the video codec that is actually used.
+function showStatsMessage() {
   setInterval(async () => {
     if (receiver == null) {
       return;

--- a/WebApp/client/public/receiver/js/main.js
+++ b/WebApp/client/public/receiver/js/main.js
@@ -113,9 +113,6 @@ async function setupVideoPlayer(elements) {
       const selectedCodecIndex = codecs.findIndex(c => c.mimeType === mimeType && c.sdpFmtpLine === sdpFmtpLine);
       const selectCodec = codecs[selectedCodecIndex];
       selectedCodecs = [selectCodec];
-      // codecs.splice(selectedCodecIndex, 1);
-      // codecs.unshift(selectedCodec);
-      console.log('Preferred video codec', selectedCodecs);
     }
   }
   codecPreferences.disabled = true;

--- a/WebApp/client/public/receiver/js/main.js
+++ b/WebApp/client/public/receiver/js/main.js
@@ -176,7 +176,7 @@ function showStatsMessage() {
       return;
     }
     stats.forEach(stat => {
-      if (!(stat.type === 'inbound-rtp' && stat.kind === 'video')) {
+      if (!(stat.type === 'inbound-rtp' && stat.kind === 'video') || stat.codecId === undefined) {
         return;
       }
       const codec = stats.get(stat.codecId);

--- a/WebApp/client/public/receiver/js/main.js
+++ b/WebApp/client/public/receiver/js/main.js
@@ -12,6 +12,7 @@ const codecPreferences = document.getElementById('codecPreferences');
 const supportsSetCodecPreferences = window.RTCRtpTransceiver &&
   'setCodecPreferences' in window.RTCRtpTransceiver.prototype;
 const messageDiv = document.getElementById('message');
+messageDiv.style.display = 'none';
 
 window.document.oncontextmenu = function () {
   return false;     // cancel default menu
@@ -54,7 +55,6 @@ function showPlayButton() {
 
 function onClickPlayButton() {
 
-  messageDiv.style.hidden = true;
   playButton.style.display = 'none';
 
   // add video player
@@ -128,8 +128,8 @@ async function setupVideoPlayer(elements) {
 
 async function onDisconnect(message) {
   if (message) {
+    messageDiv.style.display = 'block';
     messageDiv.innerText = message;
-    messageDiv.style.hidden = false;
   }
 
   clearChildren(playerDiv);
@@ -164,7 +164,6 @@ function showCodecSelect() {
   });
   codecPreferences.disabled = false;
 
-  const actualCodec = document.getElementById('actualCodec');
   // Display the video codec that is actually used.
   setInterval(async () => {
     if (receiver == null) {
@@ -180,7 +179,8 @@ function showCodecSelect() {
         return;
       }
       const codec = stats.get(stat.codecId);
-      actualCodec.innerText = `Using ${codec.mimeType} ${codec.sdpFmtpLine}, payloadType=${codec.payloadType}. Decoder: ${stat.decoderImplementation}`;
+      messageDiv.style.display = 'block';
+      messageDiv.innerText = `Using ${codec.mimeType} ${codec.sdpFmtpLine}, payloadType=${codec.payloadType}. Decoder: ${stat.decoderImplementation}`;
     });
   }, 1000);
 }

--- a/WebApp/client/public/receiver/js/main.js
+++ b/WebApp/client/public/receiver/js/main.js
@@ -11,6 +11,7 @@ const playerDiv = document.getElementById('player');
 const codecPreferences = document.getElementById('codecPreferences');
 const supportsSetCodecPreferences = window.RTCRtpTransceiver &&
   'setCodecPreferences' in window.RTCRtpTransceiver.prototype;
+const messageDiv = document.getElementById('message');
 
 window.document.oncontextmenu = function () {
   return false;     // cancel default menu
@@ -53,6 +54,7 @@ function showPlayButton() {
 
 function onClickPlayButton() {
 
+  messageDiv.style.hidden = true;
   playButton.style.display = 'none';
 
   // add video player
@@ -124,9 +126,14 @@ async function setupVideoPlayer(elements) {
   return videoPlayer;
 }
 
-function onDisconnect() {
+async function onDisconnect(message) {
+  if (message) {
+    messageDiv.innerText = message;
+    messageDiv.style.hidden = false;
+  }
+
   clearChildren(playerDiv);
-  receiver.stop();
+  await receiver.stop();
   receiver = null;
   if (supportsSetCodecPreferences) {
     codecPreferences.disabled = false;

--- a/WebApp/client/public/receiver/js/receiver.js
+++ b/WebApp/client/public/receiver/js/receiver.js
@@ -46,7 +46,7 @@ export class Receiver {
     this.ondisconnect = function () { };
   }
 
-  async setupConnection(useWebSocket) {
+  async setupConnection(useWebSocket, codecs) {
     const _this = this;
     // close current RTCPeerConnection
     if (this.pc) {
@@ -64,7 +64,7 @@ export class Receiver {
     this.connectionId = uuid4();
 
     // Create peerConnection with proxy server and set up handlers
-    this.pc = new Peer(this.connectionId, true);
+    this.pc = new Peer(this.connectionId, true, codecs);
     this.pc.addEventListener('disconnect', () => {
       _this.ondisconnect();
     });
@@ -125,6 +125,10 @@ export class Receiver {
     this.inputSenderChannel = this.pc.createDataChannel(this.connectionId, "input");
     this.inputSenderChannel.onopen = this._onOpenInputSenderChannel.bind(this);
     this.inputRemoting.subscribe(new Observer(this.inputSenderChannel));
+  }
+
+  async getStats() {
+    return await this.pc.getStats(this.connectionId)
   }
 
   resizeVideo() {

--- a/WebApp/client/public/receiver/js/receiver.js
+++ b/WebApp/client/public/receiver/js/receiver.js
@@ -43,7 +43,7 @@ export class Receiver {
     }, true);
     this.video.srcObject = this.localStream;
 
-    this.ondisconnect = function (message) { Logger.log(`Disconnect peer. message:${message}`) };
+    this.ondisconnect = function (message) { Logger.log(`Disconnect peer. message:${message}`); };
   }
 
   async setupConnection(useWebSocket, codecs) {
@@ -138,7 +138,7 @@ export class Receiver {
   }
 
   async getStats() {
-    return await this.pc.getStats(this.connectionId)
+    return await this.pc.getStats(this.connectionId);
   }
 
   resizeVideo() {

--- a/WebApp/client/public/receiver/js/receiver.js
+++ b/WebApp/client/public/receiver/js/receiver.js
@@ -128,6 +128,8 @@ export class Receiver {
 
     // setup signaling
     await this.signaling.start();
+    // register using connectionId
+    await this.signaling.createConnection(this.connectionId);
 
     // kick send offer process
     this.inputSenderChannel = this.pc.createDataChannel(this.connectionId, "input");

--- a/WebApp/client/test/peerconnection.test.js
+++ b/WebApp/client/test/peerconnection.test.js
@@ -28,14 +28,14 @@ describe(`peer connection test`, () => {
     expect(peer.pc).toBeNull();
   });
 
-  test(`transceiver direction is sendonly if using addtrack`, () => {
+  test(`transceiver direction is sendrecv if using addtrack`, () => {
     const peer = new Peer(connectionId, true);
     expect(peer).not.toBeNull();
 
     const track = { id: getUniqueId(), kind: "audio" };
     const sender = peer.addTrack(connectionId, track);
     const transceiver = peer.getTransceivers(connectionId).find(t => t.sender == sender);
-    expect(transceiver.direction).toBe("sendonly");
+    expect(transceiver.direction).toBe("sendrecv");
   });
 
   test(`fire trackevent when addtrack`, async () => {
@@ -99,7 +99,7 @@ describe(`peer connection test`, () => {
   test(`re-fire sendoffer if get answer not yet`, async () => {
     let sendOfferCount = 0;
     let offer;
-    const peer = new Peer(connectionId, true, 100);
+    const peer = new Peer(connectionId, true, null, 100);
     expect(peer).not.toBeNull();
     peer.addEventListener('sendoffer', (e) => {
       offer = e.detail;

--- a/WebApp/client/test/peerconnectionmock.js
+++ b/WebApp/client/test/peerconnectionmock.js
@@ -79,7 +79,7 @@ export default class PeerConnectionMock extends EventTarget {
     } else {
       this.videoTracks.set(track.id, track);
     }
-    const transceiver = { sender: { direction: "sendrecv", track: track }, receiver: null };
+    const transceiver = { direction: "sendrecv", sender: { track: track }, receiver: null, setCodecPreferences: (codecs) => { } };
     this.transceivers.set(this.transceiverCount++, transceiver);
     this.fireOnNegotiationNeeded();
     return transceiver.sender;
@@ -93,7 +93,7 @@ export default class PeerConnectionMock extends EventTarget {
       } else {
         this.videoTracks.set(track.id, track);
       }
-      const transceiver = { sender: { direction: "sendrecv", track: track }, receiver: null };
+      const transceiver = { direction: "sendrecv", sender: { track: track }, receiver: null, setCodecPreferences: (codecs) => { } };
       this.transceivers.set(this.transceiverCount++, transceiver);
       this.fireOnNegotiationNeeded();
       return transceiver;
@@ -104,7 +104,7 @@ export default class PeerConnectionMock extends EventTarget {
     } else {
       this.videoTracks.set(trackOrKind.id, trackOrKind);
     }
-    const transceiver = { sender: { direction: "sendrecv", track: trackOrKind }, receiver: null };
+    const transceiver = { direction: "sendrecv", sender: { track: trackOrKind }, receiver: null, setCodecPreferences: (codecs) => { } };
     this.transceivers.set(this.transceiverCount++, transceiver);
     this.fireOnNegotiationNeeded();
     return transceiver;

--- a/WebApp/src/index.ts
+++ b/WebApp/src/index.ts
@@ -71,7 +71,7 @@ export class RenderStreaming {
     }
 
     if (this.options.websocket) {
-      console.log(`start websocket signaling server ws://${this.getIPAddress()[0]}`)
+      console.log(`start websocket signaling server ws://${this.getIPAddress()[0]}`);
       //Start Websocket Signaling server
       new WSSignaling(this.server, this.options.mode);
     }

--- a/WebApp/src/websocket.ts
+++ b/WebApp/src/websocket.ts
@@ -1,6 +1,6 @@
 import * as websocket from "ws";
 import { Server } from 'http';
-import * as handler from "./class/websockethandler"
+import * as handler from "./class/websockethandler";
 
 export default class WSSignaling {
   server: Server;
@@ -17,7 +17,7 @@ export default class WSSignaling {
 
       ws.onclose = (): void => {
         handler.remove(ws);
-      }
+      };
 
       ws.onmessage = (event: MessageEvent): void => {
 

--- a/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
@@ -55,8 +55,11 @@ namespace Unity.RenderStreaming.Samples
             microphoneSelectDropdown.onValueChanged.AddListener(index => microphoneStreamer.SetDeviceIndex(index));
             microphoneSelectDropdown.options =
                 microphoneStreamer.MicrophoneNameList.Select(x => new Dropdown.OptionData(x)).ToList();
-            microphoneStreamer.OnStartedStream += id => receiveAudioViewer.enabled = true;
-            receiveAudioViewer.SetSource(receiveAudioSource);
+            microphoneStreamer.OnStartedStream += id =>
+            {
+                receiveAudioViewer.SetSource(receiveAudioSource);
+                receiveAudioViewer.enabled = true;
+            };
             receiveAudioViewer.OnUpdateReceiveAudioSource += source =>
             {
                 source.loop = true;


### PR DESCRIPTION
- Add codec select option each sample on WebApp.
- Add message div for error message or stats about using codec  etc.
- Show error message if failed `onGotDescription` process.

example Receiver sample on got error.
![image](https://user-images.githubusercontent.com/26959415/169726069-896f7fc7-350f-4e0f-b50b-6f6c121f2ae2.png)
