### PR TITLE
feat: Add add/remove button and list view about codec select in Project Settings

### DIFF
--- a/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
@@ -44,29 +44,25 @@ namespace Unity.RenderStreaming
             // video codec setting control
             var videoCodecSetting = newVisualElement.Q<CodecSettings>("videoCodecSettings");
             videoCodecSetting.onChangeCodecs += codecSetting => UnityEngine.Debug.Log(string.Join(",", codecSetting));
-
-            var videoCodecFoldout = newVisualElement.Q<Foldout>("videoCodecSettingFoldout");
-            videoCodecFoldout.style.display = DisplayStyle.None;
+            videoCodecSetting.SetEnabled(false);
 
             var autoVideoCodecToggle = newVisualElement.Q<Toggle>("autoVideoCodecSettingToggle");
             autoVideoCodecToggle.value = true;
             autoVideoCodecToggle.RegisterCallback<ChangeEvent<bool>>(evt =>
             {
-                videoCodecFoldout.style.display = evt.newValue ? DisplayStyle.None : DisplayStyle.Flex;
+                videoCodecSetting.SetEnabled(!evt.newValue);
             });
 
             // audio codec setting control
             var audioCodecSetting = newVisualElement.Q<CodecSettings>("audioCodecSettings");
             audioCodecSetting.onChangeCodecs += codecSetting => UnityEngine.Debug.Log(string.Join(",", codecSetting));
-
-            var audioCodecFoldout = newVisualElement.Q<Foldout>("audioCodecSettingFoldout");
-            audioCodecFoldout.style.display = DisplayStyle.None;
+            audioCodecSetting.SetEnabled(false);
 
             var autoAudioCodecToggle = newVisualElement.Q<Toggle>("autoAudioCodecSettingToggle");
             autoAudioCodecToggle.value = true;
             autoAudioCodecToggle.RegisterCallback<ChangeEvent<bool>>(evt =>
             {
-                audioCodecFoldout.style.display = evt.newValue ? DisplayStyle.None : DisplayStyle.Flex;
+                audioCodecSetting.SetEnabled(!evt.newValue);
             });
         }
 

--- a/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Unity.RenderStreaming
@@ -39,11 +42,54 @@ namespace Unity.RenderStreaming
             VisualElement newVisualElement = new VisualElement();
             template.CloneTree(newVisualElement);
             rootVisualElement.Add(newVisualElement);
+
+            CreateVideoCodecSetting();
+        }
+
+        internal VisualElementCache cache;
+
+        private void CreateVideoCodecSetting()
+        {
+            cache = new VisualElementCache(videoCodecSettingContainer);
+
+            const int itemCount = 10;
+            var items = new List<string>(itemCount);
+            for (int i = 0; i <= itemCount; i++)
+                items.Add(i.ToString());
+            Func<VisualElement> makeItem = () => new Label();
+            Action<VisualElement, int> bindItem = (e, i) => (e as Label).text = items[i];
+            videoCodecList.makeItem = makeItem;
+            videoCodecList.bindItem = bindItem;
+            videoCodecList.itemsSource = items;
+            videoCodecList.selectionType = SelectionType.Multiple;
+            videoCodecList.itemHeight = 16;
+            videoCodecList.reorderable = true;
+            videoCodecList.style.height = videoCodecList.itemHeight * items.Count;
+
+            addScopeButton.clickable.clicked += () =>
+            {
+                var item = items.Count.ToString();
+                items.Add(item);
+                videoCodecList.style.height = videoCodecList.itemHeight * items.Count;
+                videoCodecList.Refresh();
+            };
+            removeScopeButton.clickable.clicked += () =>
+            {
+                items.Remove(items.Last());
+                videoCodecList.style.height = videoCodecList.itemHeight * items.Count;
+                videoCodecList.Refresh();
+            };
         }
 
         public RenderStreamingProjectSettingsProvider(string path, SettingsScope scopes, IEnumerable<string> keywords = null)
             : base(path, scopes, keywords)
         {
         }
+
+        private Foldout videoCodecSettingFoldout => rootVisualElement.Q<Foldout>("videoCodecSettingFoldout");
+        private VisualElement videoCodecSettingContainer => rootVisualElement.Q<VisualElement>("videoCodecSettingContainer");
+        private ListView videoCodecList => cache.Get<ListView>("videoCodecList");
+        private Button addScopeButton => cache.Get<Button>("addCodecButton");
+        private Button removeScopeButton => cache.Get<Button>("removeCodecButton");
     }
 }

--- a/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
-using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Unity.RenderStreaming
@@ -42,54 +39,11 @@ namespace Unity.RenderStreaming
             VisualElement newVisualElement = new VisualElement();
             template.CloneTree(newVisualElement);
             rootVisualElement.Add(newVisualElement);
-
-            CreateVideoCodecSetting();
-        }
-
-        internal VisualElementCache cache;
-
-        private void CreateVideoCodecSetting()
-        {
-            cache = new VisualElementCache(videoCodecSettingContainer);
-
-            const int itemCount = 10;
-            var items = new List<string>(itemCount);
-            for (int i = 0; i <= itemCount; i++)
-                items.Add(i.ToString());
-            Func<VisualElement> makeItem = () => new Label();
-            Action<VisualElement, int> bindItem = (e, i) => (e as Label).text = items[i];
-            videoCodecList.makeItem = makeItem;
-            videoCodecList.bindItem = bindItem;
-            videoCodecList.itemsSource = items;
-            videoCodecList.selectionType = SelectionType.Multiple;
-            videoCodecList.itemHeight = 16;
-            videoCodecList.reorderable = true;
-            videoCodecList.style.height = videoCodecList.itemHeight * items.Count;
-
-            addScopeButton.clickable.clicked += () =>
-            {
-                var item = items.Count.ToString();
-                items.Add(item);
-                videoCodecList.style.height = videoCodecList.itemHeight * items.Count;
-                videoCodecList.Refresh();
-            };
-            removeScopeButton.clickable.clicked += () =>
-            {
-                items.Remove(items.Last());
-                videoCodecList.style.height = videoCodecList.itemHeight * items.Count;
-                videoCodecList.Refresh();
-            };
         }
 
         public RenderStreamingProjectSettingsProvider(string path, SettingsScope scopes, IEnumerable<string> keywords = null)
             : base(path, scopes, keywords)
         {
         }
-
-        private Foldout videoCodecSettingFoldout => rootVisualElement.Q<Foldout>("videoCodecSettingFoldout");
-        private VisualElement videoCodecSettingContainer => rootVisualElement.Q<VisualElement>("videoCodecSettingContainer");
-        private ListView videoCodecList => cache.Get<ListView>("videoCodecList");
-        private Button addScopeButton => cache.Get<Button>("addCodecButton");
-        private Button removeScopeButton => cache.Get<Button>("removeCodecButton");
     }
 }

--- a/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Unity.RenderStreaming.Editor.UI;
 using UnityEditor;
 using UnityEngine.UIElements;
 
@@ -39,6 +40,34 @@ namespace Unity.RenderStreaming
             VisualElement newVisualElement = new VisualElement();
             template.CloneTree(newVisualElement);
             rootVisualElement.Add(newVisualElement);
+
+            // video codec setting control
+            var videoCodecSetting = newVisualElement.Q<CodecSettings>("videoCodecSettings");
+            videoCodecSetting.onChangeCodecs += codecSetting => UnityEngine.Debug.Log(string.Join(",", codecSetting));
+
+            var videoCodecFoldout = newVisualElement.Q<Foldout>("videoCodecSettingFoldout");
+            videoCodecFoldout.style.display = DisplayStyle.None;
+
+            var autoVideoCodecToggle = newVisualElement.Q<Toggle>("autoVideoCodecSettingToggle");
+            autoVideoCodecToggle.value = true;
+            autoVideoCodecToggle.RegisterCallback<ChangeEvent<bool>>(evt =>
+            {
+                videoCodecFoldout.style.display = evt.newValue ? DisplayStyle.None : DisplayStyle.Flex;
+            });
+
+            // audio codec setting control
+            var audioCodecSetting = newVisualElement.Q<CodecSettings>("audioCodecSettings");
+            audioCodecSetting.onChangeCodecs += codecSetting => UnityEngine.Debug.Log(string.Join(",", codecSetting));
+
+            var audioCodecFoldout = newVisualElement.Q<Foldout>("audioCodecSettingFoldout");
+            audioCodecFoldout.style.display = DisplayStyle.None;
+
+            var autoAudioCodecToggle = newVisualElement.Q<Toggle>("autoAudioCodecSettingToggle");
+            autoAudioCodecToggle.value = true;
+            autoAudioCodecToggle.RegisterCallback<ChangeEvent<bool>>(evt =>
+            {
+                audioCodecFoldout.style.display = evt.newValue ? DisplayStyle.None : DisplayStyle.Flex;
+            });
         }
 
         public RenderStreamingProjectSettingsProvider(string path, SettingsScope scopes, IEnumerable<string> keywords = null)

--- a/com.unity.renderstreaming/Editor/Styles/CodecSettings.uss
+++ b/com.unity.renderstreaming/Editor/Styles/CodecSettings.uss
@@ -1,0 +1,7 @@
+#codecSettingContainer .bottom-buttons {
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-top: auto;
+  padding: 2px 0;
+  flex-shrink: 0;
+}

--- a/com.unity.renderstreaming/Editor/Styles/CodecSettings.uss.meta
+++ b/com.unity.renderstreaming/Editor/Styles/CodecSettings.uss.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 89ce5644b1814632b3026f7e5ec3b7b3
+timeCreated: 1659055582

--- a/com.unity.renderstreaming/Editor/Styles/RenderStreamingProjectSettings.uss
+++ b/com.unity.renderstreaming/Editor/Styles/RenderStreamingProjectSettings.uss
@@ -36,12 +36,3 @@ Foldout {
 Foldout Label {
   margin: 2px 0 0 3px;
 }
-
-
-#videoCodecSettingContainer .bottom-buttons {
-  flex-direction: row;
-  justify-content: flex-end;
-  margin-top: auto;
-  padding: 2px 0;
-  flex-shrink: 0;
-}

--- a/com.unity.renderstreaming/Editor/Styles/RenderStreamingProjectSettings.uss
+++ b/com.unity.renderstreaming/Editor/Styles/RenderStreamingProjectSettings.uss
@@ -36,3 +36,12 @@ Foldout {
 Foldout Label {
   margin: 2px 0 0 3px;
 }
+
+
+#videoCodecSettingContainer .bottom-buttons {
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-top: auto;
+  padding: 2px 0;
+  flex-shrink: 0;
+}

--- a/com.unity.renderstreaming/Editor/UI.meta
+++ b/com.unity.renderstreaming/Editor/UI.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ce61fa6dbbab4704a4317b11bf4e719d
+timeCreated: 1659055840

--- a/com.unity.renderstreaming/Editor/UI/CodecSettings.cs
+++ b/com.unity.renderstreaming/Editor/UI/CodecSettings.cs
@@ -66,6 +66,8 @@ namespace Unity.RenderStreaming.Editor.UI
 #if UNITY_2021_3_OR_NEWER
             codecList.reorderMode = ListViewReorderMode.Animated;
             codecList.itemIndexChanged += (b, a) => NotifyChangeCodecList();
+            codecList.itemsAdded += addItems => NotifyChangeCodecList();
+            codecList.itemsRemoved += removeItems => NotifyChangeCodecList();
 #endif
 
             var contextualMenuManipulator = new ContextualMenuManipulator((evt) =>
@@ -88,7 +90,6 @@ namespace Unity.RenderStreaming.Editor.UI
                 draft.Add(data);
             }
 
-            NotifyChangeCodecList();
             UpdateCodecList();
         }
 
@@ -99,7 +100,6 @@ namespace Unity.RenderStreaming.Editor.UI
                 draft.Remove(selectItem);
             }
 
-            NotifyChangeCodecList();
             UpdateCodecList();
         }
 
@@ -108,7 +108,7 @@ namespace Unity.RenderStreaming.Editor.UI
             removeCodecButton.SetEnabled(codecList.itemsSource.Count > 0);
             codecList.ClearSelection();
             codecList.style.height = codecList.itemHeight * codecList.itemsSource.Count;
-            codecList.Rebuild();
+            codecList.Refresh();
         }
 
         private void NotifyChangeCodecList()

--- a/com.unity.renderstreaming/Editor/UI/CodecSettings.cs
+++ b/com.unity.renderstreaming/Editor/UI/CodecSettings.cs
@@ -53,20 +53,9 @@ namespace Unity.RenderStreaming.Editor.UI
                 evt.menu.AppendAction("Add 200", AddCodec, ValidateCodecStatus, "200");
             });
             contextualMenuManipulator.activators.Add(new ManipulatorActivationFilter {button = MouseButton.LeftMouse});
-            addScopeButton.AddManipulator(contextualMenuManipulator);
+            addCodecButton.AddManipulator(contextualMenuManipulator);
 
-
-            removeScopeButton.clickable.clicked += () =>
-            {
-                foreach (var selectItem in codecList.selectedItems.Cast<string>())
-                {
-                    draft.Remove(selectItem);
-                }
-
-                codecList.ClearSelection();
-                codecList.style.height = codecList.itemHeight * draft.Count;
-                codecList.Refresh();
-            };
+            removeCodecButton.clickable.clicked += RemoveCodec;
         }
 
         void AddCodec(DropdownMenuAction menuAction)
@@ -74,9 +63,26 @@ namespace Unity.RenderStreaming.Editor.UI
             if (menuAction.userData is string data && !string.IsNullOrEmpty(data))
             {
                 draft.Add(data);
-                codecList.style.height = codecList.itemHeight * draft.Count;
-                codecList.Refresh();
+                UpdateCodecList();
             }
+        }
+
+        void RemoveCodec()
+        {
+            foreach (var selectItem in codecList.selectedItems.Cast<string>())
+            {
+                draft.Remove(selectItem);
+            }
+
+            UpdateCodecList();
+        }
+
+        private void UpdateCodecList()
+        {
+            removeCodecButton.SetEnabled(codecList.itemsSource.Count > 0);
+            codecList.ClearSelection();
+            codecList.style.height = codecList.itemHeight * codecList.itemsSource.Count;
+            codecList.Refresh();
         }
 
         DropdownMenuAction.Status ValidateCodecStatus(DropdownMenuAction menuAction)
@@ -90,7 +96,7 @@ namespace Unity.RenderStreaming.Editor.UI
         }
 
         private ListView codecList => cache.Get<ListView>("codecList");
-        private Button addScopeButton => cache.Get<Button>("addCodecButton");
-        private Button removeScopeButton => cache.Get<Button>("removeCodecButton");
+        private Button addCodecButton => cache.Get<Button>("addCodecButton");
+        private Button removeCodecButton => cache.Get<Button>("removeCodecButton");
     }
 }

--- a/com.unity.renderstreaming/Editor/UI/CodecSettings.cs
+++ b/com.unity.renderstreaming/Editor/UI/CodecSettings.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine.UIElements;
+
+namespace Unity.RenderStreaming.Editor.UI
+{
+    internal class CodecSettings : VisualElement
+    {
+        const string kTemplatePath = "Packages/com.unity.renderstreaming/Editor/UXML/CodecSettings.uxml";
+        const string kStylePath = "Packages/com.unity.renderstreaming/Editor/Styles/CodecSettings.uss";
+
+        internal new class UxmlFactory : UxmlFactory<CodecSettings>
+        {
+        }
+
+        //todo: change codecs model class
+        internal List<string> draft;
+
+        internal VisualElementCache cache;
+
+        public CodecSettings()
+        {
+            var styleSheet = EditorGUIUtility.Load(kStylePath) as StyleSheet;
+            styleSheets.Add(styleSheet);
+
+            var template = EditorGUIUtility.Load(kTemplatePath) as VisualTreeAsset;
+            var newVisualElement = new VisualElement();
+            template.CloneTree(newVisualElement);
+            this.Add(newVisualElement);
+
+            cache = new VisualElementCache(newVisualElement);
+
+            const int itemCount = 10;
+            draft = new List<string>(itemCount);
+            for (int i = 0; i <= itemCount; i++)
+                draft.Add(i.ToString());
+
+            Func<VisualElement> makeItem = () => new Label();
+            Action<VisualElement, int> bindItem = (e, i) => (e as Label).text = draft[i];
+            codecList.makeItem = makeItem;
+            codecList.bindItem = bindItem;
+            codecList.itemsSource = draft;
+            codecList.selectionType = SelectionType.Multiple;
+            codecList.itemHeight = 16;
+            codecList.reorderable = true;
+            codecList.style.height = codecList.itemHeight * draft.Count;
+
+            var contextualMenuManipulator = new ContextualMenuManipulator((evt) =>
+            {
+                evt.menu.AppendAction("Add 100", AddCodec, ValidateCodecStatus, "100");
+                evt.menu.AppendAction("Add 200", AddCodec, ValidateCodecStatus, "200");
+            });
+            contextualMenuManipulator.activators.Add(new ManipulatorActivationFilter {button = MouseButton.LeftMouse});
+            addScopeButton.AddManipulator(contextualMenuManipulator);
+
+
+            removeScopeButton.clickable.clicked += () =>
+            {
+                foreach (var selectItem in codecList.selectedItems.Cast<string>())
+                {
+                    draft.Remove(selectItem);
+                }
+
+                codecList.ClearSelection();
+                codecList.style.height = codecList.itemHeight * draft.Count;
+                codecList.Refresh();
+            };
+        }
+
+        void AddCodec(DropdownMenuAction menuAction)
+        {
+            if (menuAction.userData is string data && !string.IsNullOrEmpty(data))
+            {
+                draft.Add(data);
+                codecList.style.height = codecList.itemHeight * draft.Count;
+                codecList.Refresh();
+            }
+        }
+
+        DropdownMenuAction.Status ValidateCodecStatus(DropdownMenuAction menuAction)
+        {
+            if (menuAction.userData is string data && !string.IsNullOrEmpty(data))
+            {
+                return draft.Contains(data) ? DropdownMenuAction.Status.Disabled : DropdownMenuAction.Status.Normal;
+            }
+
+            return DropdownMenuAction.Status.Normal;
+        }
+
+        private ListView codecList => cache.Get<ListView>("codecList");
+        private Button addScopeButton => cache.Get<Button>("addCodecButton");
+        private Button removeScopeButton => cache.Get<Button>("removeCodecButton");
+    }
+}

--- a/com.unity.renderstreaming/Editor/UI/CodecSettings.cs
+++ b/com.unity.renderstreaming/Editor/UI/CodecSettings.cs
@@ -49,8 +49,10 @@ namespace Unity.RenderStreaming.Editor.UI
 
             var contextualMenuManipulator = new ContextualMenuManipulator((evt) =>
             {
-                evt.menu.AppendAction("Add 100", AddCodec, ValidateCodecStatus, "100");
-                evt.menu.AppendAction("Add 200", AddCodec, ValidateCodecStatus, "200");
+                foreach (var item in draft)
+                {
+                    evt.menu.AppendAction($"Add {item}", AddCodec, ValidateCodecStatus, item);
+                }
             });
             contextualMenuManipulator.activators.Add(new ManipulatorActivationFilter {button = MouseButton.LeftMouse});
             addCodecButton.AddManipulator(contextualMenuManipulator);

--- a/com.unity.renderstreaming/Editor/UI/CodecSettings.cs
+++ b/com.unity.renderstreaming/Editor/UI/CodecSettings.cs
@@ -16,6 +16,7 @@ namespace Unity.RenderStreaming.Editor.UI
         }
 
         //todo: change codecs model class
+        internal List<string> sourceList = new List<string> {"VP8", "VP9", "H264", "AV1"};
         internal List<string> draft;
 
         internal VisualElementCache cache;
@@ -31,11 +32,7 @@ namespace Unity.RenderStreaming.Editor.UI
             this.Add(newVisualElement);
 
             cache = new VisualElementCache(newVisualElement);
-
-            const int itemCount = 10;
-            draft = new List<string>(itemCount);
-            for (int i = 0; i <= itemCount; i++)
-                draft.Add(i.ToString());
+            draft = new List<string>(sourceList);
 
             Func<VisualElement> makeItem = () => new Label();
             Action<VisualElement, int> bindItem = (e, i) => (e as Label).text = draft[i];
@@ -49,7 +46,7 @@ namespace Unity.RenderStreaming.Editor.UI
 
             var contextualMenuManipulator = new ContextualMenuManipulator((evt) =>
             {
-                foreach (var item in draft)
+                foreach (var item in sourceList)
                 {
                     evt.menu.AppendAction($"Add {item}", AddCodec, ValidateCodecStatus, item);
                 }

--- a/com.unity.renderstreaming/Editor/UI/CodecSettings.cs.meta
+++ b/com.unity.renderstreaming/Editor/UI/CodecSettings.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bd32a66818454a639e3e09f02e583ad6
+timeCreated: 1659055851

--- a/com.unity.renderstreaming/Editor/UXML/CodecSettings.uxml
+++ b/com.unity.renderstreaming/Editor/UXML/CodecSettings.uxml
@@ -4,8 +4,8 @@
     <ui:VisualElement name="codecSettingContainer">
         <ui:ListView name="codecList"/>
         <ui:VisualElement name="codecListButtons" class="bottom-buttons">
-            <ui:Button name="removeCodecButton" text="-"/>
             <ui:Button name="addCodecButton" text="+"/>
+            <ui:Button name="removeCodecButton" text="-"/>
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>

--- a/com.unity.renderstreaming/Editor/UXML/CodecSettings.uxml
+++ b/com.unity.renderstreaming/Editor/UXML/CodecSettings.uxml
@@ -1,0 +1,11 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements"
+         xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements"
+         noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
+    <ui:VisualElement name="codecSettingContainer">
+        <ui:ListView name="codecList"/>
+        <ui:VisualElement name="codecListButtons" class="bottom-buttons">
+            <ui:Button name="removeCodecButton" text="-"/>
+            <ui:Button name="addCodecButton" text="+"/>
+        </ui:VisualElement>
+    </ui:VisualElement>
+</ui:UXML>

--- a/com.unity.renderstreaming/Editor/UXML/CodecSettings.uxml.meta
+++ b/com.unity.renderstreaming/Editor/UXML/CodecSettings.uxml.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3e5651d3cb764b13ab84b4412242f524
+timeCreated: 1659055231

--- a/com.unity.renderstreaming/Editor/UXML/RenderStreamingProjectSettings.uxml
+++ b/com.unity.renderstreaming/Editor/UXML/RenderStreamingProjectSettings.uxml
@@ -1,16 +1,10 @@
-<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements"
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xmlns:urs="Unity.RenderStreaming.Editor.UI"
          xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements"
          noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
     <ui:VisualElement name="renderStreamingContainer">
         <ui:Label text="Render Streaming" name="titleLabel"/>
         <ui:Foldout text="Video Codec Setting" name="videoCodecSettingFoldout">
-            <ui:VisualElement name="videoCodecSettingContainer">
-                <ui:ListView name="videoCodecList"/>
-                <ui:VisualElement name="videoCodecListButtons" class="bottom-buttons">
-                    <ui:Button name="removeCodecButton" text="-"/>
-                    <ui:Button name="addCodecButton" text="+"/>
-                </ui:VisualElement>
-            </ui:VisualElement>
+            <urs:CodecSettings name="videoCodecSettings" />
         </ui:Foldout>
     </ui:VisualElement>
 </ui:UXML>

--- a/com.unity.renderstreaming/Editor/UXML/RenderStreamingProjectSettings.uxml
+++ b/com.unity.renderstreaming/Editor/UXML/RenderStreamingProjectSettings.uxml
@@ -3,8 +3,13 @@
          noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
     <ui:VisualElement name="renderStreamingContainer">
         <ui:Label text="Render Streaming" name="titleLabel"/>
+        <ui:Toggle label="Auto Video Codec Setting" name="autoVideoCodecSettingToggle" />
         <ui:Foldout text="Video Codec Setting" name="videoCodecSettingFoldout">
             <urs:CodecSettings name="videoCodecSettings" />
+        </ui:Foldout>
+        <ui:Toggle label="Auto Audio Codec Setting" name="autoAudioCodecSettingToggle" />
+        <ui:Foldout text="Audio Codec Setting" name="audioCodecSettingFoldout">
+            <urs:CodecSettings name="audioCodecSettings" />
         </ui:Foldout>
     </ui:VisualElement>
 </ui:UXML>

--- a/com.unity.renderstreaming/Editor/UXML/RenderStreamingProjectSettings.uxml
+++ b/com.unity.renderstreaming/Editor/UXML/RenderStreamingProjectSettings.uxml
@@ -1,6 +1,16 @@
-<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements"
+         xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements"
+         noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
     <ui:VisualElement name="renderStreamingContainer">
         <ui:Label text="Render Streaming" name="titleLabel"/>
-        <ui:Foldout text="Foldout" />
+        <ui:Foldout text="Video Codec Setting" name="videoCodecSettingFoldout">
+            <ui:VisualElement name="videoCodecSettingContainer">
+                <ui:ListView name="videoCodecList"/>
+                <ui:VisualElement name="videoCodecListButtons" class="bottom-buttons">
+                    <ui:Button name="removeCodecButton" text="-"/>
+                    <ui:Button name="addCodecButton" text="+"/>
+                </ui:VisualElement>
+            </ui:VisualElement>
+        </ui:Foldout>
     </ui:VisualElement>
 </ui:UXML>

--- a/com.unity.renderstreaming/Editor/VisualElementCache.cs
+++ b/com.unity.renderstreaming/Editor/VisualElementCache.cs
@@ -5,24 +5,24 @@ namespace Unity.RenderStreaming
 {
     internal class VisualElementCache
     {
-        private Dictionary<string, VisualElement> m_Cache = new Dictionary<string, VisualElement>();
-        private VisualElement m_Root;
+        private Dictionary<string, VisualElement> cache = new Dictionary<string, VisualElement>();
+        private VisualElement root;
 
         public VisualElementCache(VisualElement root)
         {
-            m_Root = root;
+            this.root = root;
         }
 
         private T Create<T>(string query) where T : VisualElement
         {
-            return m_Root.Q<T>(query);
+            return root.Q<T>(query);
         }
 
         public T Get<T>(string query) where T : VisualElement
         {
-            if (!m_Cache.ContainsKey(query))
-                m_Cache[query] = Create<T>(query);
-            return m_Cache[query] as T;
+            if (!cache.ContainsKey(query))
+                cache[query] = Create<T>(query);
+            return cache[query] as T;
         }
     }
 }

--- a/com.unity.renderstreaming/Editor/VisualElementCache.cs
+++ b/com.unity.renderstreaming/Editor/VisualElementCache.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using UnityEngine.UIElements;
+
+namespace Unity.RenderStreaming
+{
+    internal class VisualElementCache
+    {
+        private Dictionary<string, VisualElement> m_Cache = new Dictionary<string, VisualElement>();
+        private VisualElement m_Root;
+
+        public VisualElementCache(VisualElement root)
+        {
+            m_Root = root;
+        }
+
+        private T Create<T>(string query) where T : VisualElement
+        {
+            return m_Root.Q<T>(query);
+        }
+
+        public T Get<T>(string query) where T : VisualElement
+        {
+            if (!m_Cache.ContainsKey(query))
+                m_Cache[query] = Create<T>(query);
+            return m_Cache[query] as T;
+        }
+    }
+}

--- a/com.unity.renderstreaming/Editor/VisualElementCache.cs.meta
+++ b/com.unity.renderstreaming/Editor/VisualElementCache.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c276c56c8ee04861b1a8a46f3389a552
+timeCreated: 1658902165


### PR DESCRIPTION
Temporary implementation of codec selection UI in Project Setting

- Implement CodecStting control (uxml/uss/script) that notify codec setting list if change list element(add, remove, change order)

ex.
```example.cs
            var videoCodecSetting = rootVisualElement.Q<CodecSettings>("videoCodecSettings");
            videoCodecSetting.onChangeCodecs += codecSetting => UnityEngine.Debug.Log(string.Join(",", codecSetting));
```

- Add add/remove codec button 
- Implement codec list view as sortable.


![videocodecselect](https://user-images.githubusercontent.com/26959415/181691174-18b1b619-e2b3-42d9-b8e9-eff6d6ce0c1d.gif)