### PR TITLE
refactor: Stream class owns RTCRtpTransceiver instance to configure stream codec

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -33,12 +33,10 @@ namespace Unity.RenderStreaming
             if (bitrate < 0)
                 throw new ArgumentException();
             m_bitrate = bitrate;
-            foreach (var sender in Senders.Values)
-            {
-                RTCError error = sender.SetBitrate(m_bitrate);
-                if (error.errorType == RTCErrorType.None)
-                    Debug.LogError(error.message);
-            }
+
+            RTCError error = Sender.SetBitrate(m_bitrate);
+            if (error.errorType == RTCErrorType.None)
+                Debug.LogError(error.message);
         }
 
         protected AudioStreamTrack track;

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -33,10 +33,12 @@ namespace Unity.RenderStreaming
             if (bitrate < 0)
                 throw new ArgumentException();
             m_bitrate = bitrate;
-
-            RTCError error = Sender.SetBitrate(m_bitrate);
-            if (error.errorType == RTCErrorType.None)
-                Debug.LogError(error.message);
+            foreach (var transceiver in Transceivers.Values)
+            {
+                RTCError error = transceiver.Sender.SetBitrate(m_bitrate);
+                if (error.errorType == RTCErrorType.None)
+                    Debug.LogError(error.message);
+            }
         }
 
         protected AudioStreamTrack track;

--- a/com.unity.renderstreaming/Runtime/Scripts/Broadcast.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Broadcast.cs
@@ -57,7 +57,7 @@ namespace Unity.RenderStreaming
         {
             var receiver = streams.OfType<IStreamReceiver>().
                 FirstOrDefault(r => r.Track == null);
-            receiver?.SetReceiver(data.connectionId, data.receiver);
+            receiver?.SetTransceiver(data.connectionId, data.transceiver);
         }
 
         public void OnOffer(SignalingEventData data)

--- a/com.unity.renderstreaming/Runtime/Scripts/IRenderStreamingHandler.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/IRenderStreamingHandler.cs
@@ -44,7 +44,7 @@ namespace Unity.RenderStreaming
         /// <summary>
         ///
         /// </summary>
-        event Action<string, RTCRtpReceiver> onAddReceiver;
+        event Action<string, RTCRtpTransceiver> onAddTransceiver;
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -79,7 +79,7 @@ namespace Unity.RenderStreaming
         /// <summary>
         ///
         /// </summary>
-        public event Action<string, RTCRtpReceiver> onAddReceiver;
+        public event Action<string, RTCRtpTransceiver> onAddTransceiver;
 
         /// <summary>
         ///
@@ -386,7 +386,7 @@ namespace Unity.RenderStreaming
             pc.OnConnectionStateChange = state => OnConnectionStateChange(connectionId, state);
             pc.OnTrack = trackEvent =>
             {
-                onAddReceiver?.Invoke(connectionId, trackEvent.Receiver);
+                onAddTransceiver?.Invoke(connectionId, trackEvent.Transceiver);
             };
             pc.OnNegotiationNeeded = () => _startCoroutine(OnNegotiationNeeded(connectionId));
             return peer;

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingEventData.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingEventData.cs
@@ -21,7 +21,7 @@ namespace Unity.RenderStreaming
         /// <summary>
         /// 
         /// </summary>
-        public RTCRtpReceiver receiver { get; set; }
+        public RTCRtpTransceiver transceiver { get; set; }
 
         /// <summary>
         /// 

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingEventProvider.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingEventProvider.cs
@@ -19,7 +19,7 @@ namespace Unity.RenderStreaming
             handler.onGotOffer += OnGotOffer;
             handler.onGotAnswer += OnGotAnswer;
             handler.onAddChannel += OnAddChannel;
-            handler.onAddReceiver += OnAddReceiver;
+            handler.onAddTransceiver += OnAddReceiver;
         }
 
         public bool Subscribe(Component comp)
@@ -128,12 +128,12 @@ namespace Unity.RenderStreaming
             ExecuteEventToAllTargets(data, ExecuteSignalingEvents.addChannelHandler);
         }
 
-        private void OnAddReceiver(string connectionId, RTCRtpReceiver receiver)
+        private void OnAddReceiver(string connectionId, RTCRtpTransceiver transceiver)
         {
             var data = new SignalingEventData(EventSystem.current)
             {
                 connectionId = connectionId,
-                receiver = receiver
+                transceiver = transceiver
             };
             ExecuteEventToAllTargets(data, ExecuteSignalingEvents.addReceiverHandler);
         }

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -105,7 +105,7 @@ namespace Unity.RenderStreaming
         {
             RTCRtpTransceiverInit init = GetTransceiverInit(sender);
             var transceiver = m_handler.AddTransceiver(connectionId, sender.Track, init);
-            sender.SetSender(connectionId, transceiver.Sender);
+            sender.SetTransceiver(connectionId, transceiver);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Unity.RenderStreaming
         public virtual void RemoveSender(string connectionId, IStreamSender sender)
         {
             sender.Track.Stop();
-            sender.SetSender(connectionId, null);
+            sender.SetTransceiver(connectionId, null);
             if (ExistConnection(connectionId))
                 RemoveTrack(connectionId, sender.Track);
         }
@@ -129,7 +129,7 @@ namespace Unity.RenderStreaming
         public void SetSenderCodecs(string connectionId, IStreamSender sender)
         {
             var transceivers = m_handler.GetTransceivers(connectionId)
-                .Where(t => sender.Senders.Values.Contains(t.Sender));
+                .Where(t => sender.Transceiver.Sender == t.Sender);
             sender.SetSenderCodec(connectionId, transceivers);
         }
 
@@ -146,7 +146,7 @@ namespace Unity.RenderStreaming
             };
             var transceiver = m_handler.AddTransceiver(connectionId, receiver.Kind, init);
             if (transceiver.Receiver != null)
-                receiver.SetReceiver(connectionId, transceiver.Receiver);
+                receiver.SetTransceiver(connectionId, transceiver);
         }
 
         /// <summary>
@@ -156,8 +156,7 @@ namespace Unity.RenderStreaming
         /// <param name="receiver"></param>
         public virtual void RemoveReceiver(string connectionId, IStreamReceiver receiver)
         {
-            //receiver.
-            receiver.SetReceiver(connectionId, null);
+            receiver.SetTransceiver(connectionId, null);
         }
 
         /// <summary>
@@ -258,26 +257,26 @@ namespace Unity.RenderStreaming
         /// <summary>
         ///
         /// </summary>
+        RTCRtpTransceiver Transceiver { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         MediaStreamTrack Track { get; }
 
         /// <summary>
-        ///
-        /// </summary>
-        IReadOnlyDictionary<string, RTCRtpSender> Senders { get; }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="connectionId"></param>
-        /// <param name="sender"></param>
-        void SetSender(string connectionId, RTCRtpSender sender);
-
-        /// <summary>
-        ///
+        /// 
         /// </summary>
         /// <param name="connectionId"></param>
         /// <param name="transceivers"></param>
         void SetSenderCodec(string connectionId, IEnumerable<RTCRtpTransceiver> transceivers);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="connectionId"></param>
+        /// <param name="transceiver"></param>
+        void SetTransceiver(string connectionId, RTCRtpTransceiver transceiver);
     }
 
     /// <summary>
@@ -304,8 +303,8 @@ namespace Unity.RenderStreaming
         ///
         /// </summary>
         /// <param name="connectionId"></param>
-        /// <param name="receiver"></param>
-        void SetReceiver(string connectionId, RTCRtpReceiver receiver);
+        /// <param name="transceiver"></param>
+        void SetTransceiver(string connectionId, RTCRtpTransceiver transceiver);
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -128,9 +128,10 @@ namespace Unity.RenderStreaming
         /// <param name="sender"></param>
         public void SetSenderCodecs(string connectionId, IStreamSender sender)
         {
-            var transceivers = m_handler.GetTransceivers(connectionId)
-                .Where(t => sender.Transceiver.Sender == t.Sender);
-            sender.SetSenderCodec(connectionId, transceivers);
+            if(sender.Transceivers.TryGetValue(connectionId, out RTCRtpTransceiver value))
+            {
+                sender.SetSenderCodec(connectionId, value);
+            }
         }
 
         /// <summary>
@@ -255,11 +256,6 @@ namespace Unity.RenderStreaming
     public interface IStreamSender
     {
         /// <summary>
-        ///
-        /// </summary>
-        RTCRtpTransceiver Transceiver { get; }
-
-        /// <summary>
         /// 
         /// </summary>
         MediaStreamTrack Track { get; }
@@ -267,9 +263,14 @@ namespace Unity.RenderStreaming
         /// <summary>
         /// 
         /// </summary>
+        IReadOnlyDictionary<string, RTCRtpTransceiver> Transceivers { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         /// <param name="connectionId"></param>
         /// <param name="transceivers"></param>
-        void SetSenderCodec(string connectionId, IEnumerable<RTCRtpTransceiver> transceivers);
+        void SetSenderCodec(string connectionId, RTCRtpTransceiver transceiver);
 
         /// <summary>
         ///
@@ -292,7 +293,7 @@ namespace Unity.RenderStreaming
         /// <summary>
         ///
         /// </summary>
-        RTCRtpReceiver Receiver { get; }
+        RTCRtpTransceiver Transceiver { get; }
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Runtime/Scripts/SingleConnection.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SingleConnection.cs
@@ -111,8 +111,8 @@ namespace Unity.RenderStreaming
 
             var receiver = streams.OfType<IStreamReceiver>()
                 .FirstOrDefault((r =>
-                    r.Track == null && r.Kind == data.receiver.Track.Kind && data.receiver.Track.Enabled));
-            receiver?.SetReceiver(connectionId, data.receiver);
+                    r.Track == null && r.Kind == data.transceiver.Receiver.Track.Kind && data.transceiver.Receiver.Track.Enabled));
+            receiver?.SetTransceiver(connectionId, data.transceiver);
         }
 
         public void OnAddChannel(SignalingEventData data)

--- a/com.unity.renderstreaming/Runtime/Scripts/StreamReceiverBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/StreamReceiverBase.cs
@@ -14,7 +14,7 @@ namespace Unity.RenderStreaming
         /// <summary>
         ///
         /// </summary>
-        public RTCRtpReceiver Receiver => m_transceiver?.Receiver;
+        public RTCRtpTransceiver Transceiver => m_transceiver;
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Runtime/Scripts/StreamReceiverBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/StreamReceiverBase.cs
@@ -14,7 +14,7 @@ namespace Unity.RenderStreaming
         /// <summary>
         ///
         /// </summary>
-        public RTCRtpReceiver Receiver => m_receiver;
+        public RTCRtpReceiver Receiver => m_transceiver?.Receiver;
 
         /// <summary>
         ///
@@ -27,7 +27,7 @@ namespace Unity.RenderStreaming
         public OnStoppedStreamHandler OnStoppedStream { get; set; }
 
 
-        private RTCRtpReceiver m_receiver;
+        private RTCRtpTransceiver m_transceiver;
 
 
         /// <summary>
@@ -45,11 +45,15 @@ namespace Unity.RenderStreaming
         /// </summary>
         /// <param name="connectionId"></param>
         /// <param name="receiver"></param>
-        public virtual void SetReceiver(string connectionId, RTCRtpReceiver receiver)
+        public virtual void SetTransceiver(string connectionId, RTCRtpTransceiver transceiver)
         {
-            m_receiver = receiver;
-            Track = m_receiver?.Track;
-            if (m_receiver == null)
+            if (connectionId == null)
+                throw new ArgumentNullException("connectionId", "connectionId is null");
+
+            m_transceiver = transceiver;
+            Track = m_transceiver?.Receiver.Track;
+
+            if (m_transceiver == null)
                 OnStoppedStream?.Invoke(connectionId);
             else
                 OnStartedStream?.Invoke(connectionId);

--- a/com.unity.renderstreaming/Runtime/Scripts/StreamSenderBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/StreamSenderBase.cs
@@ -12,6 +12,11 @@ namespace Unity.RenderStreaming
     public abstract class StreamSenderBase : MonoBehaviour, IStreamSender
     {
         /// <summary>
+        /// 
+        /// </summary>
+        public RTCRtpTransceiver Transceiver => m_transceiver;
+
+        /// <summary>
         ///
         /// </summary>
         public OnStartedStreamHandler OnStartedStream { get; set; }
@@ -20,22 +25,6 @@ namespace Unity.RenderStreaming
         ///
         /// </summary>
         public OnStoppedStreamHandler OnStoppedStream { get; set; }
-
-        /// <summary>
-        ///
-        /// </summary>
-        public IReadOnlyDictionary<string, RTCRtpSender> Senders => m_senders;
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns></returns>
-        protected virtual MediaStreamTrack CreateTrack() { return null; }
-
-        private MediaStreamTrack m_track;
-
-        private Dictionary<string, RTCRtpSender> m_senders =
-            new Dictionary<string, RTCRtpSender>();
 
         /// <summary>
         ///
@@ -53,20 +42,31 @@ namespace Unity.RenderStreaming
         /// <summary>
         ///
         /// </summary>
+        /// <returns></returns>
+        protected virtual MediaStreamTrack CreateTrack() { return null; }
+
+        internal RTCRtpSender Sender => m_transceiver?.Sender;
+
+        private MediaStreamTrack m_track;
+        private RTCRtpTransceiver m_transceiver;
+
+
+        /// <summary>
+        ///
+        /// </summary>
         /// <param name="connectionId"></param>
         /// <param name="sender"></param>
-        public virtual void SetSender(string connectionId, RTCRtpSender sender)
+        public virtual void SetTransceiver(string connectionId, RTCRtpTransceiver transceiver)
         {
             if (connectionId == null)
                 throw new ArgumentNullException("connectionId is null");
-            if (sender == null)
+            m_transceiver = transceiver;
+            if (m_transceiver == null)
             {
-                m_senders.Remove(connectionId);
                 OnStoppedStream?.Invoke(connectionId);
             }
             else
             {
-                m_senders.Add(connectionId, sender);
                 OnStartedStream?.Invoke(connectionId);
             }
         }

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -138,10 +138,12 @@ namespace Unity.RenderStreaming
         /// todo(kazuki)::rename `SetCodec`
         public void FilterCodec(string connectionId, int index)
         {
-            RTCRtpSendParameters parameters = Sender.GetParameters();
+            if (!Transceivers.TryGetValue(connectionId, out var transceiver))
+                return;
+            RTCRtpSendParameters parameters = transceiver.Sender.GetParameters();
             var encodings = parameters.encodings.ToList().GetRange(index, 1);
             parameters.encodings = encodings.ToArray();
-            Sender.SetParameters(parameters);
+            transceiver.Sender.SetParameters(parameters);
         }
 
         /// <summary>
@@ -153,9 +155,12 @@ namespace Unity.RenderStreaming
             if (frameRate < 0)
                 throw new ArgumentOutOfRangeException("framerate", frameRate, "The parameter must be greater than zero.");
             m_frameRate = frameRate;
-            RTCError error = Sender.SetFrameRate((uint)m_frameRate);
-            if (error.errorType == RTCErrorType.None)
-                Debug.LogError(error.message);
+            foreach (var transceiver in Transceivers.Values)
+            {
+                RTCError error = transceiver.Sender.SetFrameRate((uint)m_frameRate);
+                if (error.errorType == RTCErrorType.None)
+                    Debug.LogError(error.message);
+            }
         }
         
         /// <summary>
@@ -165,9 +170,12 @@ namespace Unity.RenderStreaming
         public void SetBitrate(uint bitrate)
         {
             m_bitrate = bitrate;
-            RTCError error = Sender.SetBitrate(m_bitrate);
-            if (error.errorType == RTCErrorType.None)
-                Debug.LogError(error.message);
+            foreach (var transceiver in Transceivers.Values)
+            {
+                RTCError error = transceiver.Sender.SetBitrate(m_bitrate);
+                if (error.errorType == RTCErrorType.None)
+                    Debug.LogError(error.message);
+            }
         }
 
         /// <summary>
@@ -181,9 +189,12 @@ namespace Unity.RenderStreaming
             if (1f < scaleFactor)
                 throw new ArgumentOutOfRangeException("scaleFactor", scaleFactor, "The parameter must be lower than one.");
             m_scaleFactor = scaleFactor;
-            RTCError error = Sender.SetScaleResolutionDown(m_scaleFactor);
-            if (error.errorType == RTCErrorType.None)
-                Debug.LogError(error.message);
+            foreach (var transceiver in Transceivers.Values)
+            {
+                RTCError error = transceiver.Sender.SetScaleResolutionDown(m_scaleFactor);
+                if (error.errorType == RTCErrorType.None)
+                    Debug.LogError(error.message);
+            }
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -138,12 +138,10 @@ namespace Unity.RenderStreaming
         /// todo(kazuki)::rename `SetCodec`
         public void FilterCodec(string connectionId, int index)
         {
-            if (!Senders.TryGetValue(connectionId, out var sender))
-                return;
-            RTCRtpSendParameters parameters = sender.GetParameters();
+            RTCRtpSendParameters parameters = Sender.GetParameters();
             var encodings = parameters.encodings.ToList().GetRange(index, 1);
             parameters.encodings = encodings.ToArray();
-            sender.SetParameters(parameters);
+            Sender.SetParameters(parameters);
         }
 
         /// <summary>
@@ -155,12 +153,9 @@ namespace Unity.RenderStreaming
             if (frameRate < 0)
                 throw new ArgumentOutOfRangeException("framerate", frameRate, "The parameter must be greater than zero.");
             m_frameRate = frameRate;
-            foreach (var sender in Senders.Values)
-            {
-                RTCError error = sender.SetFrameRate((uint)m_frameRate);
-                if (error.errorType == RTCErrorType.None)
-                    Debug.LogError(error.message);
-            }
+            RTCError error = Sender.SetFrameRate((uint)m_frameRate);
+            if (error.errorType == RTCErrorType.None)
+                Debug.LogError(error.message);
         }
         
         /// <summary>
@@ -170,12 +165,9 @@ namespace Unity.RenderStreaming
         public void SetBitrate(uint bitrate)
         {
             m_bitrate = bitrate;
-            foreach (var sender in Senders.Values)
-            {
-                RTCError error = sender.SetBitrate(m_bitrate);
-                if (error.errorType == RTCErrorType.None)
-                    Debug.LogError(error.message);
-            }
+            RTCError error = Sender.SetBitrate(m_bitrate);
+            if (error.errorType == RTCErrorType.None)
+                Debug.LogError(error.message);
         }
 
         /// <summary>
@@ -189,12 +181,9 @@ namespace Unity.RenderStreaming
             if (1f < scaleFactor)
                 throw new ArgumentOutOfRangeException("scaleFactor", scaleFactor, "The parameter must be lower than one.");
             m_scaleFactor = scaleFactor;
-            foreach (var sender in Senders.Values)
-            {
-                RTCError error = sender.SetScaleResolutionDown(m_scaleFactor);
-                if (error.errorType == RTCErrorType.None)
-                    Debug.LogError(error.message);
-            }
+            RTCError error = Sender.SetScaleResolutionDown(m_scaleFactor);
+            if (error.errorType == RTCErrorType.None)
+                Debug.LogError(error.message);
         }
     }
 }

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -363,7 +363,7 @@ namespace Unity.RenderStreaming.RuntimeTest
 
             bool isAddReceiver1 = false;
             bool isGotAnswer2 = false;
-            target1.onAddReceiver += (_, receiver) => { isAddReceiver1 = true; };
+            target1.onAddTransceiver += (_, receiver) => { isAddReceiver1 = true; };
             target1.onGotOffer += (_, sdp) => { target1.SendAnswer(connectionId); };
             target2.onGotAnswer += (_, sdp) => { isGotAnswer2 = true; };
 
@@ -441,7 +441,7 @@ namespace Unity.RenderStreaming.RuntimeTest
 
             bool isAddReceiver1 = false;
             bool isGotAnswer1 = false;
-            target1.onAddReceiver += (_, receiver) => { isAddReceiver1 = true; };
+            target1.onAddTransceiver += (_, receiver) => { isAddReceiver1 = true; };
             target1.onGotAnswer += (_, sdp) => { isGotAnswer1 = true; };
 
             var camObj = new GameObject("Camera");

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingEventProviderTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingEventProviderTest.cs
@@ -117,7 +117,7 @@ namespace Unity.RenderStreaming.RuntimeTest
         public event Action<string, string> onGotAnswer;
         public event Action<string> onConnect;
         public event Action<string> onDisconnect;
-        public event Action<string, RTCRtpReceiver> onAddReceiver;
+        public event Action<string, RTCRtpTransceiver> onAddTransceiver;
         public event Action<string, RTCDataChannel> onAddChannel;
 
         public void RaiseOnStart()
@@ -149,9 +149,9 @@ namespace Unity.RenderStreaming.RuntimeTest
         {
             onDisconnect?.Invoke(connectionId);
         }
-        public void RaiseOnAddReceiver(string connectionId, RTCRtpReceiver receiver)
+        public void RaiseOnAddTransceiver(string connectionId, RTCRtpTransceiver transceiver)
         {
-            onAddReceiver?.Invoke(connectionId, receiver);
+            onAddTransceiver?.Invoke(connectionId, transceiver);
         }
         public void RaiseOnAddChannel(string connectionId, RTCDataChannel channel)
         {
@@ -283,10 +283,10 @@ namespace Unity.RenderStreaming.RuntimeTest
             // todo:: create a receiver instance
             var test = new MonoBehaviourTest<AddReceiverHandlerTest>();
             m_provider.Subscribe(test.component);
-            _mDelegate.RaiseOnAddReceiver(connectionId, null);
+            _mDelegate.RaiseOnAddTransceiver(connectionId, null);
             Assert.That(test.component.IsTestFinished, Is.True);
             Assert.That(test.component.Data.connectionId, Is.EqualTo(connectionId));
-            Assert.That(test.component.Data.receiver, Is.Null);
+            Assert.That(test.component.Data.transceiver, Is.Null);
             UnityEngine.Object.DestroyImmediate(test.gameObject);
         }
 

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
@@ -145,7 +145,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             var streamer = container.test.gameObject.AddComponent<StreamSourceTest>();
 
             Assert.That(streamer.Track, Is.Not.Null);
-            Assert.That(streamer.Senders, Is.Empty);
+            Assert.That(streamer.Sender, Is.Null);
 
             container.test.component.AddComponent(streamer);
             container.Dispose();
@@ -267,7 +267,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             RTCCodecStats senderCodecStats = null;
             while (senderCodecStats == null)
             {
-                var statsOp = streamer.Senders[connectionId].GetStats();
+                var statsOp = streamer.Sender.GetStats();
                 yield return statsOp;
                 Assert.That(statsOp.IsError, Is.False);
 
@@ -319,14 +319,14 @@ namespace Unity.RenderStreaming.RuntimeTest
             var streamer = container.test.gameObject.AddComponent<StreamSourceTest>();
 
             Assert.That(streamer.Track, Is.Not.Null);
-            Assert.That(streamer.Senders, Is.Empty);
+            Assert.That(streamer.Sender, Is.Null);
 
             container.test.component.AddComponent(streamer);
             container.test.component.CreateConnection(connectionId);
             yield return new WaitUntil(() => container.test.component.ExistConnection(connectionId));
 
             Assert.That(streamer.Track, Is.Not.Null);
-            Assert.That(streamer.Senders, Is.Not.Empty);
+            Assert.That(streamer.Sender, Is.Not.Null);
 
             container.test.component.DeleteConnection(connectionId);
             yield return new WaitUntil(() => !container.test.component.ExistConnection(connectionId));
@@ -665,7 +665,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             RTCCodecStats senderCodecStats = null;
             while (senderCodecStats == null)
             {
-                var statsOp = streamer.Senders[connectionId].GetStats();
+                var statsOp = streamer.Sender.GetStats();
                 yield return statsOp;
                 Assert.That(statsOp.IsError, Is.False);
 
@@ -770,7 +770,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             RTCCodecStats senderCodecStats = null;
             while (senderCodecStats == null)
             {
-                var statsOp = streamer.Senders[connectionId].GetStats();
+                var statsOp = streamer.Sender.GetStats();
                 yield return statsOp;
                 Assert.That(statsOp.IsError, Is.False);
 

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
@@ -145,7 +145,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             var streamer = container.test.gameObject.AddComponent<StreamSourceTest>();
 
             Assert.That(streamer.Track, Is.Not.Null);
-            Assert.That(streamer.Sender, Is.Null);
+            Assert.That(streamer.Transceivers, Is.Empty);
 
             container.test.component.AddComponent(streamer);
             container.Dispose();
@@ -200,7 +200,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(isStartedStream2, Is.True);
 
             Assert.That(receiver.Track, Is.Not.Null);
-            Assert.That(receiver.Receiver, Is.Not.Null);
+            Assert.That(receiver.Transceiver, Is.Not.Null);
 
             yield return new WaitUntil(() => container1.test.component.IsConnected(connectionId));
             yield return new WaitUntil(() => container2.test.component.IsConnected(connectionId));
@@ -259,7 +259,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(isStartedStream2, Is.True);
 
             Assert.That(receiver.Track, Is.Not.Null);
-            Assert.That(receiver.Receiver, Is.Not.Null);
+            Assert.That(receiver.Transceiver, Is.Not.Null);
 
             yield return new WaitUntil(() => container1.test.component.IsConnected(connectionId));
             yield return new WaitUntil(() => container2.test.component.IsConnected(connectionId));
@@ -267,7 +267,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             RTCCodecStats senderCodecStats = null;
             while (senderCodecStats == null)
             {
-                var statsOp = streamer.Sender.GetStats();
+                var statsOp = streamer.Transceivers[connectionId].Sender.GetStats();
                 yield return statsOp;
                 Assert.That(statsOp.IsError, Is.False);
 
@@ -319,14 +319,14 @@ namespace Unity.RenderStreaming.RuntimeTest
             var streamer = container.test.gameObject.AddComponent<StreamSourceTest>();
 
             Assert.That(streamer.Track, Is.Not.Null);
-            Assert.That(streamer.Sender, Is.Null);
+            Assert.That(streamer.Transceivers, Is.Empty);
 
             container.test.component.AddComponent(streamer);
             container.test.component.CreateConnection(connectionId);
             yield return new WaitUntil(() => container.test.component.ExistConnection(connectionId));
 
             Assert.That(streamer.Track, Is.Not.Null);
-            Assert.That(streamer.Sender, Is.Not.Null);
+            Assert.That(streamer.Transceivers, Is.Not.Empty);
 
             container.test.component.DeleteConnection(connectionId);
             yield return new WaitUntil(() => !container.test.component.ExistConnection(connectionId));
@@ -413,7 +413,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             receiver.OnStoppedStream += _ => isStoppedStream1 = true;
 
             Assert.That(receiver.Track, Is.Null);
-            Assert.That(receiver.Receiver, Is.Null);
+            Assert.That(receiver.Transceiver, Is.Null);
 
             container2.test.component.AddComponent(receiver);
             container2.test.component.CreateConnection(connectionId);
@@ -423,7 +423,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(isStartedStream1, Is.True);
 
             Assert.That(receiver.Track, Is.Not.Null);
-            Assert.That(receiver.Receiver, Is.Not.Null);
+            Assert.That(receiver.Transceiver, Is.Not.Null);
 
             container1.test.component.DeleteConnection(connectionId);
             container2.test.component.DeleteConnection(connectionId);
@@ -650,7 +650,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             receiver.OnStoppedStream += _ => isStoppedStream1 = true;
 
             Assert.That(receiver.Track, Is.Null);
-            Assert.That(receiver.Receiver, Is.Null);
+            Assert.That(receiver.Transceiver, Is.Null);
 
             container2.test.component.AddComponent(receiver);
             container2.test.component.CreateConnection(connectionId);
@@ -660,12 +660,12 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(isStartedStream1, Is.True);
 
             Assert.That(receiver.Track, Is.Not.Null);
-            Assert.That(receiver.Receiver, Is.Not.Null);
+            Assert.That(receiver.Transceiver, Is.Not.Null);
 
             RTCCodecStats senderCodecStats = null;
             while (senderCodecStats == null)
             {
-                var statsOp = streamer.Sender.GetStats();
+                var statsOp = streamer.Transceivers[connectionId].Sender.GetStats();
                 yield return statsOp;
                 Assert.That(statsOp.IsError, Is.False);
 
@@ -688,7 +688,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             RTCCodecStats receiverCodecStats = null;
             while (receiverCodecStats == null)
             {
-                var statsOp = receiver.Receiver.GetStats();
+                var statsOp = receiver.Transceiver.Receiver.GetStats();
                 yield return statsOp;
                 Assert.That(statsOp.IsError, Is.False);
 
@@ -755,7 +755,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             receiver.FilterVideoCodecs(index);
 
             Assert.That(receiver.Track, Is.Null);
-            Assert.That(receiver.Receiver, Is.Null);
+            Assert.That(receiver.Transceiver, Is.Null);
 
             container2.test.component.AddComponent(receiver);
             container2.test.component.CreateConnection(connectionId);
@@ -765,12 +765,12 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(isStartedStream1, Is.True);
 
             Assert.That(receiver.Track, Is.Not.Null);
-            Assert.That(receiver.Receiver, Is.Not.Null);
+            Assert.That(receiver.Transceiver, Is.Not.Null);
 
             RTCCodecStats senderCodecStats = null;
             while (senderCodecStats == null)
             {
-                var statsOp = streamer.Sender.GetStats();
+                var statsOp = streamer.Transceivers[connectionId].Sender.GetStats();
                 yield return statsOp;
                 Assert.That(statsOp.IsError, Is.False);
 
@@ -793,7 +793,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             RTCCodecStats receiverCodecStats = null;
             while (receiverCodecStats == null)
             {
-                var statsOp = receiver.Receiver.GetStats();
+                var statsOp = receiver.Transceiver.Receiver.GetStats();
                 yield return statsOp;
                 Assert.That(statsOp.IsError, Is.False);
 


### PR DESCRIPTION
We define multiple components to stream video/audio.
- `VideoStreamSender`
- `VideoStreamReceiver`
- `VideoStreamSender`
- `AudioStreamReceiver`

These components should own RTCRtpTransceiver instance to control stream more detail. Since this pull request refactor code to take the instance to these components.