### PR TITLE
feat: Add CodecDrawer

### DIFF
--- a/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
@@ -26,10 +26,8 @@ namespace Unity.RenderStreaming.Editor
         {
             if (!cache)
             {
-                property.Next(true);
-                propertyMinimum = property.Copy();
-                property.Next(true);
-                propertyMaximum = property.Copy();
+                propertyMinimum = property.FindPropertyInChildren("min");
+                propertyMaximum = property.FindPropertyInChildren("max");
                 var attr = attribute as BitrateAttribute;
                 minLimit = attr.minValue;
                 maxLimit = attr.maxValue;

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
@@ -15,11 +15,11 @@ namespace Unity.RenderStreaming.Editor
         int minLimit;
         int maxLimit;
 
-        readonly GUIContent s_bitrateLabel =
+        static readonly GUIContent s_bitrateLabel =
             EditorGUIUtility.TrTextContent("Bitrate (kbits/sec)", "A range of bitrate of streaming.");
-        readonly GUIContent s_minBitrateLabel =
+        static readonly GUIContent s_minBitrateLabel =
             EditorGUIUtility.TrTextContent("Min");
-        readonly GUIContent s_maxBitrateLabel =
+        static readonly GUIContent s_maxBitrateLabel =
             EditorGUIUtility.TrTextContent("Max");
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
@@ -39,7 +39,7 @@ namespace Unity.RenderStreaming.Editor
             var rect = position;
             rect.height = EditorGUIUtility.singleLineHeight;
 
-            label = EditorGUI.BeginProperty(position, label, property);
+            EditorGUI.BeginProperty(position, label, property);
 
             float minValue = propertyMinimum.intValue;
             float maxValue = propertyMaximum.intValue;

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/BitrateDrawer.cs
@@ -33,13 +33,14 @@ namespace Unity.RenderStreaming.Editor
                 var attr = attribute as BitrateAttribute;
                 minLimit = attr.minValue;
                 maxLimit = attr.maxValue;
+                property.Reset();
                 cache = true;
             }
 
             var rect = position;
             rect.height = EditorGUIUtility.singleLineHeight;
 
-            EditorGUI.BeginProperty(position, label, property);
+            EditorGUI.BeginProperty(rect, label, property);
 
             float minValue = propertyMinimum.intValue;
             float maxValue = propertyMaximum.intValue;

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/CodecDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/CodecDrawer.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using System.Reflection;
+
+namespace Unity.RenderStreaming.Editor
+{
+    [CustomPropertyDrawer(typeof(CodecAttribute))]
+    class CodecDrawer : PropertyDrawer
+    {
+        //readonly GUIContent[] frameRateText =
+        //{
+        //    EditorGUIUtility.TrTextContent("Default"),
+        //    EditorGUIUtility.TrTextContent("10"),
+        //    EditorGUIUtility.TrTextContent("15"),
+        //    EditorGUIUtility.TrTextContent("20"),
+        //    EditorGUIUtility.TrTextContent("30"),
+        //    EditorGUIUtility.TrTextContent("60"),
+        //};
+
+        //readonly float?[] frameRateValues =
+        //{
+        //    null,
+        //    10,
+        //    15,
+        //    20,
+        //    30,
+        //    60
+        //};
+
+        SerializedProperty propertyCodecName;
+        SerializedProperty propertySdpFmtpLine;
+        IEnumerable<VideoCodecInfo> codecs;
+        string[] codecNames = new string[] { "Default" };
+        bool cache = false;
+
+        readonly GUIContent s_codecLabel =
+            EditorGUIUtility.TrTextContent("Codec", "Video encoding codec.");
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            if (!cache)
+            {
+                property.Next(true);
+                propertyCodecName = property.Copy();
+                property.Next(true);
+                propertySdpFmtpLine = property.Copy();
+                //var attr = attribute as BitrateAttribute;
+                //minLimit = attr.minValue;
+                //maxLimit = attr.maxValue;
+                codecs = VideoStreamSender.GetAvailableCodecs();
+                codecNames = codecNames.Concat(codecs.Select(codec => codec.name)).ToArray();
+                cache = true;
+            }
+
+            string codecName = propertyCodecName.stringValue;
+            int selectIndex = 0;
+            if (!string.IsNullOrEmpty(codecName))
+            {
+                while (selectIndex < codecNames.Length && codecName != codecNames[selectIndex])
+                {
+                    ++selectIndex;
+                }
+            }
+            if(selectIndex == codecNames.Length)
+            {
+                selectIndex = 0;
+            }
+
+            var rect = position;
+            rect = EditorGUI.PrefixLabel(rect, s_codecLabel);
+            EditorGUI.BeginChangeCheck();
+            selectIndex = EditorGUI.Popup(rect, selectIndex, codecNames);
+
+            //// default value
+            //if (selectIndex == frameRateValues.Length)
+            //    selectIndex = 0;
+
+            //var popupRect = position;
+            //popupRect.height = EditorGUIUtility.singleLineHeight;
+
+            //selectIndex = EditorGUI.Popup(popupRect, s_FramerateLabel,
+            //    selectIndex, frameRateText);
+
+            //float newValue;
+            //var cutomValueRect = position;
+            //cutomValueRect.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+            //cutomValueRect.height = 0;
+
+            //if (0 < selectIndex && selectIndex < frameRateValues.Length)
+            //{
+            //    newValue = frameRateValues[selectIndex].Value;
+            //}
+            //else
+            //{
+            //    newValue = 0;
+            //}
+            if (EditorGUI.EndChangeCheck())
+            {
+                string newValue = selectIndex == 0 ? null : codecNames[selectIndex];
+
+                if (Application.isPlaying)
+                {
+                    var objectReferenceValue = property.serializedObject.targetObject;
+                    var type = objectReferenceValue.GetType();
+                    var attribute = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+                    var methodName = "SetCodec";
+                    var method = type.GetMethod(methodName, attribute);
+                    method.Invoke(objectReferenceValue, new object[] { newValue });
+                }
+                else
+                {
+                    propertyCodecName.stringValue = newValue;
+                }
+            }
+            EditorGUI.EndProperty();
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            if (property == null)
+                throw new System.ArgumentNullException(nameof(property));
+
+            var height = 0f;
+
+            // Popup.
+            height += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+            return height;
+        }
+    }
+}

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/CodecDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/CodecDrawer.cs
@@ -32,6 +32,7 @@ namespace Unity.RenderStreaming.Editor
         SerializedProperty propertySdpFmtpLine;
         IEnumerable<VideoCodecInfo> codecs;
         string[] codecNames = new string[] { "Default" };
+        string[] codecDetails = new string[] {};
         string[] sdpFmtpLines = new string[] {};
 
         int selectCodecIndex = 0;
@@ -45,6 +46,19 @@ namespace Unity.RenderStreaming.Editor
         static bool HasProfile(VideoCodecInfo codec)
         {
             return codec is H264CodecInfo || codec is VP9CodecInfo;
+        }
+
+        static string GetCodecDetail(VideoCodecInfo codec)
+        {
+            if(codec is H264CodecInfo h264Codec)
+            {
+                return $"{h264Codec.profile} Profile, Level {h264Codec.level.ToString().Insert(1, ".")}";
+            }
+            else if(codec is VP9CodecInfo vp9codec)
+            {
+                return $"Profile {(int)vp9codec.profile}";
+            }
+            return null;
         }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
@@ -87,7 +101,9 @@ namespace Unity.RenderStreaming.Editor
                 {
                     codecName = codecNames[selectCodecIndex];
                     propertyCodecName.stringValue = codecNames[selectCodecIndex];
-                    sdpFmtpLines = codecs.Where(codec => codec.name == codecName).Select(codec => codec.sdpFmtpLine).ToArray();
+                    var selectedCodecs = codecs.Where(codec => codec.name == codecName);
+                    codecDetails = selectedCodecs.Select(codec => GetCodecDetail(codec)).ToArray();
+                    sdpFmtpLines = selectedCodecs.Select(codec => codec.sdpFmtpLine).ToArray();
                     propertySdpFmtpLine.stringValue = sdpFmtpLines[0];
                 }
                 else
@@ -101,14 +117,14 @@ namespace Unity.RenderStreaming.Editor
             int codecIndex = selectCodecIndex - 1;
             if (0 < codecIndex)
             {
-                if (HasProfile(codecs.ElementAt(codecIndex)) && 0 < sdpFmtpLines.Length)
+                if (HasProfile(codecs.ElementAt(codecIndex)) && 0 < codecDetails.Length)
                 {
                     // sdp fmtp line
                     rect.y += EditorGUIUtility.singleLineHeight;
                     EditorGUI.BeginProperty(rect, label, propertyCodecName);
 
                     EditorGUI.BeginChangeCheck();
-                    selectSdpFmtpLineIndex = EditorGUI.Popup(rect, selectSdpFmtpLineIndex, sdpFmtpLines);
+                    selectSdpFmtpLineIndex = EditorGUI.Popup(rect, selectSdpFmtpLineIndex, codecDetails);
 
                     if (EditorGUI.EndChangeCheck())
                     {

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/CodecDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/CodecDrawer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Collections.Generic;
 using UnityEditor;
@@ -7,24 +6,6 @@ using System.Reflection;
 
 namespace Unity.RenderStreaming.Editor
 {
-    static class SerializedPropertyExtension
-    {
-        public static SerializedProperty FindPropertyInChildren(this SerializedProperty target, string propertyName)
-        {
-            SerializedProperty property = null;
-            while (target.Next(true))
-            {
-                if (target.name == propertyName)
-                {
-                    property = target.Copy();
-                    break;
-                }
-            }
-            target.Reset();
-            return property;
-        }
-    }
-
     [CustomPropertyDrawer(typeof(CodecAttribute))]
     class CodecDrawer : PropertyDrawer
     {
@@ -40,7 +21,7 @@ namespace Unity.RenderStreaming.Editor
         bool cache = false;
         bool changed = false;
 
-        readonly GUIContent s_codecLabel =
+        static readonly GUIContent s_codecLabel =
             EditorGUIUtility.TrTextContent("Codec", "Video encoding codec.");
 
         static bool HasProfile(VideoCodecInfo codec)

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/CodecDrawer.cs.meta
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/CodecDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ffbb807e4a1ab4440a236d73776265b3
+timeCreated: 1637904184

--- a/com.unity.renderstreaming/Editor/SerializedPropertyExtension.cs
+++ b/com.unity.renderstreaming/Editor/SerializedPropertyExtension.cs
@@ -1,0 +1,22 @@
+using UnityEditor;
+
+namespace Unity.RenderStreaming.Editor
+{
+    static class SerializedPropertyExtension
+    {
+        public static SerializedProperty FindPropertyInChildren(this SerializedProperty target, string propertyName)
+        {
+            SerializedProperty property = null;
+            while (target.Next(true))
+            {
+                if (target.name == propertyName)
+                {
+                    property = target.Copy();
+                    break;
+                }
+            }
+            target.Reset();
+            return property;
+        }
+    }
+}

--- a/com.unity.renderstreaming/Editor/SerializedPropertyExtension.cs.meta
+++ b/com.unity.renderstreaming/Editor/SerializedPropertyExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e226116f6c4a4b40a27c93778cd162c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
@@ -11,7 +11,7 @@ namespace Unity.RenderStreaming
         /// <summary>
         /// 
         /// </summary>
-        public string name { get { return capability.mimeType.Split('/')[1]; } }
+        public string name { get { return capability.GetCodecName(); } }
 
         /// <summary>
         /// 

--- a/com.unity.renderstreaming/Runtime/Scripts/Codec.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Codec.cs
@@ -8,7 +8,7 @@ namespace Unity.RenderStreaming
     {
         public static string GetCodecName(this RTCRtpCodecCapability cap)
         {
-            return cap.mimeType.Split('/')[1];
+            return cap?.mimeType.Split('/')[1];
         }
     }        
 
@@ -83,20 +83,20 @@ namespace Unity.RenderStreaming
 
         public static explicit operator Codec<T>(VideoCodecInfo codec)
         {
-            return (Codec<T>)codec.capability;
+            return (Codec<T>)codec?.capability;
         }
 
         public static explicit operator Codec<T>(AudioCodecInfo codec)
         {
-            return (Codec<T>)codec.capability;
+            return (Codec<T>)codec?.capability;
         }
 
         public static explicit operator Codec<T>(RTCRtpCodecCapability capability)
         {
             return new Codec<T>()
             {
-                codecName = capability.GetCodecName(),
-                sdpFmtpLine = capability.sdpFmtpLine
+                codecName = capability?.GetCodecName(),
+                sdpFmtpLine = capability?.sdpFmtpLine
             };
         }
 

--- a/com.unity.renderstreaming/Runtime/Scripts/Codec.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Codec.cs
@@ -4,11 +4,32 @@ using Unity.WebRTC;
 
 namespace Unity.RenderStreaming
 {
+    internal static class RTCRtpCodecCapabilityExtension
+    {
+        public static string GetCodecName(this RTCRtpCodecCapability cap)
+        {
+            return cap.mimeType.Split('/')[1];
+        }
+    }        
+
     [Serializable]
     internal struct Codec<T> : IEquatable<RTCRtpCodecCapability>
     {
-        public string mimeType;
+        public string codecName;
         public string sdpFmtpLine;
+
+        public string mimeType
+        {
+            get
+            {
+                Type type = typeof(T);
+                if (type == typeof(VideoStreamSender) || type == typeof(VideoStreamReceiver))
+                    return $"video/{codecName}";
+                if (type == typeof(AudioStreamSender) || type == typeof(AudioStreamReceiver))
+                    return $"audio/{codecName}";
+                throw new InvalidOperationException();
+            }
+        }
 
         public static IEnumerable<VideoCodecInfo> GetAvailableVideoCodecs(Type type)
         {
@@ -74,7 +95,7 @@ namespace Unity.RenderStreaming
         {
             return new Codec<T>()
             {
-                mimeType = capability.mimeType,
+                codecName = capability.GetCodecName(),
                 sdpFmtpLine = capability.sdpFmtpLine
             };
         }

--- a/com.unity.renderstreaming/Runtime/Scripts/Codec.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Codec.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using Unity.WebRTC;
+
+namespace Unity.RenderStreaming
+{
+    [Serializable]
+    internal struct Codec<T> : IEquatable<RTCRtpCodecCapability>
+    {
+        public string mimeType;
+        public string sdpFmtpLine;
+
+        public static IEnumerable<VideoCodecInfo> GetAvailableVideoCodecs(Type type)
+        {
+            if (type == typeof(VideoStreamSender))
+            {
+                return VideoStreamSender.GetAvailableCodecs();
+            }
+            if (type == typeof(VideoStreamReceiver))
+            {
+                return VideoStreamReceiver.GetAvailableCodecs();
+            }
+            return null;
+        }
+
+        public static IEnumerable<AudioCodecInfo> GetAvailableAudioCodecs(Type type)
+        {
+            if (type == typeof(AudioStreamSender))
+            {
+                return AudioStreamSender.GetAvailableCodecs();
+            }
+            if (type == typeof(AudioStreamReceiver))
+            {
+                return AudioStreamReceiver.GetAvailableCodecs();
+            }
+            return null;
+        }
+
+        public static explicit operator VideoCodecInfo(Codec<T> codec)
+        {
+            foreach (var codec_ in GetAvailableVideoCodecs(typeof(T)))
+            {
+                if (codec.Equals(codec_.capability))
+                {
+                    return codec_;
+                }
+            }
+            return null;
+        }
+
+        public static explicit operator AudioCodecInfo(Codec<T> codec)
+        {
+            foreach (var codec_ in GetAvailableAudioCodecs(typeof(T)))
+            {
+                if (codec.Equals(codec_.capability))
+                {
+                    return codec_;
+                }
+            }
+            return null;
+        }
+
+        public static explicit operator Codec<T>(VideoCodecInfo codec)
+        {
+            return (Codec<T>)codec.capability;
+        }
+
+        public static explicit operator Codec<T>(AudioCodecInfo codec)
+        {
+            return (Codec<T>)codec.capability;
+        }
+
+        public static explicit operator Codec<T>(RTCRtpCodecCapability capability)
+        {
+            return new Codec<T>()
+            {
+                mimeType = capability.mimeType,
+                sdpFmtpLine = capability.sdpFmtpLine
+            };
+        }
+
+        public bool Equals(RTCRtpCodecCapability obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+            if (obj.mimeType == mimeType && obj.sdpFmtpLine == sdpFmtpLine)
+                return true;
+            return false;
+        }
+    }
+}

--- a/com.unity.renderstreaming/Runtime/Scripts/Codec.cs.meta
+++ b/com.unity.renderstreaming/Runtime/Scripts/Codec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b406692f7c30444a94245fd5ce14112
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
@@ -14,7 +14,7 @@ namespace Unity.RenderStreaming
         /// <summary>
         /// 
         /// </summary>
-        public string name { get { return capability.mimeType.Split('/')[1]; } }
+        public string name { get { return capability.GetCodecName(); } }
 
         /// <summary>
         /// 

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
@@ -9,7 +9,7 @@ namespace Unity.RenderStreaming
     /// </summary>
     public class VideoCodecInfo : IEquatable<VideoCodecInfo>
     {
-        const string KeyCodecImplementation = "implementation_name";
+        static readonly string KeyCodecImplementation = "implementation_name";
 
         /// <summary>
         /// 
@@ -24,7 +24,12 @@ namespace Unity.RenderStreaming
         /// <summary>
         /// 
         /// </summary>
-        public string CodecImplementation { get { return parameters[KeyCodecImplementation]; } }
+        public string codecImplementation { get { return parameters[KeyCodecImplementation]; } }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string sdpFmtpLine { get { return capability.sdpFmtpLine; } }
 
         /// <summary>
         /// 

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -39,6 +39,8 @@ namespace Unity.RenderStreaming
         public Range(uint min, uint max) { this.min = min; this.max = max; }
     }
 
+    internal sealed class CodecAttribute : PropertyAttribute { }
+
     internal static class RTCRtpSenderExtension
     {
         public static RTCError SetFrameRate(this RTCRtpSender sender, uint framerate)
@@ -104,7 +106,8 @@ namespace Unity.RenderStreaming
         [SerializeField, ScaleResolution]
         private float m_scaleFactor = 1f;
 
-        private VideoCodecInfo m_codec;
+        [SerializeField, Codec]
+        private Codec<VideoStreamSender> m_codec;
 
         /// <summary>
         ///
@@ -143,7 +146,7 @@ namespace Unity.RenderStreaming
         /// </summary>
         public VideoCodecInfo codec
         {
-            get { return m_codec; }
+            get { return (VideoCodecInfo)m_codec; }
         }
 
         /// <summary>
@@ -158,7 +161,7 @@ namespace Unity.RenderStreaming
         /// <param name="mimeType"></param>
         public void SetCodec(VideoCodecInfo codec)
         {
-            m_codec = codec;
+            m_codec = (Codec<VideoStreamSender>)codec;
             foreach (var transceiver in Transceivers.Values)
             {
                 if(!string.IsNullOrEmpty(transceiver.Mid))
@@ -166,7 +169,7 @@ namespace Unity.RenderStreaming
                 if (transceiver.Sender.Track.ReadyState == TrackState.Ended)
                     continue;
 
-                RTCErrorType error = transceiver.SetCodec(new VideoCodecInfo[] { m_codec });
+                RTCErrorType error = transceiver.SetCodec(new VideoCodecInfo[] { (VideoCodecInfo)m_codec });
                 if (error != RTCErrorType.None)
                     throw new InvalidOperationException($"Set codec is failed. errorCode={error}");
             }

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -97,6 +97,9 @@ namespace Unity.RenderStreaming
         [SerializeField, StreamingSize]
         public Vector2Int streamingSize = new Vector2Int(1280, 720);
 
+        [SerializeField, Codec]
+        private Codec<VideoStreamSender> m_codec;
+
         [SerializeField, FrameRate]
         private float m_frameRate = s_defaultFrameRate;
 
@@ -105,9 +108,6 @@ namespace Unity.RenderStreaming
 
         [SerializeField, ScaleResolution]
         private float m_scaleFactor = 1f;
-
-        [SerializeField, Codec]
-        private Codec<VideoStreamSender> m_codec;
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
@@ -150,11 +150,11 @@ namespace Unity.RenderStreaming.Samples
             switch (codec)
             {
                 case H264CodecInfo h264Codec:
-                    return $"{h264Codec.mimeType} {h264Codec.profile} {h264Codec.level.ToString().Insert(1, ".")} {h264Codec.CodecImplementation}";
+                    return $"{h264Codec.mimeType} {h264Codec.profile} {h264Codec.level.ToString().Insert(1, ".")} {h264Codec.codecImplementation}";
                 case VP9CodecInfo V9Codec:
-                    return $"{V9Codec.mimeType} {V9Codec.profile} {V9Codec.CodecImplementation}";
+                    return $"{V9Codec.mimeType} {V9Codec.profile} {V9Codec.codecImplementation}";
                 default:
-                    return $"{codec.mimeType} {codec.CodecImplementation}";
+                    return $"{codec.mimeType} {codec.codecImplementation}";
             }
             throw new ArgumentException();
         }

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -21,7 +21,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             {
                 Assert.That(codec.name, Is.Not.Empty);
                 Assert.That(codec.mimeType, Is.Not.Empty);
-                Assert.That(codec.CodecImplementation, Is.Not.Empty);
+                Assert.That(codec.codecImplementation, Is.Not.Empty);
 
                 switch (codec)
                 {
@@ -146,7 +146,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             {
                 Assert.That(codec.name, Is.Not.Empty);
                 Assert.That(codec.mimeType, Is.Not.Empty);
-                Assert.That(codec.CodecImplementation, Is.Not.Empty);
+                Assert.That(codec.codecImplementation, Is.Not.Empty);
 
                 switch (codec)
                 {


### PR DESCRIPTION
This pull request adds the dropdown UI to select video codec on the inspector window.
![image](https://user-images.githubusercontent.com/1132081/187383265-f2b46bc9-ff74-41a3-8c02-77290099810b.png)

If the codec contains multiple options like H264, you can choise them.
![image](https://user-images.githubusercontent.com/1132081/187384008-89ee3b5c-2051-4409-8df6-a325fd1977e4.png)

It also defined a serializable data to represent codec information.

```csharp
    internal struct Codec<T> : IEquatable<RTCRtpCodecCapability>
    {
        public string codecName;
        public string sdpFmtpLine;
    }
```