### PR TITLE
fix: Change argument of SetBitrate to set value as range

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -16,14 +16,25 @@ namespace Unity.RenderStreaming
         const uint s_defaultBitrate = 1000;
 
         [SerializeField]
-        private uint m_bitrate = s_defaultBitrate;
+        private uint m_minBitrate = s_defaultBitrate;
+
+        [SerializeField]
+        private uint m_maxBitrate = s_defaultBitrate;
 
         /// <summary>
         /// 
         /// </summary>
-        public uint bitrate
+        public uint minBitrate
         {
-            get { return m_bitrate; }
+            get { return m_minBitrate; }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public uint maxBitrate
+        {
+            get { return m_maxBitrate; }
         }
 
         /// <summary>
@@ -41,14 +52,15 @@ namespace Unity.RenderStreaming
         /// 
         /// </summary>
         /// <param name="bitrate"></param>
-        public void SetBitrate(uint bitrate)
+        public void SetBitrate(uint minBitrate, uint maxBitrate)
         {
-            if (bitrate < 0)
-                throw new ArgumentException();
-            m_bitrate = bitrate;
+            if (minBitrate > maxBitrate)
+                throw new ArgumentException("The maxBitrate must be greater than minBitrate.", "maxBitrate");
+            m_minBitrate = minBitrate;
+            m_maxBitrate = maxBitrate;
             foreach (var transceiver in Transceivers.Values)
             {
-                RTCError error = transceiver.Sender.SetBitrate(m_bitrate);
+                RTCError error = transceiver.Sender.SetBitrate(m_minBitrate, m_maxBitrate);
                 if (error.errorType == RTCErrorType.None)
                     Debug.LogError(error.message);
             }

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -73,8 +73,8 @@ namespace Unity.RenderStreaming
                     new RTCRtpEncodingParameters()
                     {
                         active = true,
-                        maxBitrate = (ulong?)videoStreamSender.bitrate * 1000,
-                        minBitrate = (ulong?)videoStreamSender.bitrate * 1000,
+                        minBitrate = (ulong?)videoStreamSender.minBitrate * 1000,
+                        maxBitrate = (ulong?)videoStreamSender.maxBitrate * 1000,
                         maxFramerate = (uint?)videoStreamSender.frameRate,
                         scaleResolutionDownBy = videoStreamSender.scaleResolutionDown
                     }
@@ -87,8 +87,8 @@ namespace Unity.RenderStreaming
                     new RTCRtpEncodingParameters()
                     {
                         active = true,
-                        maxBitrate = audioStreamSender.bitrate == 0 ? null : (ulong?)audioStreamSender.bitrate * 1000,
-                        minBitrate = audioStreamSender.bitrate == 0 ? null : (ulong?)audioStreamSender.bitrate * 1000,
+                        minBitrate = (ulong?)audioStreamSender.minBitrate * 1000,
+                        maxBitrate = (ulong?)audioStreamSender.maxBitrate * 1000,
                     }
                 };
             }

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
@@ -93,8 +93,8 @@ namespace Unity.RenderStreaming.Samples
 
         private void ChangeBandwidth(int index)
         {
-            var bandwidth = bandwidthOptions.Values.ElementAt(index);
-            videoStreamSender.SetBitrate(bandwidth);
+            var bitrate = bandwidthOptions.Values.ElementAt(index);
+            videoStreamSender.SetBitrate(bitrate, bitrate);
         }
 
         private void ChangeScaleResolutionDown(int index)

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -55,14 +55,14 @@ namespace Unity.RenderStreaming.RuntimeTest
             var go = new GameObject();
             var sender = go.AddComponent<VideoStreamSender>();
 
-            uint bitrate = 2000;
-            sender.SetBitrate(bitrate);
-            Assert.That(sender.bitrate, Is.EqualTo(bitrate));
+            uint minBitrate = 1000;
+            uint maxBitrate = 2000;
+            sender.SetBitrate(minBitrate, maxBitrate);
+            Assert.That(sender.minBitrate, Is.EqualTo(minBitrate));
+            Assert.That(sender.maxBitrate, Is.EqualTo(maxBitrate));
 
-            bitrate = 0;
-            sender.SetBitrate(bitrate);
-            Assert.That(sender.bitrate, Is.EqualTo(bitrate));
-
+            minBitrate = 3000;
+            Assert.Throws<ArgumentException>(() => sender.SetBitrate(minBitrate, maxBitrate));
             UnityEngine.Object.DestroyImmediate(go);
         }
 
@@ -144,14 +144,16 @@ namespace Unity.RenderStreaming.RuntimeTest
             var go = new GameObject();
             var sender = go.AddComponent<AudioStreamSender>();
 
-            uint bitrate = 2000;
-            sender.SetBitrate(bitrate);
-            Assert.That(sender.bitrate, Is.EqualTo(bitrate));
+            uint minBitrate = 1000;
+            uint maxBitrate = 2000;
+            sender.SetBitrate(minBitrate, maxBitrate);
+            Assert.That(sender.minBitrate, Is.EqualTo(minBitrate));
+            Assert.That(sender.maxBitrate, Is.EqualTo(maxBitrate));
 
-            bitrate = 0;
-            sender.SetBitrate(bitrate);
-            Assert.That(sender.bitrate, Is.EqualTo(bitrate));
+            minBitrate = 3000;
+            Assert.Throws<ArgumentException>(() => sender.SetBitrate(minBitrate, maxBitrate));
             UnityEngine.Object.DestroyImmediate(go);
+
         }
 
     }


### PR DESCRIPTION
In WebRTC API, we can set the range of bitrate for video/audio streaming. Therefore, this pull request changes the arguments of methods `VideoStreamSender.SetBitrate` and `AudioStreamSender.SetBitrate`.