### PR TITLE
fix: Call once WebRTC.Initialize when the Unity Editor is launched

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AvailableCodecsUtils.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AvailableCodecsUtils.cs
@@ -33,25 +33,10 @@ namespace Unity.RenderStreaming
         {
             if (s_availableVideoCodecs == null)
             {
-                bool alreadyInitialized = false;
-                try
-                {
-                    WebRTC.WebRTC.Initialize();
-                }
-                catch (InvalidOperationException)
-                {
-                    alreadyInitialized = true;
-                }
-
                 s_availableVideoCodecs = RTCRtpReceiver.GetCapabilities(TrackKind.Video).codecs
                     .Where(codec => !s_excludeCodecMimeType.Contains(codec.mimeType))
                     .Select((codec, index) => new {codec, index})
                     .ToDictionary(t => t.index, t => t.codec);
-
-                if (!alreadyInitialized)
-                {
-                    WebRTC.WebRTC.Dispose();
-                }
             }
 
             return s_availableVideoCodecs.ToDictionary(pair => pair.Key, pair =>
@@ -70,24 +55,9 @@ namespace Unity.RenderStreaming
         {
             if (s_availableAudioCodecs == null)
             {
-                bool alreadyInitialized = false;
-                try
-                {
-                    WebRTC.WebRTC.Initialize();
-                }
-                catch (InvalidOperationException)
-                {
-                    alreadyInitialized = true;
-                }
-
                 s_availableAudioCodecs = RTCRtpReceiver.GetCapabilities(TrackKind.Audio).codecs
                     .Select((codec, index) => new {codec, index})
                     .ToDictionary(t => t.index, t => t.codec);
-
-                if (!alreadyInitialized)
-                {
-                    WebRTC.WebRTC.Dispose();
-                }
             }
 
             return s_availableAudioCodecs.ToDictionary(pair => pair.Key, pair =>

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
@@ -6,8 +6,15 @@ using UnityEngine;
 using Unity.WebRTC;
 using Unity.RenderStreaming.Signaling;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 namespace Unity.RenderStreaming
 {
+#if UNITY_EDITOR
+    [InitializeOnLoad]
+#endif
     public sealed class RenderStreaming : MonoBehaviour
     {
 #pragma warning disable 0649
@@ -36,6 +43,12 @@ namespace Unity.RenderStreaming
         private RenderStreamingInternal m_instance;
         private SignalingEventProvider m_provider;
         private bool m_running;
+
+        static RenderStreaming()
+        {
+            RenderStreamingInternal.DomainUnload();
+            RenderStreamingInternal.DomainLoad();
+        }
 
         static Type GetType(string typeName) {
             var type = Type.GetType(typeName);

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
@@ -48,6 +48,7 @@ namespace Unity.RenderStreaming
         {
             RenderStreamingInternal.DomainUnload();
             RenderStreamingInternal.DomainLoad();
+            EditorApplication.quitting += RenderStreamingInternal.DomainUnload;
         }
 
         static Type GetType(string typeName) {

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
@@ -12,9 +12,6 @@ using UnityEditor;
 
 namespace Unity.RenderStreaming
 {
-#if UNITY_EDITOR
-    [InitializeOnLoad]
-#endif
     public sealed class RenderStreaming : MonoBehaviour
     {
 #pragma warning disable 0649
@@ -44,12 +41,23 @@ namespace Unity.RenderStreaming
         private SignalingEventProvider m_provider;
         private bool m_running;
 
-        static RenderStreaming()
+#if UNITY_EDITOR
+        [InitializeOnLoadMethod]
+        static void InitializeOnEditor()
         {
             RenderStreamingInternal.DomainUnload();
             RenderStreamingInternal.DomainLoad();
             EditorApplication.quitting += RenderStreamingInternal.DomainUnload;
         }
+#else
+        [RuntimeInitializeOnLoadMethod]
+        static void InitializeOnRuntime()
+        {
+            RenderStreamingInternal.DomainUnload();
+            RenderStreamingInternal.DomainLoad();
+            Application.quitting += RenderStreamingInternal.DomainUnload;
+        }
+#endif
 
         static Type GetType(string typeName) {
             var type = Type.GetType(typeName);

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -95,7 +95,15 @@ namespace Unity.RenderStreaming
         private bool _runningResendCoroutine;
         private float _resendInterval = 3.0f;
 
-        static List<RenderStreamingInternal> s_list = new List<RenderStreamingInternal>();
+        internal static void DomainLoad()
+        {
+            WebRTC.WebRTC.Initialize();
+        }
+
+        internal static void DomainUnload()
+        {
+            WebRTC.WebRTC.Dispose();
+        }
 
         /// <summary>
         ///
@@ -108,11 +116,6 @@ namespace Unity.RenderStreaming
             if (dependencies.startCoroutine == null)
                 throw new ArgumentException("Coroutine action instance is null.");
 
-            if (s_list.Count == 0)
-            {
-                WebRTC.WebRTC.Initialize();
-            }
-
             _config = dependencies.config;
             _startCoroutine = dependencies.startCoroutine;
             _resendInterval = dependencies.resentOfferInterval;
@@ -124,8 +127,6 @@ namespace Unity.RenderStreaming
             _signaling.OnAnswer += OnAnswer;
             _signaling.OnIceCandidate += OnIceCandidate;
             _signaling.Start();
-
-            s_list.Add(this);
             _startCoroutine(WebRTC.WebRTC.Update());
         }
 
@@ -156,12 +157,6 @@ namespace Unity.RenderStreaming
             _signaling.OnOffer -= OnOffer;
             _signaling.OnAnswer -= OnAnswer;
             _signaling.OnIceCandidate -= OnIceCandidate;
-
-            s_list.Remove(this);
-            if (s_list.Count == 0)
-            {
-                WebRTC.WebRTC.Dispose();
-            }
 
             this._disposed = true;
             GC.SuppressFinalize(this);

--- a/com.unity.renderstreaming/Runtime/Scripts/StreamSenderBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/StreamSenderBase.cs
@@ -51,6 +51,15 @@ namespace Unity.RenderStreaming
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        virtual protected void OnDestroy()
+        {
+            m_track?.Dispose();
+            m_track = null;
+        }
+
+        /// <summary>
         ///
         /// </summary>
         /// <param name="connectionId"></param>

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -141,8 +141,6 @@ namespace Unity.RenderStreaming.RuntimeTest
         [UnitySetUp, Timeout(1000)]
         public IEnumerator UnitySetUp()
         {
-            WebRTC.WebRTC.Initialize();
-
             RTCConfiguration config = default;
             RTCIceCandidate candidate_ = null;
             config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
@@ -185,7 +183,6 @@ namespace Unity.RenderStreaming.RuntimeTest
         [TearDown]
         public void TearDown()
         {
-            WebRTC.WebRTC.Dispose();
             signaling1.Stop();
             signaling2.Stop();
             m_Context = null;

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingEventProviderTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingEventProviderTest.cs
@@ -169,14 +169,12 @@ namespace Unity.RenderStreaming.RuntimeTest
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            WebRTC.WebRTC.Initialize();
             m_eventSystem = new GameObject("EventSystem").AddComponent<EventSystem>();
         }
 
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            WebRTC.WebRTC.Dispose();
             UnityEngine.Object.DestroyImmediate(m_eventSystem);
         }
 

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
@@ -136,8 +136,6 @@ namespace Unity.RenderStreaming.RuntimeTest
         [UnitySetUp, Timeout(1000)]
         public IEnumerator UnitySetUp()
         {
-            WebRTC.WebRTC.Initialize();
-
             RTCConfiguration config = default;
             RTCIceCandidate candidate_ = null;
             config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
@@ -180,8 +178,6 @@ namespace Unity.RenderStreaming.RuntimeTest
         [TearDown]
         public void TearDown()
         {
-            WebRTC.WebRTC.Dispose();
-
             signaling1.Stop();
             signaling2.Stop();
             m_Context = null;


### PR DESCRIPTION
This pull request changes the timing of the WebRTC initialization process. This makes available to call WebRTC APIs anytime in the Unity Render Streaming package.

To call WebRTC APIs, `WebRTC.Initialize` must be called once at first.
For example, since we need to define static methods to get available codec list, this pull request added the initialization process using Unity attributes `InitializeOnLoadAttribute` and `RuntimeInitializeOnLoadMethodAttribute`. This can complete the initialization process before calling static methods.