### PR TITLE
feat: Delegate SetDescription process to PeerConnection class

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/PeerConnection.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/PeerConnection.cs
@@ -275,13 +275,17 @@ namespace Unity.RenderStreaming
             onComplete?.Invoke();
         }
 
-        public void OnGotIceCandidate(RTCIceCandidate candidate)
+        public bool OnGotIceCandidate(RTCIceCandidate candidate)
         {
             if (!_peer.AddIceCandidate(candidate))
             {
                 if (!_ignoreOffer)
                     Debug.LogWarning($"{this} this candidate can't accept current signaling state {_peer.SignalingState}");
+
+                return false;
             }
+
+            return true;
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
@@ -162,6 +162,7 @@ namespace Unity.RenderStreaming
                 config = _conf,
                 signaling = _signaling,
                 startCoroutine = StartCoroutine,
+                stopCoroutine = StopCoroutine,
                 resentOfferInterval = interval,
             };
             var _handlers = (handlers ?? this.handlers.AsEnumerable()).Where(_ => _ != null);

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -384,13 +384,8 @@ namespace Unity.RenderStreaming
                 return;
             }
 
-            _startCoroutine(GotAnswerCoroutine(e.connectionId, pc, e.sdp));
-        }
-
-        IEnumerator GotAnswerCoroutine(string connectionId, PeerConnection pc, string sdp)
-        {
-            var description = new RTCSessionDescription {type = RTCSdpType.Answer, sdp = sdp};
-            yield return pc.OnGotDescription(description, () => onGotAnswer?.Invoke(connectionId, sdp));
+            RTCSessionDescription description = new RTCSessionDescription {type = RTCSdpType.Answer, sdp = e.sdp};
+            _startCoroutine(pc.OnGotDescription(description, () => onGotAnswer?.Invoke(e.connectionId, e.sdp)));
         }
 
         void OnIceCandidate(ISignaling signaling, CandidateData e)
@@ -415,13 +410,8 @@ namespace Unity.RenderStreaming
                 pc = CreatePeerConnection(connectionId, e.polite);
             }
 
-            _startCoroutine(GotOfferCoroutine(connectionId, pc, e.sdp));
-        }
-
-        IEnumerator GotOfferCoroutine(string connectionId, PeerConnection pc, string sdp)
-        {
-            RTCSessionDescription description = new RTCSessionDescription {type = RTCSdpType.Offer, sdp = sdp};
-            yield return pc.OnGotDescription(description, () => onGotOffer?.Invoke(connectionId, sdp));
+            RTCSessionDescription description = new RTCSessionDescription {type = RTCSdpType.Offer, sdp = e.sdp};
+            _startCoroutine(pc.OnGotDescription(description, () => onGotOffer?.Invoke(connectionId, e.sdp)));
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -30,6 +30,11 @@ namespace Unity.RenderStreaming
         public Func<IEnumerator, Coroutine> startCoroutine;
 
         /// <summary>
+        ///
+        /// </summary>
+        public Action<Coroutine> stopCoroutine;
+
+        /// <summary>
         /// unit is second;
         /// </summary>
         public float resentOfferInterval;
@@ -90,6 +95,7 @@ namespace Unity.RenderStreaming
         private readonly ISignaling _signaling;
         private RTCConfiguration _config;
         private readonly Func<IEnumerator, Coroutine> _startCoroutine;
+        private readonly Action<Coroutine> _stopCoroutine;
         private readonly Dictionary<string, PeerConnection> _mapConnectionIdAndPeer =
             new Dictionary<string, PeerConnection>();
         private bool _runningResendCoroutine;
@@ -118,6 +124,7 @@ namespace Unity.RenderStreaming
 
             _config = dependencies.config;
             _startCoroutine = dependencies.startCoroutine;
+            _stopCoroutine = dependencies.stopCoroutine;
             _resendInterval = dependencies.resentOfferInterval;
             _signaling = dependencies.signaling;
             _signaling.OnStart += OnStart;
@@ -345,7 +352,7 @@ namespace Unity.RenderStreaming
                 peer.Dispose();
             }
 
-            peer = new PeerConnection(polite, _config, _resendInterval, _startCoroutine);
+            peer = new PeerConnection(polite, _config, _resendInterval, _startCoroutine, _stopCoroutine);
             _mapConnectionIdAndPeer[connectionId] = peer;
 
             peer.OnConnectHandler += () => onConnect?.Invoke(connectionId);

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingInternal.cs
@@ -190,23 +190,12 @@ namespace Unity.RenderStreaming
 
         public bool IsConnected(string connectionId)
         {
-            if (!_mapConnectionIdAndPeer.TryGetValue(connectionId, out var peer))
-                return false;
-
-            return peer.peer.ConnectionState == RTCPeerConnectionState.Connected;
+            return _mapConnectionIdAndPeer.TryGetValue(connectionId, out var peer) && peer.IsConnected();
         }
 
         public bool IsStable(string connectionId)
         {
-            if (!_mapConnectionIdAndPeer.TryGetValue(connectionId, out var peer))
-                return false;
-
-            if (peer.makingOffer || peer.waitingAnswer)
-            {
-                return false;
-            }
-
-            return peer.peer.SignalingState == RTCSignalingState.Stable;
+            return _mapConnectionIdAndPeer.TryGetValue(connectionId, out var peer) && peer.IsStable();
         }
 
         /// <summary>
@@ -301,18 +290,7 @@ namespace Unity.RenderStreaming
         {
             if (!_mapConnectionIdAndPeer.TryGetValue(connectionId, out var pc))
                 return;
-            if (!IsStable(connectionId))
-            {
-                if (!pc.waitingAnswer)
-                {
-                    throw new InvalidOperationException(
-                        $"{pc} sendoffer needs in stable state, current state is {pc.peer.SignalingState}");
-                }
-
-                _signaling.SendOffer(connectionId, pc.peer.LocalDescription);
-                return;
-            }
-            _startCoroutine(SendOfferCoroutine(connectionId, pc));
+            pc.SendOffer();
         }
 
         /// <summary>
@@ -321,22 +299,18 @@ namespace Unity.RenderStreaming
         /// <param name="connectionId"></param>
         public void SendAnswer(string connectionId)
         {
-            _startCoroutine(SendAnswerCoroutine(connectionId, _mapConnectionIdAndPeer[connectionId]));
+            if (!_mapConnectionIdAndPeer.TryGetValue(connectionId, out var pc))
+                return;
+            pc.SendAnswer();
         }
 
         IEnumerator ResendOfferCoroutine()
         {
             while (_runningResendCoroutine)
             {
-                foreach (var pair in _mapConnectionIdAndPeer.Where(x => x.Value.waitingAnswer))
+                foreach (var peer in _mapConnectionIdAndPeer.Where(x => x.Value.waitingAnswer))
                 {
-                    float timeout = pair.Value.timeSinceStartWaitingAnswer + _resendInterval;
-
-                    if (timeout < Time.realtimeSinceStartup)
-                    {
-                        _signaling.SendOffer(pair.Key, pair.Value.peer.LocalDescription);
-                        pair.Value.RestartTimerForWaitingAnswer();
-                    }
+                    peer.Value.SendOffer();
                 }
                 yield return 0;
             }
@@ -368,25 +342,19 @@ namespace Unity.RenderStreaming
         {
             if (_mapConnectionIdAndPeer.TryGetValue(connectionId, out var peer))
             {
-                peer.peer.Close();
+                peer.Dispose();
             }
 
-            var pc = new RTCPeerConnection();
-            peer = new PeerConnection(pc, polite);
+            peer = new PeerConnection(polite, _config, _resendInterval, _startCoroutine);
             _mapConnectionIdAndPeer[connectionId] = peer;
 
-            pc.SetConfiguration(ref _config);
-            pc.OnDataChannel = channel => { OnDataChannel(connectionId, channel); };
-            pc.OnIceCandidate = candidate =>
-            {
-                _signaling.SendCandidate(connectionId, candidate);
-            };
-            pc.OnConnectionStateChange = state => OnConnectionStateChange(connectionId, state);
-            pc.OnTrack = trackEvent =>
-            {
-                onAddTransceiver?.Invoke(connectionId, trackEvent.Transceiver);
-            };
-            pc.OnNegotiationNeeded = () => _startCoroutine(OnNegotiationNeeded(connectionId));
+            peer.OnConnectHandler += () => onConnect?.Invoke(connectionId);
+            peer.OnDisconnectHandler += () => onDisconnect?.Invoke(connectionId);
+            peer.OnDataChannelHandler += channel => onAddChannel?.Invoke(connectionId, channel);;
+            peer.OnTrackEventHandler += e => onAddTransceiver?.Invoke(connectionId, e.Transceiver);
+            peer.SendOfferHandler += desc => _signaling?.SendOffer(connectionId, desc);
+            peer.SendAnswerHandler += desc => _signaling?.SendAnswer(connectionId, desc);
+            peer.SendCandidateHandler += candidate => _signaling?.SendCandidate(connectionId, candidate);
             return peer;
         }
 
@@ -399,62 +367,6 @@ namespace Unity.RenderStreaming
 
             peer.Dispose();
             _mapConnectionIdAndPeer.Remove(connectionId);
-        }
-
-        void OnDataChannel(string connectionId, RTCDataChannel channel)
-        {
-            onAddChannel?.Invoke(connectionId, channel);
-        }
-
-        void OnConnectionStateChange(string connectionId, RTCPeerConnectionState state)
-        {
-            switch (state)
-            {
-                case RTCPeerConnectionState.Connected:
-                    onConnect?.Invoke(connectionId);
-                    break;
-                case RTCPeerConnectionState.Disconnected:
-                    onDisconnect?.Invoke(connectionId);
-                    break;
-            }
-        }
-
-        IEnumerator OnNegotiationNeeded(string connectionId)
-        {
-            yield return new WaitWhile(() => !IsStable(connectionId));
-            SendOffer(connectionId);
-        }
-
-        IEnumerator SendOfferCoroutine(string connectionId, PeerConnection pc)
-        {
-            // waiting other setLocalDescription process
-            yield return new WaitWhile(() => !IsStable(connectionId));
-
-            if (!ExistConnection(connectionId))
-                yield break;
-
-            Assert.AreEqual(pc.peer.SignalingState, RTCSignalingState.Stable,
-                $"{pc} negotiationneeded always fires in stable state");
-            Assert.AreEqual(pc.makingOffer, false, $"{pc} negotiationneeded not already in progress");
-
-            pc.makingOffer = true;
-            var opLocalDesc = pc.peer.SetLocalDescription();
-            yield return opLocalDesc;
-
-            if (opLocalDesc.IsError)
-            {
-                Debug.LogError($"{pc} {opLocalDesc.Error.message}");
-                pc.makingOffer = false;
-                yield break;
-            }
-
-            Assert.AreEqual(pc.peer.SignalingState, RTCSignalingState.HaveLocalOffer,
-                $"{pc} negotiationneeded not racing with onmessage");
-            Assert.AreEqual(pc.peer.LocalDescription.type, RTCSdpType.Offer, $"{pc} negotiationneeded SLD worked");
-            pc.makingOffer = false;
-            pc.waitingAnswer = true;
-
-            _signaling.SendOffer(connectionId, pc.peer.LocalDescription);
         }
 
         void OnAnswer(ISignaling signaling, DescData e)
@@ -470,31 +382,8 @@ namespace Unity.RenderStreaming
 
         IEnumerator GotAnswerCoroutine(string connectionId, PeerConnection pc, string sdp)
         {
-            var description = new RTCSessionDescription();
-            description.type = RTCSdpType.Answer;
-            description.sdp = sdp;
-
-            // waiting other setLocalDescription process
-            yield return new WaitWhile(() => pc.makingOffer || pc.makingAnswer);
-
-            pc.waitingAnswer = false;
-            pc.srdAnswerPending = true;
-
-            var opRemoteDesc = pc.peer.SetRemoteDescription(ref description);
-            yield return opRemoteDesc;
-
-            if (opRemoteDesc.IsError)
-            {
-                Debug.LogError($"{pc} {opRemoteDesc.Error.message}");
-                pc.srdAnswerPending = false;
-                yield break;
-            }
-
-            Assert.AreEqual(pc.peer.RemoteDescription.type, RTCSdpType.Answer, $"{pc} Answer was set");
-            Assert.AreEqual(pc.peer.SignalingState, RTCSignalingState.Stable, $"{pc} answered");
-            pc.srdAnswerPending = false;
-
-            onGotAnswer?.Invoke(connectionId, sdp);
+            var description = new RTCSessionDescription {type = RTCSdpType.Answer, sdp = sdp};
+            yield return pc.OnGotDescription(description, () => onGotAnswer?.Invoke(connectionId, sdp));
         }
 
         void OnIceCandidate(ISignaling signaling, CandidateData e)
@@ -508,11 +397,7 @@ namespace Unity.RenderStreaming
             {
                 candidate = e.candidate, sdpMLineIndex = e.sdpMLineIndex, sdpMid = e.sdpMid
             };
-
-            if (!pc.peer.AddIceCandidate(new RTCIceCandidate(option)) && !pc.ignoreOffer)
-            {
-                Debug.LogWarning($"{pc} this candidate can't accept current signaling state {pc.peer.SignalingState}.");
-            }
+            pc.OnGotIceCandidate(new RTCIceCandidate(option));
         }
 
         void OnOffer(ISignaling signaling, DescData e)
@@ -528,59 +413,8 @@ namespace Unity.RenderStreaming
 
         IEnumerator GotOfferCoroutine(string connectionId, PeerConnection pc, string sdp)
         {
-            RTCSessionDescription description;
-            description.type = RTCSdpType.Offer;
-            description.sdp = sdp;
-
-            var isStable =
-                pc.peer.SignalingState == RTCSignalingState.Stable ||
-                (pc.peer.SignalingState == RTCSignalingState.HaveLocalOffer && pc.srdAnswerPending);
-            pc.ignoreOffer = !pc.polite && (pc.makingOffer || !isStable);
-            if (pc.ignoreOffer || pc.makingAnswer)
-            {
-                Debug.LogWarning($"{pc} glare - ignoreOffer {nameof(pc.peer.SignalingState)}:{pc.peer.SignalingState}");
-                yield break;
-            }
-
-            // waiting other setRemoteDescription process
-            yield return new WaitWhile(() => pc.srdAnswerPending);
-            pc.waitingAnswer = false;
-
-            var opRemoteDesc = pc.peer.SetRemoteDescription(ref description);
-            yield return opRemoteDesc;
-
-            if (opRemoteDesc.IsError)
-            {
-                Debug.LogError($"{pc} {opRemoteDesc.Error.message}");
-                yield break;
-            }
-
-            Assert.AreEqual(pc.peer.RemoteDescription.type, RTCSdpType.Offer, $"{pc} SRD worked");
-            Assert.AreEqual(pc.peer.SignalingState, RTCSignalingState.HaveRemoteOffer, $"{pc} Remote offer");
-
-            onGotOffer?.Invoke(connectionId, sdp);
-        }
-
-        IEnumerator SendAnswerCoroutine(string connectionId, PeerConnection pc)
-        {
-            pc.makingAnswer = true;
-
-            var opLocalDesc = pc.peer.SetLocalDescription();
-            yield return opLocalDesc;
-
-            if (opLocalDesc.IsError)
-            {
-                Debug.LogError($"{pc} {opLocalDesc.Error.message}");
-                pc.makingAnswer = false;
-                yield break;
-            }
-
-            Assert.AreEqual(pc.peer.LocalDescription.type, RTCSdpType.Answer, $"{pc} onmessage SLD worked");
-            Assert.AreEqual(pc.peer.SignalingState, RTCSignalingState.Stable,
-                $"{pc} onmessage not racing with negotiationneeded");
-            pc.makingAnswer = false;
-
-            _signaling.SendAnswer(connectionId, pc.peer.LocalDescription);
+            RTCSessionDescription description = new RTCSessionDescription {type = RTCSdpType.Offer, sdp = sdp};
+            yield return pc.OnGotDescription(description, () => onGotOffer?.Invoke(connectionId, sdp));
         }
     }
 }

--- a/com.unity.renderstreaming/Tests/Runtime/InputSystem/InputRemotingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/InputSystem/InputRemotingTest.cs
@@ -63,6 +63,7 @@ namespace Unity.RenderStreaming.RuntimeTest
                     iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } },
                 },
                 startCoroutine = _test.component.StartCoroutine,
+                stopCoroutine = _test.component.StopCoroutine,
                 resentOfferInterval = ResendOfferInterval,
             };
         }
@@ -176,7 +177,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             receiverDisposer.Dispose();
         }
 
-        /// todo(kazuki): This test is failed for timeout on macOS 
+        /// todo(kazuki): This test is failed for timeout on macOS
         [UnityTest, Timeout(3000)]
         [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator AddDevice()

--- a/com.unity.renderstreaming/Tests/Runtime/PeerConnectionTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PeerConnectionTest.cs
@@ -38,8 +38,79 @@ namespace Unity.RenderStreaming.RuntimeTest
             Object.Destroy(test.gameObject);
         }
 
-        [UnityTest, Timeout(10000)]
-        public IEnumerator CreateChannel()
+        [Test, Timeout(5000)]
+        public void Construct()
+        {
+            var peer = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer, Is.Not.Null);
+            var rtcPeer = peer.peer;
+            Assert.That(rtcPeer, Is.Not.Null);
+            Assert.That(rtcPeer.OnTrack, Is.Not.Null);
+            Assert.That(rtcPeer.OnIceCandidate, Is.Not.Null);
+            Assert.That(rtcPeer.OnNegotiationNeeded, Is.Not.Null);
+            Assert.That(rtcPeer.OnDataChannel, Is.Not.Null);
+            Assert.That(rtcPeer.OnConnectionStateChange, Is.Not.Null);
+
+            peer.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator CalledSendOfferWhenAddTrack()
+        {
+            var peer = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer, Is.Not.Null);
+
+            var isGotSendOffer = false;
+            RTCSessionDescription offerDesc = default;
+            peer.SendOfferHandler += description =>
+            {
+                isGotSendOffer = true;
+                offerDesc = description;
+            };
+
+            var track = new AudioStreamTrack();
+            peer.peer.AddTrack(track);
+
+            yield return new WaitUntil(() => isGotSendOffer);
+            Assert.That(isGotSendOffer, Is.True);
+            Assert.That(offerDesc.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc.sdp, Is.Not.Null.Or.Empty);
+
+            track.Dispose();
+            peer.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator CalledSendOfferWhenAddTransceiver()
+        {
+            var peer = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer, Is.Not.Null);
+
+            var isGotSendOffer = false;
+            RTCSessionDescription offerDesc = default;
+            peer.SendOfferHandler += description =>
+            {
+                isGotSendOffer = true;
+                offerDesc = description;
+            };
+
+            var transceiver = peer.peer.AddTransceiver(TrackKind.Video);
+            Assert.That(transceiver, Is.Not.Null);
+
+            yield return new WaitUntil(() => isGotSendOffer);
+            Assert.That(isGotSendOffer, Is.True);
+            Assert.That(offerDesc.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc.sdp, Is.Not.Null.Or.Empty);
+
+            transceiver.Dispose();
+            peer.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator CalledSendOfferWhenCreateChannel()
         {
             var peer = new PeerConnection(
                 true,
@@ -68,5 +139,445 @@ namespace Unity.RenderStreaming.RuntimeTest
             channel.Dispose();
             peer.Dispose();
         }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator CalledSendOfferTwiceIfGetAnswerNotYet()
+        {
+            var peer = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer, Is.Not.Null);
+
+            var sendOfferCount = 0;
+            RTCSessionDescription offerDesc = default;
+            peer.SendOfferHandler += description =>
+            {
+                sendOfferCount++;
+                offerDesc = description;
+            };
+
+            var track = new AudioStreamTrack();
+            peer.peer.AddTrack(track);
+
+            while (sendOfferCount <= 2)
+            {
+                yield return new WaitForSeconds(ResendOfferInterval);
+                Assert.That(peer.waitingAnswer, Is.True);
+                peer.SendOffer();
+            }
+
+            yield return new WaitUntil(() => sendOfferCount > 2);
+            Assert.That(sendOfferCount, Is.GreaterThan(2));
+            Assert.That(offerDesc.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc.sdp, Is.Not.Null.Or.Empty);
+
+            track.Dispose();
+            peer.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        [TestCase(true, ExpectedResult = null)]
+        [TestCase(false, ExpectedResult = null)]
+        public IEnumerator CalledSendAnswerWhenGotDescriptionWhenStable(bool polite)
+        {
+            var peer1 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer1, Is.Not.Null);
+            var peer2 = new PeerConnection(polite, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer2, Is.Not.Null);
+
+            var isGotSendOffer = false;
+            RTCSessionDescription offerDesc = default;
+            peer1.SendOfferHandler += description =>
+            {
+                isGotSendOffer = true;
+                offerDesc = description;
+            };
+
+            var isGotSendAnswer = false;
+            RTCSessionDescription answerDesc = default;
+            peer2.SendAnswerHandler += description =>
+            {
+                isGotSendAnswer = true;
+                answerDesc = description;
+            };
+
+            var track = new AudioStreamTrack();
+            peer1.peer.AddTrack(track);
+
+            yield return new WaitUntil(() => isGotSendOffer);
+            Assert.That(isGotSendOffer, Is.True);
+            Assert.That(offerDesc.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc.sdp, Is.Not.Null.Or.Empty);
+
+            var isComplete = false;
+            yield return peer2.OnGotDescription(offerDesc, () => isComplete = true);
+            Assert.That(isComplete, Is.True);
+            peer2.SendAnswer();
+
+            yield return new WaitUntil(() => isGotSendAnswer);
+            Assert.That(isGotSendAnswer, Is.True);
+            Assert.That(answerDesc.type, Is.EqualTo(RTCSdpType.Answer));
+            Assert.That(answerDesc.sdp, Is.Not.Null.Or.Empty);
+
+            track.Dispose();
+            peer1.Dispose();
+            peer2.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator CalledSendAnswerWhenGotDescriptionThatHaveLocalOfferInPolite()
+        {
+            var peer1 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer1, Is.Not.Null);
+            var peer2 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer2, Is.Not.Null);
+
+            var isGotSendOffer1 = false;
+            RTCSessionDescription offerDesc1 = default;
+            peer1.SendOfferHandler += description =>
+            {
+                isGotSendOffer1 = true;
+                offerDesc1 = description;
+            };
+
+            var isGotSendOffer2 = false;
+            RTCSessionDescription offerDesc2 = default;
+            peer2.SendOfferHandler += description =>
+            {
+                isGotSendOffer2 = true;
+                offerDesc2 = description;
+            };
+
+            var isGotSendAnswer = false;
+            RTCSessionDescription answerDesc = default;
+            peer2.SendAnswerHandler += description =>
+            {
+                isGotSendAnswer = true;
+                answerDesc = description;
+            };
+
+            var track1 = new AudioStreamTrack();
+            peer1.peer.AddTrack(track1);
+            var track2 = new AudioStreamTrack();
+            peer2.peer.AddTrack(track2);
+
+            yield return new WaitUntil(() => isGotSendOffer1);
+            Assert.That(isGotSendOffer1, Is.True);
+            Assert.That(offerDesc1.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc1.sdp, Is.Not.Null.Or.Empty);
+
+            yield return new WaitUntil(() => isGotSendOffer2);
+            Assert.That(isGotSendOffer1, Is.True);
+            Assert.That(offerDesc2.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc2.sdp, Is.Not.Null.Or.Empty);
+            Assert.That(peer2.peer.SignalingState, Is.EqualTo(RTCSignalingState.HaveLocalOffer));
+
+            var isComplete = false;
+            yield return peer2.OnGotDescription(offerDesc1, () => isComplete = true);
+            Assert.That(isComplete, Is.True);
+            peer2.SendAnswer();
+
+            yield return new WaitUntil(() => isGotSendAnswer);
+            Assert.That(isGotSendAnswer, Is.True);
+            Assert.That(answerDesc.type, Is.EqualTo(RTCSdpType.Answer));
+            Assert.That(answerDesc.sdp, Is.Not.Null.Or.Empty);
+            Assert.That(peer2.peer.SignalingState, Is.EqualTo(RTCSignalingState.Stable));
+
+            track1.Dispose();
+            track2.Dispose();
+            peer1.Dispose();
+            peer2.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator NotCalledSendAnswerWhenGotDescriptionThatHaveLocalOfferInImpolite()
+        {
+            var peer1 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer1, Is.Not.Null);
+            var peer2 = new PeerConnection(false, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer2, Is.Not.Null);
+
+            var isGotSendOffer1 = false;
+            RTCSessionDescription offerDesc1 = default;
+            peer1.SendOfferHandler += description =>
+            {
+                isGotSendOffer1 = true;
+                offerDesc1 = description;
+            };
+
+            var isGotSendOffer2 = false;
+            RTCSessionDescription offerDesc2 = default;
+            peer2.SendOfferHandler += description =>
+            {
+                isGotSendOffer2 = true;
+                offerDesc2 = description;
+            };
+
+            var track1 = new AudioStreamTrack();
+            peer1.peer.AddTrack(track1);
+            var track2 = new AudioStreamTrack();
+            peer2.peer.AddTrack(track2);
+
+            yield return new WaitUntil(() => isGotSendOffer1);
+            Assert.That(isGotSendOffer1, Is.True);
+            Assert.That(offerDesc1.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc1.sdp, Is.Not.Null.Or.Empty);
+
+            yield return new WaitUntil(() => isGotSendOffer2);
+            Assert.That(isGotSendOffer1, Is.True);
+            Assert.That(offerDesc2.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc2.sdp, Is.Not.Null.Or.Empty);
+            Assert.That(peer2.peer.SignalingState, Is.EqualTo(RTCSignalingState.HaveLocalOffer));
+
+            var isComplete = false;
+            yield return peer2.OnGotDescription(offerDesc1, () => isComplete = true);
+            Assert.That(isComplete, Is.False);
+            Assert.That(peer2.peer.SignalingState, Is.EqualTo(RTCSignalingState.HaveLocalOffer));
+
+            track1.Dispose();
+            track2.Dispose();
+            peer1.Dispose();
+            peer2.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator CalledTrackEventWhenGotSdpIncludeTrack()
+        {
+            var peer1 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer1, Is.Not.Null);
+            var peer2 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer2, Is.Not.Null);
+
+            var isGotSendOffer = false;
+            RTCSessionDescription offerDesc = default;
+            peer1.SendOfferHandler += description =>
+            {
+                isGotSendOffer = true;
+                offerDesc = description;
+            };
+
+            var isGotTrackEvent = false;
+            RTCTrackEvent trackEvent = null;
+            peer2.OnTrackEventHandler += e =>
+            {
+                isGotTrackEvent = true;
+                trackEvent = e;
+            };
+
+            var track = new AudioStreamTrack();
+            peer1.peer.AddTrack(track);
+
+            yield return new WaitUntil(() => isGotSendOffer);
+            Assert.That(isGotSendOffer, Is.True);
+            Assert.That(offerDesc.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc.sdp, Is.Not.Null.Or.Empty);
+
+            var isComplete = false;
+            yield return peer2.OnGotDescription(offerDesc, () => isComplete = true);
+            Assert.That(isComplete, Is.True);
+
+            yield return new WaitUntil(() => isGotTrackEvent);
+            Assert.That(isGotTrackEvent, Is.True);
+            Assert.That(trackEvent, Is.Not.Null);
+            Assert.That(trackEvent.Track.Id, Is.EqualTo(track.Id));
+
+            track.Dispose();
+            peer1.Dispose();
+            peer2.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator CalledOnDataChannelWhenGotSdpIncludeDataChannel()
+        {
+            var peer1 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer1, Is.Not.Null);
+            var peer2 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer2, Is.Not.Null);
+
+            var isGotSendOffer = false;
+            RTCSessionDescription offerDesc = default;
+            peer1.SendOfferHandler += description =>
+            {
+                isGotSendOffer = true;
+                offerDesc = description;
+            };
+
+            var isGotSendAnswer = false;
+            RTCSessionDescription answerDesc = default;
+            peer2.SendAnswerHandler += description =>
+            {
+                isGotSendAnswer = true;
+                answerDesc = description;
+            };
+
+            var isGotDataChannel = false;
+            RTCDataChannel dataChannel = null;
+            peer2.OnDataChannelHandler += e =>
+            {
+                isGotDataChannel = true;
+                dataChannel = e;
+            };
+
+            var channel = peer1.peer.CreateDataChannel("test");
+            Assert.That(channel, Is.Not.Null);
+
+            yield return new WaitUntil(() => isGotSendOffer);
+            Assert.That(isGotSendOffer, Is.True);
+            Assert.That(offerDesc.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc.sdp, Is.Not.Null.Or.Empty);
+
+            var isComplete = false;
+            yield return peer2.OnGotDescription(offerDesc, () => isComplete = true);
+            Assert.That(isComplete, Is.True);
+
+            peer2.SendAnswer();
+            yield return new WaitUntil(() => isGotSendAnswer);
+            Assert.That(isGotSendAnswer, Is.True);
+            Assert.That(answerDesc.type, Is.EqualTo(RTCSdpType.Answer));
+            Assert.That(answerDesc.sdp, Is.Not.Null.Or.Empty);
+
+            isComplete = false;
+            yield return peer1.OnGotDescription(answerDesc, () => isComplete = true);
+            Assert.That(isComplete, Is.True);
+
+            yield return new WaitUntil(() => isGotDataChannel);
+            Assert.That(isGotDataChannel, Is.True);
+            Assert.That(dataChannel, Is.Not.Null);
+            Assert.That(dataChannel.Id, Is.EqualTo(channel.Id));
+
+            channel.Dispose();
+            peer1.Dispose();
+            peer2.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator CalledSendCandidateWhenAddTransceiver()
+        {
+            var peer = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer, Is.Not.Null);
+
+            var isGotSendCandidate = false;
+            RTCIceCandidate candidate = null;
+            peer.SendCandidateHandler += e =>
+            {
+                isGotSendCandidate = true;
+                candidate = e;
+            };
+
+            var transceiver = peer.peer.AddTransceiver(TrackKind.Video);
+            Assert.That(transceiver, Is.Not.Null);
+
+            yield return new WaitUntil(() => isGotSendCandidate);
+            Assert.That(isGotSendCandidate, Is.True);
+            Assert.That(candidate, Is.Not.Null);
+
+            transceiver.Dispose();
+            peer.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator AcceptWhenGotCandidateThatHaveRemoteDescription()
+        {
+            var peer1 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer1, Is.Not.Null);
+            var peer2 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer2, Is.Not.Null);
+
+            var isGotSendOffer1 = false;
+            RTCSessionDescription offerDesc1 = default;
+            peer1.SendOfferHandler += description =>
+            {
+                isGotSendOffer1 = true;
+                offerDesc1 = description;
+            };
+
+            var isGotSendCandidate = false;
+            RTCIceCandidate candidate = null;
+            peer1.SendCandidateHandler += e =>
+            {
+                isGotSendCandidate = true;
+                candidate = e;
+            };
+
+            var transceiver = peer1.peer.AddTransceiver(TrackKind.Video);
+            Assert.That(transceiver, Is.Not.Null);
+
+            yield return new WaitUntil(() => isGotSendOffer1);
+            Assert.That(isGotSendOffer1, Is.True);
+            Assert.That(offerDesc1.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc1.sdp, Is.Not.Null.Or.Empty);
+
+            yield return new WaitUntil(() => isGotSendCandidate);
+            Assert.That(isGotSendCandidate, Is.True);
+            Assert.That(candidate, Is.Not.Null);
+
+            var isComplete = false;
+            yield return peer2.OnGotDescription(offerDesc1, () => isComplete = true);
+            Assert.That(isComplete, Is.True);
+
+            Assert.That(peer2.OnGotIceCandidate(candidate), Is.True);
+
+            transceiver.Dispose();
+            peer1.Dispose();
+            peer2.Dispose();
+        }
+
+        [UnityTest, Timeout(5000)]
+        public IEnumerator NotAcceptWhenGotCandidateThatDontHaveRemoteDescription()
+        {
+            var peer1 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer1, Is.Not.Null);
+            var peer2 = new PeerConnection(true, config, ResendOfferInterval,
+                test.component.StartCoroutine, test.component.StopCoroutine);
+            Assert.That(peer2, Is.Not.Null);
+
+            var isGotSendOffer1 = false;
+            RTCSessionDescription offerDesc1 = default;
+            peer1.SendOfferHandler += description =>
+            {
+                isGotSendOffer1 = true;
+                offerDesc1 = description;
+            };
+
+            var isGotSendCandidate = false;
+            RTCIceCandidate candidate = null;
+            peer1.SendCandidateHandler += e =>
+            {
+                isGotSendCandidate = true;
+                candidate = e;
+            };
+
+            var transceiver = peer1.peer.AddTransceiver(TrackKind.Video);
+            Assert.That(transceiver, Is.Not.Null);
+
+            yield return new WaitUntil(() => isGotSendOffer1);
+            Assert.That(isGotSendOffer1, Is.True);
+            Assert.That(offerDesc1.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc1.sdp, Is.Not.Null.Or.Empty);
+
+            yield return new WaitUntil(() => isGotSendCandidate);
+            Assert.That(isGotSendCandidate, Is.True);
+            Assert.That(candidate, Is.Not.Null);
+
+            Assert.That(peer2.OnGotIceCandidate(candidate), Is.False);
+
+            transceiver.Dispose();
+            peer1.Dispose();
+            peer2.Dispose();
+        }
+
     }
 }

--- a/com.unity.renderstreaming/Tests/Runtime/PeerConnectionTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PeerConnectionTest.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Unity.WebRTC;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.RenderStreaming.RuntimeTest
+{
+    class PeerConnectionTest
+    {
+        class MyMonoBehaviourTest : MonoBehaviour, IMonoBehaviourTest
+        {
+            public bool IsTestFinished
+            {
+                get { return true; }
+            }
+        }
+
+        private const float ResendOfferInterval = 1.0f;
+        private MonoBehaviourTest<MyMonoBehaviourTest> test;
+        private RTCConfiguration config;
+
+        [SetUp]
+        public void SetUp()
+        {
+            test = new MonoBehaviourTest<MyMonoBehaviourTest>();
+            config = new RTCConfiguration
+            {
+                iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } },
+            };
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            test.component.StopAllCoroutines();
+            Object.Destroy(test.gameObject);
+        }
+
+        [UnityTest, Timeout(10000)]
+        public IEnumerator CreateChannel()
+        {
+            var peer = new PeerConnection(
+                true,
+                config,
+                ResendOfferInterval,
+                test.component.StartCoroutine,
+                test.component.StopCoroutine
+            );
+
+            var isGotSendOffer = false;
+            RTCSessionDescription offerDesc = default;
+            peer.SendOfferHandler += description =>
+            {
+                isGotSendOffer = true;
+                offerDesc = description;
+            };
+
+            var channel = peer.peer.CreateDataChannel("test");
+            Assert.That(channel, Is.Not.Null);
+
+            yield return new WaitUntil(() => isGotSendOffer);
+            Assert.That(isGotSendOffer, Is.True);
+            Assert.That(offerDesc.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(offerDesc.sdp, Is.Not.Null.Or.Empty);
+
+            channel.Dispose();
+            peer.Dispose();
+        }
+    }
+}

--- a/com.unity.renderstreaming/Tests/Runtime/PeerConnectionTest.cs.meta
+++ b/com.unity.renderstreaming/Tests/Runtime/PeerConnectionTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ba9cd9098d364eecbabbf6d1c678b2d5
+timeCreated: 1661734624

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingInternalTest.cs
@@ -62,6 +62,7 @@ namespace Unity.RenderStreaming.RuntimeTest
                     iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } },
                 },
                 startCoroutine = test.component.StartCoroutine,
+                stopCoroutine = test.component.StopCoroutine,
                 resentOfferInterval = ResendOfferInterval,
             };
         }

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
@@ -101,6 +101,7 @@ namespace Unity.RenderStreaming.RuntimeTest
                     iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } },
                 },
                 startCoroutine = behaviour.StartCoroutine,
+                stopCoroutine = behaviour.StopCoroutine,
                 resentOfferInterval = ResendOfferInterval,
             };
         }


### PR DESCRIPTION
Delegate `SetDescription` process to `Unity.RenderStreaming.PeerConnection` class.
Changed to `SetDescription` processing is not executed in parallel.

Add test about `Unity.RenderStreaming.PeerConnection` class.
- Confirm that the result is according to the current `SignalingState`.
- Check the behavior when receiving description while processing other description.
```
PeerConnectionTest
- SendOfferTwiceImmediately
- SendAnswerTwiceImmediately
- OnGotOfferDescriptionAfterSendOfferImmediatelyInPolite
- OnGotOfferDescriptionAfterSendOfferImmediatelyInImPolite
- OnGotAnswerDescriptionAfterSendOfferImmediately(polite/impolite)
- OnGotOfferDescriptionAfterSendAnswerImmediately(polite/impolite)
```