### PR TITLE
fix: building by command line timing out when project references RenderStreaming package

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
@@ -42,7 +42,7 @@ namespace Unity.RenderStreaming
         private bool m_running;
 
 #if UNITY_EDITOR
-        [InitializeOnLoadMethod]
+        [InitializeOnEnterPlayMode]
         static void InitializeOnEditor()
         {
             RenderStreamingInternal.DomainUnload();


### PR DESCRIPTION
Issue was due to the InitializeOnLoadMethod attribute causing the doman load to occur during batch mode command line builds.
Using InitializeOnEnterPlayMode attribute allows us to run static init code when starting playmode in the editor, but won't initialize during builds.