### PR TITLE
fix: [workaround] Avoid crash when build app with batchmode on command-line

### DIFF
--- a/BuildScripts~/template/remote.sh.template
+++ b/BuildScripts~/template/remote.sh.template
@@ -4,6 +4,7 @@
 # python version is random on each VM
 export PATH=$PATH:/usr/local/bin:/Users/bokken/Library/Python/3.7/bin:/Users/bokken/Library/Python/3.8/bin
 export ARTIFACT_DIR=${PWD}/test-results
+export YAMATO_JOB_ID=${YAMATO_JOB_ID}
 
 # TEST_TARGET = `ios` or `macos`
 # TEST_PLATFORM = `editmode` or `playmode` or `standalone`

--- a/BuildScripts~/test_package_mac.sh
+++ b/BuildScripts~/test_package_mac.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 #
-# BOKKEN_DEVICE_IP: 
-# TEMPLATE_FILE: 
+# BOKKEN_DEVICE_IP:
+# TEMPLATE_FILE:
 # TEST_TARGET:
 # TEST_PLATFORM:
 # SCRIPTING_BACKEND:
@@ -12,7 +12,7 @@
 # TEST_RESULT_DIR:
 # EDITOR_VERSION:
 #
-# 
+#
 # brew install gettext
 #
 
@@ -33,7 +33,8 @@ envsubst ' \
   $TEST_TARGET \
   $TEST_PLATFORM \
   $TEST_ARCHITECTURE \
-  $EDITOR_VERSION' \
+  $EDITOR_VERSION \
+  $YAMATO_JOB_ID' \
   < ${TEMPLATE_FILE} \
   > ~/remote.sh
 chmod +x ~/remote.sh
@@ -49,7 +50,7 @@ then
 fi
 
 # copy package to remote machine
-scp -i ${IDENTITY} -r ${YAMATO_SOURCE_DIR} bokken@${BOKKEN_DEVICE_IP}:~/${PACKAGE_DIR}  
+scp -i ${IDENTITY} -r ${YAMATO_SOURCE_DIR} bokken@${BOKKEN_DEVICE_IP}:~/${PACKAGE_DIR}
 
 set +e
 
@@ -63,7 +64,7 @@ set -e
 mkdir -p ${TEST_RESULT_DIR}
 scp -i ${IDENTITY} -r bokken@${BOKKEN_DEVICE_IP}:~/test-results ${TEST_RESULT_DIR}
 
-# return ssh commend results 
+# return ssh commend results
 if [ $result -ne 0 ]; then
   exit $result
 fi

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
@@ -52,12 +52,20 @@ namespace Unity.RenderStreaming
             /// therefore the package initialization must be completed just after launching Editor.
             /// In the future, we will remove this workaround after improving the initialization of the
             /// WebRTC package.
-            if (Application.isBatchMode)
-                return;
+            if(!IsYamato)
+            {
+                if (Application.isBatchMode)
+                    return;
+            }
             RenderStreamingInternal.DomainUnload();
             RenderStreamingInternal.DomainLoad();
             EditorApplication.quitting += RenderStreamingInternal.DomainUnload;
         }
+
+        /// <summary>
+        /// Executed from the auto testing environment or not.
+        /// </summary>
+        static bool IsYamato => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("YAMATO_JOB_ID"));
 #else
         [RuntimeInitializeOnLoadMethod]
         static void InitializeOnRuntime()


### PR DESCRIPTION
https://github.com/Unity-Technologies/UnityRenderStreaming/pull/739

This comment in this code describes about the workaround.
```
/// todo(kazuki):: This is workaround.
/// When kicking the Unity Editor with batchmode flag on command line, The Unity Editor crashes 
/// caused by not unloading WebRTC native plugin. By this workaround, Some static methods of this
/// package don't work correctly when batchmode. These static methods depend on WebRTC API,
/// therefore the package initialization must be completed just after launching Editor.
/// In the future, we will remove this workaround after improving the initialization of the
/// WebRTC package.