### PR TITLE
feat: Add BitrateDrawer 

### DIFF
--- a/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
@@ -11,6 +11,7 @@ namespace Unity.RenderStreaming.Editor
         SerializedProperty propertyMinimum;
         SerializedProperty propertyMaximum;
         bool cache = false;
+        bool changed = false;
         int minLimit;
         int maxLimit;
 
@@ -56,6 +57,7 @@ namespace Unity.RenderStreaming.Editor
             {
                 propertyMinimum.intValue = min;
                 propertyMaximum.intValue = max;
+                changed = true;
             }
             EditorGUI.EndProperty();
 
@@ -69,6 +71,7 @@ namespace Unity.RenderStreaming.Editor
                 min = Mathf.Max(min, minLimit);
                 min = Mathf.Min(min, max);
                 propertyMinimum.intValue = min;
+                changed = true;
             }
 
             // max value
@@ -81,6 +84,21 @@ namespace Unity.RenderStreaming.Editor
                 max = Mathf.Min(max, maxLimit);
                 max = Mathf.Max(min, max);
                 propertyMaximum.intValue = max;
+                changed = true;
+            }
+
+            if (changed)
+            {
+                if (Application.isPlaying)
+                {
+                    var objectReferenceValue = property.serializedObject.targetObject;
+                    var type = objectReferenceValue.GetType();
+                    var attribute = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+                    var methodName = "SetBitrate";
+                    var method = type.GetMethod(methodName, attribute);
+                    method.Invoke(objectReferenceValue, new object[] { (uint)min, (uint)max });
+                }
+                changed = false;
             }
         }
 

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
@@ -1,0 +1,91 @@
+using UnityEditor;
+using UnityEngine;
+using System.Reflection;
+
+namespace Unity.RenderStreaming.Editor
+{
+    [CustomPropertyDrawer(typeof(BitrateAttribute))]
+
+    public class BitrateDrawer : PropertyDrawer
+    {
+        SerializedProperty propertyMinimum;
+        SerializedProperty propertyMaximum;
+        bool cache = false;
+        int minLimit;
+        int maxLimit;
+
+        readonly GUIContent s_bitrateLabel =
+            EditorGUIUtility.TrTextContent("Bitrate (kbits/sec)", "A range of bitrate of video streaming.");
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            if (!cache)
+            {
+                property.Next(true);
+                propertyMinimum = property.Copy();
+                property.Next(true);
+                propertyMaximum = property.Copy();
+                var attr = attribute as BitrateAttribute;
+                minLimit = attr.minValue;
+                maxLimit = attr.maxValue;
+                cache = true;
+            }
+
+            var rect = position;
+            rect.height = EditorGUIUtility.singleLineHeight;
+
+            label = EditorGUI.BeginProperty(position, label, property);
+
+            float minValue = propertyMinimum.intValue;
+            float maxValue = propertyMaximum.intValue;
+
+            // slider 
+            EditorGUI.BeginChangeCheck();
+
+            rect = EditorGUI.PrefixLabel(rect, s_bitrateLabel);
+            EditorGUI.MinMaxSlider(rect, new GUIContent(), ref minValue, ref maxValue, minLimit, maxLimit);
+
+            int min = (int)minValue;
+            int max = (int)maxValue;
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                propertyMinimum.intValue = min;
+                propertyMaximum.intValue = max;
+            }
+            EditorGUI.EndProperty();
+
+            // min value
+            EditorGUI.BeginChangeCheck();
+
+            rect.y += EditorGUIUtility.singleLineHeight;
+            min = EditorGUI.IntField(rect, new GUIContent("Min"), min);
+            if (EditorGUI.EndChangeCheck())
+            {
+                min = Mathf.Max(min, minLimit);
+                min = Mathf.Min(min, max);
+                propertyMinimum.intValue = min;
+            }
+
+            // max value
+            EditorGUI.BeginChangeCheck();
+
+            rect.y += EditorGUIUtility.singleLineHeight;
+            max = EditorGUI.IntField(rect, new GUIContent("Max"), max);
+            if (EditorGUI.EndChangeCheck())
+            {
+                max = Mathf.Min(max, maxLimit);
+                max = Mathf.Max(min, max);
+                propertyMaximum.intValue = max;
+            }
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            //var height = 0f;
+
+            return EditorGUIUtility.singleLineHeight * 3;
+            //return height;
+        }
+    }
+}

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
@@ -16,6 +16,10 @@ namespace Unity.RenderStreaming.Editor
 
         readonly GUIContent s_bitrateLabel =
             EditorGUIUtility.TrTextContent("Bitrate (kbits/sec)", "A range of bitrate of streaming.");
+        readonly GUIContent s_minBitrateLabel =
+            EditorGUIUtility.TrTextContent("Min");
+        readonly GUIContent s_maxBitrateLabel =
+            EditorGUIUtility.TrTextContent("Max");
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -43,7 +47,7 @@ namespace Unity.RenderStreaming.Editor
             EditorGUI.BeginChangeCheck();
 
             rect = EditorGUI.PrefixLabel(rect, s_bitrateLabel);
-            EditorGUI.MinMaxSlider(rect, new GUIContent(), ref minValue, ref maxValue, minLimit, maxLimit);
+            EditorGUI.MinMaxSlider(rect, ref minValue, ref maxValue, minLimit, maxLimit);
 
             int min = (int)minValue;
             int max = (int)maxValue;
@@ -59,7 +63,7 @@ namespace Unity.RenderStreaming.Editor
             EditorGUI.BeginChangeCheck();
 
             rect.y += EditorGUIUtility.singleLineHeight;
-            min = EditorGUI.IntField(rect, new GUIContent("Min"), min);
+            min = EditorGUI.IntField(rect, s_minBitrateLabel, min);
             if (EditorGUI.EndChangeCheck())
             {
                 min = Mathf.Max(min, minLimit);
@@ -71,7 +75,7 @@ namespace Unity.RenderStreaming.Editor
             EditorGUI.BeginChangeCheck();
 
             rect.y += EditorGUIUtility.singleLineHeight;
-            max = EditorGUI.IntField(rect, new GUIContent("Max"), max);
+            max = EditorGUI.IntField(rect, s_maxBitrateLabel, max);
             if (EditorGUI.EndChangeCheck())
             {
                 max = Mathf.Min(max, maxLimit);

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
@@ -15,7 +15,7 @@ namespace Unity.RenderStreaming.Editor
         int maxLimit;
 
         readonly GUIContent s_bitrateLabel =
-            EditorGUIUtility.TrTextContent("Bitrate (kbits/sec)", "A range of bitrate of video streaming.");
+            EditorGUIUtility.TrTextContent("Bitrate (kbits/sec)", "A range of bitrate of streaming.");
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs.meta
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc46ff7d23716ad46823d54c4152b335
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/FrameRateDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/FrameRateDrawer.cs
@@ -67,8 +67,6 @@ namespace Unity.RenderStreaming.Editor
             }
             if (!Mathf.Approximately(value, newValue))
             {
-                property.floatValue = newValue;
-
                 if(Application.isPlaying)
                 {
                     var objectReferenceValue = property.serializedObject.targetObject;
@@ -77,6 +75,10 @@ namespace Unity.RenderStreaming.Editor
                     var methodName = "SetFrameRate";
                     var method = type.GetMethod(methodName, attribute);
                     method.Invoke(objectReferenceValue, new object[] { newValue });
+                }
+                else
+                {
+                    property.floatValue = newValue;
                 }
             }
             EditorGUI.EndProperty();

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -12,14 +12,12 @@ namespace Unity.RenderStreaming
     /// </summary>
     public class AudioStreamSender : StreamSenderBase
     {
-        // todo(kazuki): check default value.
-        const uint s_defaultBitrate = 1000;
+        const uint s_defaultMinBitrate = 0;
+        const uint s_defaultMaxBitrate = 200;
 
-        [SerializeField]
-        private uint m_minBitrate = s_defaultBitrate;
+        [SerializeField, Bitrate(0, 1000)]
+        private Range m_bitrate = new Range(s_defaultMinBitrate, s_defaultMaxBitrate);
 
-        [SerializeField]
-        private uint m_maxBitrate = s_defaultBitrate;
 
         private AudioCodecInfo m_codec;
 
@@ -40,7 +38,7 @@ namespace Unity.RenderStreaming
         /// </summary>
         public uint minBitrate
         {
-            get { return m_minBitrate; }
+            get { return m_bitrate.min; }
         }
 
         /// <summary>
@@ -48,7 +46,7 @@ namespace Unity.RenderStreaming
         /// </summary>
         public uint maxBitrate
         {
-            get { return m_maxBitrate; }
+            get { return m_bitrate.max; }
         }
 
         /// <summary>
@@ -70,11 +68,11 @@ namespace Unity.RenderStreaming
         {
             if (minBitrate > maxBitrate)
                 throw new ArgumentException("The maxBitrate must be greater than minBitrate.", "maxBitrate");
-            m_minBitrate = minBitrate;
-            m_maxBitrate = maxBitrate;
+            m_bitrate.min = minBitrate;
+            m_bitrate.max = maxBitrate;
             foreach (var transceiver in Transceivers.Values)
             {
-                RTCError error = transceiver.Sender.SetBitrate(m_minBitrate, m_maxBitrate);
+                RTCError error = transceiver.Sender.SetBitrate(m_bitrate.min, m_bitrate.max);
                 if (error.errorType != RTCErrorType.None)
                     Debug.LogError(error.message);
             }


### PR DESCRIPTION
Add the new PropertyDrawer which available to set range of bitrate.
<img width="514" alt="image" src="https://user-images.githubusercontent.com/1132081/187119449-afda4208-3f51-4cf8-8623-42b62914ad3d.png">

Also, **BitrateAttribute** class can sets min/max of the slider.
```csharp
        [SerializeField, Bitrate(0, 10000)]
        private Range m_bitrate = new Range(s_defaultMinBitrate, s_defaultMaxBitrate);
```