### PR TITLE
Webserver pointer lock support

### DIFF
--- a/WebApp/client/public/receiver/index.html
+++ b/WebApp/client/public/receiver/index.html
@@ -26,6 +26,10 @@
     </div>
 
     <div id="message"></div>
+    <div class="box">
+      <span>Lock Cursor to Player:</span>
+        <input type="checkbox" id="lockMouseCheck">
+    </div>
 
     <section>
       <a href="https://github.com/Unity-Technologies/UnityRenderStreaming/tree/develop/WebApp/client/public/receiver"

--- a/WebApp/client/public/receiver/js/main.js
+++ b/WebApp/client/public/receiver/js/main.js
@@ -6,9 +6,11 @@ setup();
 let playButton;
 let receiver;
 let useWebSocket;
+let elementVideo;
 
 const playerDiv = document.getElementById('player');
 const codecPreferences = document.getElementById('codecPreferences');
+const lockMouseCheck = document.getElementById('lockMouseCheck');
 const supportsSetCodecPreferences = window.RTCRtpTransceiver &&
   'setCodecPreferences' in window.RTCRtpTransceiver.prototype;
 const messageDiv = document.getElementById('message');
@@ -59,7 +61,7 @@ function onClickPlayButton() {
   playButton.style.display = 'none';
 
   // add video player
-  const elementVideo = document.createElement('video');
+  elementVideo = document.createElement('video');
   elementVideo.id = 'Video';
   elementVideo.style.touchAction = 'none';
   playerDiv.appendChild(elementVideo);
@@ -87,17 +89,68 @@ function onClickPlayButton() {
       }
     }
   });
+  
   document.addEventListener('webkitfullscreenchange', onFullscreenChange);
   document.addEventListener('fullscreenchange', onFullscreenChange);
+
+  elementVideo.addEventListener("click", _mouseClick, false);
 
   function onFullscreenChange() {
     if (document.webkitFullscreenElement || document.fullscreenElement) {
       playerDiv.style.position = "absolute";
       elementFullscreenButton.style.display = 'none';
+
+      if (lockMouseCheck.checked) {
+        if (document.webkitFullscreenElement.requestPointerLock) {
+          document.webkitFullscreenElement.requestPointerLock();
+        } else if (document.fullscreenElement.requestPointerLock) {
+          document.fullscreenElement.requestPointerLock()
+        } else if (document.mozFullScreenElement.requestPointerLock) {
+          document.mozFullScreenElement.requestPointerLock()
+        }
+
+        // Subscribe to events
+        document.addEventListener('mousemove', _mouseMove, false);
+        document.addEventListener('click', _mouseClickFullScreen, false);
+      }
     }
     else {
       playerDiv.style.position = "relative";
       elementFullscreenButton.style.display = 'block';
+ 
+      document.removeEventListener('mousemove', _mouseMove, false);
+      document.removeEventListener('click', _mouseClickFullScreen, false);
+    }
+  }
+
+  function _mouseMove(event)
+  {
+    // Forward mouseMove event of fullscreen player directly to sender
+    // This is required, as the regular mousemove event doesn't fire when in fullscreen mode
+    receiver.sender._onMouseEvent(event);
+  }
+  
+  function _mouseClick(event)
+  {
+    // Restores pointer lock when we unfocus the player and click on it again
+    if (lockMouseCheck.checked) {
+      if (elementVideo.requestPointerLock) {
+        elementVideo.requestPointerLock().catch(function(error) {});
+      }
+    }
+  }
+  
+  function _mouseClickFullScreen(event)
+  {
+    // Restores pointer lock when we unfocus the fullscreen player and click on it again
+    if (lockMouseCheck.checked) {
+      if (document.webkitFullscreenElement.requestPointerLock) {
+        document.webkitFullscreenElement.requestPointerLock();
+      } else if (document.fullscreenElement.requestPointerLock) {
+        document.fullscreenElement.requestPointerLock();
+      } else if (document.mozFullScreenElement.requestPointerLock) {
+        document.mozFullScreenElement.requestPointerLock();
+      }
     }
   }
 }


### PR DESCRIPTION
The beginning of this video showcases the problem, the rest of it shows the solution in action:

https://user-images.githubusercontent.com/12199415/172070832-ca605fd2-8f80-4b7a-8d2a-096adc32bdcf.mp4

You are unable to rotate the camera farther than your screen size allows. This PR introduces a checkbox to the Receiver Sample that allows the Pointer to be locked into the player using `requestPointerLock()`, which allows full camera rotation independent of screen size.

Tested on Edge (Chromium) and Firefox. Final result:
![image](https://user-images.githubusercontent.com/12199415/172071408-47274395-3163-4093-8739-3f26ed724a9e.png)