### PR TITLE
fix: fix logging errors on success

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -61,7 +61,7 @@ namespace Unity.RenderStreaming
             foreach (var transceiver in Transceivers.Values)
             {
                 RTCError error = transceiver.Sender.SetBitrate(m_minBitrate, m_maxBitrate);
-                if (error.errorType == RTCErrorType.None)
+                if (error.errorType != RTCErrorType.None)
                     Debug.LogError(error.message);
             }
         }

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -185,7 +185,7 @@ namespace Unity.RenderStreaming
             foreach (var transceiver in Transceivers.Values)
             {
                 RTCError error = transceiver.Sender.SetFrameRate((uint)m_frameRate);
-                if (error.errorType == RTCErrorType.None)
+                if (error.errorType != RTCErrorType.None)
                     Debug.LogError(error.message);
             }
         }
@@ -203,7 +203,7 @@ namespace Unity.RenderStreaming
             foreach (var transceiver in Transceivers.Values)
             {
                 RTCError error = transceiver.Sender.SetBitrate(m_minBitrate, m_maxBitrate);
-                if (error.errorType == RTCErrorType.None)
+                if (error.errorType != RTCErrorType.None)
                     Debug.LogError(error.message);
             }
         }
@@ -220,7 +220,7 @@ namespace Unity.RenderStreaming
             foreach (var transceiver in Transceivers.Values)
             {
                 RTCError error = transceiver.Sender.SetScaleResolutionDown(m_scaleFactor);
-                if (error.errorType == RTCErrorType.None)
+                if (error.errorType != RTCErrorType.None)
                     Debug.LogError(error.message);
             }
         }


### PR DESCRIPTION
Setting parameters on the Audio or Video sender is resulting in "null" error messages in the debug log.
This is due to the error logging only occuring when there isn't an error.
With this commit it should now only log when set calls are unsuccessful.

To replicate, call a set method during runtime.
The console, or debug log, will contain errors that say null when the set is successful.