### PR TITLE
fix: Add FrameRatePropertyDrawer 

### DIFF
--- a/com.unity.renderstreaming/Editor/PropertyDrawers/FrameRateDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/FrameRateDrawer.cs
@@ -1,0 +1,97 @@
+using UnityEditor;
+using UnityEngine;
+using System.Reflection;
+
+namespace Unity.RenderStreaming.Editor
+{
+    [CustomPropertyDrawer(typeof(FrameRateAttribute))]
+    class FrameRateDrawer : PropertyDrawer
+    {
+        readonly GUIContent[] frameRateText =
+        {
+            EditorGUIUtility.TrTextContent("Default"),
+            EditorGUIUtility.TrTextContent("10"),
+            EditorGUIUtility.TrTextContent("15"),
+            EditorGUIUtility.TrTextContent("20"),
+            EditorGUIUtility.TrTextContent("30"),
+            EditorGUIUtility.TrTextContent("60"),
+        };
+
+        readonly float?[] frameRateValues =
+        {
+            null,
+            10,
+            15,
+            20,
+            30,
+            60
+        };
+
+        readonly GUIContent s_FramerateLabel =
+            EditorGUIUtility.TrTextContent("Framerate",
+                "Video encoding framerate.");
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            float value = property.floatValue;
+            var selectIndex = 1;
+            while (selectIndex < frameRateValues.Length && !Mathf.Approximately(value, frameRateValues[selectIndex].Value))
+            {
+                ++selectIndex;
+            }
+
+            // default value
+            if (selectIndex == frameRateValues.Length)
+                selectIndex = 0;
+
+            var popupRect = position;
+            popupRect.height = EditorGUIUtility.singleLineHeight;
+
+            selectIndex = EditorGUI.Popup(popupRect, s_FramerateLabel,
+                selectIndex, frameRateText);
+
+            float newValue;
+            var cutomValueRect = position;
+            cutomValueRect.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+            cutomValueRect.height = 0;
+
+            if (0 < selectIndex && selectIndex < frameRateValues.Length)
+            {
+                newValue = frameRateValues[selectIndex].Value;
+            }
+            else
+            {
+                newValue = 0;
+            }
+            if (!Mathf.Approximately(value, newValue))
+            {
+                property.floatValue = newValue;
+
+                if(Application.isPlaying)
+                {
+                    var objectReferenceValue = property.serializedObject.targetObject;
+                    var type = objectReferenceValue.GetType();
+                    var attribute = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+                    var methodName = "SetFrameRate";
+                    var method = type.GetMethod(methodName, attribute);
+                    method.Invoke(objectReferenceValue, new object[] { newValue });
+                }
+            }
+            EditorGUI.EndProperty();
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            if (property == null)
+                throw new System.ArgumentNullException(nameof(property));
+
+            var height = 0f;
+
+            // Popup.
+            height += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+            return height;
+        }
+    }
+}

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/FrameRateDrawer.cs.meta
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/FrameRateDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6955fbf0f885c624786f638fdcca131a
+timeCreated: 1637904184

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -6,29 +6,14 @@ using System.Linq;
 
 namespace Unity.RenderStreaming
 {
-    /// <summary>
-    ///
-    /// </summary>
     internal sealed class StreamingSizeAttribute : PropertyAttribute { }
 
-    /// <summary>
-    ///
-    /// </summary>
-    internal sealed class FramerateAttribute : PropertyAttribute { }
+    internal sealed class FrameRateAttribute : PropertyAttribute { }
 
-    /// <summary>
-    ///
-    /// </summary>
     internal sealed class BitrateAttribute : PropertyAttribute { }
 
-    /// <summary>
-    ///
-    /// </summary>
     internal sealed class RenderTextureAntiAliasingAttribute : PropertyAttribute { }
 
-    /// <summary>
-    ///
-    /// </summary>
     internal sealed class RenderTextureDepthBufferAttribute : PropertyAttribute { }
 
     internal static class RTCRtpSenderExtension
@@ -96,7 +81,7 @@ namespace Unity.RenderStreaming
         [SerializeField, StreamingSize]
         public Vector2Int streamingSize = new Vector2Int(1280, 720);
 
-        [SerializeField]
+        [SerializeField, FrameRate]
         private float m_frameRate = s_defaultFrameRate;
 
         [SerializeField]


### PR DESCRIPTION
Added the property drawer for the frame rate of the video streaming.
![image](https://user-images.githubusercontent.com/1132081/186296255-b9c2a021-8073-4f46-b87d-2ef510f3f69d.png)
