### PR TITLE
feat: Add VideoStreamReceiverEditor

### DIFF
--- a/com.unity.renderstreaming/Editor/VideoStreamReceiverEditor.cs
+++ b/com.unity.renderstreaming/Editor/VideoStreamReceiverEditor.cs
@@ -1,0 +1,76 @@
+#if UNITY_EDITOR
+using System;
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.AnimatedValues;
+
+namespace Unity.RenderStreaming.Editor
+{
+    [CustomEditor(typeof(VideoStreamReceiver))]
+    [CanEditMultipleObjects]
+    internal class VideoStreamSenderReceiver : UnityEditor.Editor
+    {
+        SerializedProperty m_codec;
+        SerializedProperty m_renderMode;
+        SerializedProperty m_targetTexture;
+
+        static AnimBool[] m_renderModeFade;
+
+        void OnEnable()
+        {
+            m_codec = serializedObject.FindProperty("m_Codec");
+            m_renderMode = serializedObject.FindProperty("m_RenderMode");
+            m_targetTexture = serializedObject.FindProperty("m_TargetTexture");
+
+            if (m_renderModeFade == null)
+            {
+                m_renderModeFade = new AnimBool[Enum.GetValues(typeof(VideoRenderMode)).Length];
+                for (int i = 0; i < m_renderModeFade.Length; i++)
+                    m_renderModeFade[i] = new AnimBool(i == m_renderMode.intValue);
+            }
+            Array.ForEach(m_renderModeFade, anim => anim.valueChanged.AddListener(Repaint));
+        }
+
+        void OnDisable()
+        {
+            Array.ForEach(m_renderModeFade, anim => anim.valueChanged.RemoveListener(Repaint));
+        }
+
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            bool disableEditMediaSource = Application.isPlaying;
+
+            /// todo(kazuki): Make available to change video source parameters in runtime.
+            using (new EditorGUI.DisabledScope(disableEditMediaSource))
+            {
+                EditorGUILayout.PropertyField(m_renderMode);
+                HandleDataSourceField();
+
+                EditorGUILayout.Space();
+                EditorGUILayout.PropertyField(m_codec);
+            }
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        private void HandleDataSourceField()
+        {
+            for (var i = 0; i < m_renderModeFade.Length; i++)
+                m_renderModeFade[i].target = m_renderMode.intValue == i;
+
+            if (EditorGUILayout.BeginFadeGroup(m_renderModeFade[(int)VideoRenderMode.APIOnly].faded))
+            {
+            }
+            EditorGUILayout.EndFadeGroup();
+
+            if (EditorGUILayout.BeginFadeGroup(m_renderModeFade[(int)VideoRenderMode.RenderTexture].faded))
+            {
+                EditorGUILayout.PropertyField(m_targetTexture);
+            }
+            EditorGUILayout.EndFadeGroup();
+        }
+    }
+}
+#endif

--- a/com.unity.renderstreaming/Editor/VideoStreamReceiverEditor.cs.meta
+++ b/com.unity.renderstreaming/Editor/VideoStreamReceiverEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7459e047525e6f42996495242fc6cc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Editor/VideoStreamSenderEditor.cs
+++ b/com.unity.renderstreaming/Editor/VideoStreamSenderEditor.cs
@@ -1,54 +1,18 @@
 #if UNITY_EDITOR
 using System;
-using System.Linq;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Events;
 using UnityEditor;
 using UnityEditor.AnimatedValues;
 
 namespace Unity.RenderStreaming.Editor
 {
-    static class DictionaryExtension
-    {
-        public static void SetTarget(this Dictionary<VideoStreamSource, AnimBool> dict, VideoStreamSource selected)
-        {
-            foreach (var pair in dict)
-            {
-                pair.Value.target = pair.Key == selected;
-            }
-        }
-        public static void AddListener(this Dictionary<VideoStreamSource, AnimBool> dict, UnityAction action)
-        {
-            foreach (var pair in dict)
-            {
-                pair.Value.valueChanged.AddListener(action);
-            }
-        }
-        public static void RemoveListener(this Dictionary<VideoStreamSource, AnimBool> dict, UnityAction action)
-        {
-            foreach (var pair in dict)
-            {
-                pair.Value.valueChanged.RemoveListener(action);
-            }
-        }
-
-        public static Dictionary<VideoStreamSource, AnimBool> Create(VideoStreamSource initialValue)
-        {
-            return Enum.GetValues(typeof(VideoStreamSource))
-                .Cast<VideoStreamSource>()
-                .ToDictionary(source => source, source => new AnimBool(source == initialValue));
-        }
-    }
-
-
     [CustomEditor(typeof(VideoStreamSender))]
     [CanEditMultipleObjects]
     internal class VideoStreamSenderEditor : UnityEditor.Editor
     {
         class Styles
         {
-            public readonly GUIContent dataSourceContent =
+            public readonly GUIContent sourceContent =
                 EditorGUIUtility.TrTextContent("Video Source Type", "Type of source the video will be streamed.");
             public readonly GUIContent frameRateContent =
                 EditorGUIUtility.TrTextContent("Frame rate", "A value affects loads on the encoding thread.");
@@ -73,7 +37,7 @@ namespace Unity.RenderStreaming.Editor
         SerializedProperty m_webCamDeviceIndex;
         SerializedProperty m_autoRequestUserAuthorization;
 
-        static Dictionary<VideoStreamSource, AnimBool> m_videoSource;
+        static AnimBool[] m_sourceFade;
 
         void OnEnable()
         {
@@ -90,14 +54,18 @@ namespace Unity.RenderStreaming.Editor
             m_antiAliasing = serializedObject.FindProperty("m_antiAliasing");
             m_autoRequestUserAuthorization = serializedObject.FindProperty("m_autoRequestUserAuthorization");
 
-            if (m_videoSource == null)
-                m_videoSource = DictionaryExtension.Create((VideoStreamSource)m_source.intValue);
-            m_videoSource.AddListener(Repaint);
+            if (m_sourceFade == null)
+            {
+                m_sourceFade = new AnimBool[Enum.GetValues(typeof(VideoStreamSource)).Length];
+                for (int i = 0; i < m_sourceFade.Length; i++)
+                    m_sourceFade[i] = new AnimBool(i == m_source.intValue);
+            }
+            Array.ForEach(m_sourceFade, anim => anim.valueChanged.AddListener(Repaint));
         }
 
         void OnDisable()
         {
-            m_videoSource.RemoveListener(Repaint);
+            Array.ForEach(m_sourceFade, anim => anim.valueChanged.RemoveListener(Repaint));
         }
 
 
@@ -114,7 +82,7 @@ namespace Unity.RenderStreaming.Editor
             /// todo(kazuki): Make available to change video source parameters in runtime.
             using (new EditorGUI.DisabledScope(disableEditMediaSource))
             {
-                EditorGUILayout.PropertyField(m_source, s_Styles.dataSourceContent);
+                EditorGUILayout.PropertyField(m_source, s_Styles.sourceContent);
                 HandleDataSourceField();
 
                 EditorGUILayout.Space();
@@ -123,8 +91,7 @@ namespace Unity.RenderStreaming.Editor
 
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(m_frameRate, s_Styles.frameRateContent);
-            EditorGUILayout.PropertyField(m_bitrate, s_Styles.frameRateContent);
-
+            EditorGUILayout.PropertyField(m_bitrate, s_Styles.bitrateContent);
             EditorGUILayout.PropertyField(m_scaleFactor, s_Styles.scaleFactorContent);
 
             serializedObject.ApplyModifiedProperties();
@@ -132,9 +99,10 @@ namespace Unity.RenderStreaming.Editor
 
         private void HandleDataSourceField()
         {
-            m_videoSource.SetTarget((VideoStreamSource)m_source.intValue);
+            for (var i = 0; i < m_sourceFade.Length; i++)
+                m_sourceFade[i].target = m_source.intValue == i;
 
-            if (EditorGUILayout.BeginFadeGroup(m_videoSource[VideoStreamSource.Camera].faded))
+            if (EditorGUILayout.BeginFadeGroup(m_sourceFade[(int)VideoStreamSource.Camera].faded))
             {
                 EditorGUILayout.PropertyField(m_camera);
                 EditorGUILayout.PropertyField(m_depth);
@@ -143,7 +111,7 @@ namespace Unity.RenderStreaming.Editor
             }
             EditorGUILayout.EndFadeGroup();
 
-            if (EditorGUILayout.BeginFadeGroup(m_videoSource[VideoStreamSource.Screen].faded))
+            if (EditorGUILayout.BeginFadeGroup(m_sourceFade[(int)VideoStreamSource.Screen].faded))
             {
                 EditorGUILayout.PropertyField(m_depth);
                 EditorGUILayout.PropertyField(m_antiAliasing);
@@ -151,11 +119,11 @@ namespace Unity.RenderStreaming.Editor
             }
             EditorGUILayout.EndFadeGroup();
 
-            if (EditorGUILayout.BeginFadeGroup(m_videoSource[VideoStreamSource.Texture].faded))
+            if (EditorGUILayout.BeginFadeGroup(m_sourceFade[(int)VideoStreamSource.Texture].faded))
                 EditorGUILayout.PropertyField(m_texture);
             EditorGUILayout.EndFadeGroup();
 
-            if (EditorGUILayout.BeginFadeGroup(m_videoSource[VideoStreamSource.WebCamera].faded))
+            if (EditorGUILayout.BeginFadeGroup(m_sourceFade[(int)VideoStreamSource.WebCamera].faded))
             {
                 EditorGUILayout.PropertyField(m_webCamDeviceIndex);
                 EditorGUILayout.PropertyField(m_autoRequestUserAuthorization);

--- a/com.unity.renderstreaming/Editor/VideoStreamSenderEditor.cs
+++ b/com.unity.renderstreaming/Editor/VideoStreamSenderEditor.cs
@@ -41,18 +41,18 @@ namespace Unity.RenderStreaming.Editor
 
         void OnEnable()
         {
-            m_source = serializedObject.FindProperty("m_source");
-            m_camera = serializedObject.FindProperty("m_camera");
-            m_texture = serializedObject.FindProperty("m_texture");
-            m_webCamDeviceIndex = serializedObject.FindProperty("m_webCamDeviceIndex");
-            m_codec = serializedObject.FindProperty("m_codec");
-            m_textureSize = serializedObject.FindProperty("m_textureSize");
-            m_frameRate = serializedObject.FindProperty("m_frameRate");
-            m_bitrate = serializedObject.FindProperty("m_bitrate");
-            m_scaleFactor = serializedObject.FindProperty("m_scaleFactor");
-            m_depth = serializedObject.FindProperty("m_depth");
-            m_antiAliasing = serializedObject.FindProperty("m_antiAliasing");
-            m_autoRequestUserAuthorization = serializedObject.FindProperty("m_autoRequestUserAuthorization");
+            m_source = serializedObject.FindProperty("m_Source");
+            m_camera = serializedObject.FindProperty("m_Camera");
+            m_texture = serializedObject.FindProperty("m_Texture");
+            m_webCamDeviceIndex = serializedObject.FindProperty("m_WebCamDeviceIndex");
+            m_codec = serializedObject.FindProperty("m_Codec");
+            m_textureSize = serializedObject.FindProperty("m_TextureSize");
+            m_frameRate = serializedObject.FindProperty("m_FrameRate");
+            m_bitrate = serializedObject.FindProperty("m_Bitrate");
+            m_scaleFactor = serializedObject.FindProperty("m_ScaleFactor");
+            m_depth = serializedObject.FindProperty("m_Depth");
+            m_antiAliasing = serializedObject.FindProperty("m_AntiAliasing");
+            m_autoRequestUserAuthorization = serializedObject.FindProperty("m_AutoRequestUserAuthorization");
 
             if (m_sourceFade == null)
             {

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamReceiver.cs
@@ -34,11 +34,6 @@ namespace Unity.RenderStreaming
         /// <summary>
         ///
         /// </summary>
-        public override TrackKind Kind { get { return TrackKind.Audio; } }
-
-        /// <summary>
-        ///
-        /// </summary>
         public AudioSource Source => m_source;
 
         private AudioSource m_source;

--- a/com.unity.renderstreaming/Runtime/Scripts/Broadcast.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Broadcast.cs
@@ -57,7 +57,7 @@ namespace Unity.RenderStreaming
         public void OnAddReceiver(SignalingEventData data)
         {
             var track = data.transceiver.Receiver.Track;
-            var receiver = streams.OfType<IStreamReceiver>().FirstOrDefault((r => r.Kind == track.Kind));
+            IStreamReceiver receiver = GetReceiver(track.Kind);
             SetReceiver(data.connectionId, receiver, data.transceiver);
         }
 
@@ -86,6 +86,15 @@ namespace Unity.RenderStreaming
             var channel = streams.OfType<IDataChannel>().
                 FirstOrDefault(r => !r.IsConnected && !r.IsLocal);
             channel?.SetChannel(data.connectionId, data.channel);
+        }
+
+        IStreamReceiver GetReceiver(WebRTC.TrackKind kind)
+        {
+            if (kind == WebRTC.TrackKind.Audio)
+                return streams.OfType<AudioStreamReceiver>().First();
+            if (kind == WebRTC.TrackKind.Video)
+                return streams.OfType<VideoStreamReceiver>().First();
+            throw new System.ArgumentException();
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -182,7 +182,6 @@ namespace Unity.RenderStreaming
                 RemoveTrack(connectionId, sender.Track);
         }
 
-
         /// <summary>
         /// 
         /// </summary>
@@ -329,11 +328,6 @@ namespace Unity.RenderStreaming
         ///
         /// </summary>
         RTCRtpTransceiver Transceiver { get; }
-
-        /// <summary>
-        ///
-        /// </summary>
-        TrackKind Kind { get; }
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Runtime/Scripts/SingleConnection.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SingleConnection.cs
@@ -93,7 +93,7 @@ namespace Unity.RenderStreaming
                 return;
 
             var track = data.transceiver.Receiver.Track;
-            var receiver = streams.OfType<IStreamReceiver>().FirstOrDefault((r => r.Kind == track.Kind));
+            IStreamReceiver receiver = GetReceiver(track.Kind);
             SetReceiver(data.connectionId, receiver, data.transceiver);
         }
 
@@ -103,6 +103,15 @@ namespace Unity.RenderStreaming
                 return;
             var channel = streams.OfType<IDataChannel>().FirstOrDefault(r => !r.IsConnected && !r.IsLocal);
             channel?.SetChannel(connectionId, data.channel);
+        }
+
+        IStreamReceiver GetReceiver(WebRTC.TrackKind kind)
+        {
+            if (kind == WebRTC.TrackKind.Audio)
+                return streams.OfType<AudioStreamReceiver>().First();
+            if (kind == WebRTC.TrackKind.Video)
+                return streams.OfType<VideoStreamReceiver>().First();
+            throw new System.ArgumentException();
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/StreamReceiverBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/StreamReceiverBase.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Linq;
-using System.Collections.Generic;
 using Unity.WebRTC;
 using UnityEngine;
 
@@ -26,19 +24,30 @@ namespace Unity.RenderStreaming
         /// </summary>
         public OnStoppedStreamHandler OnStoppedStream { get; set; }
 
+        /// <summary>
+        ///
+        /// </summary>
+        public MediaStreamTrack Track => m_track;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool isPlaying
+        {
+            get
+            {
+                if (!Application.isPlaying)
+                    return false;
+                if (string.IsNullOrEmpty(Transceiver.Mid))
+                    return false;
+                if (Transceiver.Sender.Track.ReadyState == TrackState.Ended)
+                    return false;
+                return true;
+            }
+        }
 
         private RTCRtpTransceiver m_transceiver;
-
-
-        /// <summary>
-        ///
-        /// </summary>
-        public MediaStreamTrack Track { get; private set; }
-
-        /// <summary>
-        ///
-        /// </summary>
-        public virtual TrackKind Kind { get; }
+        private MediaStreamTrack m_track;
 
         /// <summary>
         ///
@@ -51,7 +60,7 @@ namespace Unity.RenderStreaming
                 throw new ArgumentNullException("connectionId", "connectionId is null");
 
             m_transceiver = transceiver;
-            Track = m_transceiver?.Receiver.Track;
+            m_track = m_transceiver?.Receiver.Track;
 
             if (m_transceiver == null)
                 OnStoppedStream?.Invoke(connectionId);
@@ -61,8 +70,8 @@ namespace Unity.RenderStreaming
 
         protected virtual void OnDestroy()
         {
-            Track?.Dispose();
-            Track = null;
+            m_track?.Dispose();
+            m_track = null;
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamReceiver.cs
@@ -1,20 +1,33 @@
 using System;
-using Unity.WebRTC;
-using UnityEngine;
+using System.Collections;
 using System.Linq;
 using System.Collections.Generic;
+using UnityEngine;
+using Unity.WebRTC;
 
 namespace Unity.RenderStreaming
 {
     /// <summary>
-    ///
+    /// 
+    /// </summary>
+    public enum VideoRenderMode
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        RenderTexture,
+        /// <summary>
+        /// 
+        /// </summary>
+        APIOnly,
+    }
+
+    /// <summary>
+    /// 
     /// </summary>
     [AddComponentMenu("Render Streaming/Video Stream Receiver")]
     public class VideoStreamReceiver : StreamReceiverBase
     {
-        [SerializeField]
-        private Texture m_targetTexture;
-
         /// <summary>
         ///
         /// </summary>
@@ -26,45 +39,51 @@ namespace Unity.RenderStreaming
         /// </summary>
         public OnUpdateReceiveTextureHandler OnUpdateReceiveTexture;
 
-        /// <summary>
-        ///
-        /// </summary>
-        public override TrackKind Kind { get { return TrackKind.Video; } }
+        [SerializeField, Codec]
+        private VideoCodecInfo m_Codec;
 
-        /// <summary>
-        /// 
-        /// </summary>
-        public uint width
-        {
-            get { return (uint)m_targetTexture.width; }
-        }
+        [SerializeField]
+        private VideoRenderMode m_RenderMode;
 
-        /// <summary>
-        /// 
-        /// </summary>
-        public uint height
-        {
-            get { return (uint)m_targetTexture.height; }
-        }
-
-
-        private VideoCodecInfo m_codec;
-
-        private Texture m_receiveTexture;
-
+        [SerializeField]
+        private RenderTexture m_TargetTexture;
 
         /// <summary>
         /// 
         /// </summary>
         public VideoCodecInfo codec
         {
-            get { return m_codec; }
+            get { return m_Codec; }
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public int width => m_texture.width;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public int height => m_texture.height;
 
         /// <summary>
         ///
         /// </summary>
-        public Texture targetTexture => m_targetTexture;
+        public Texture texture => m_texture;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public RenderTexture targetTexture
+        {
+            get { return m_TargetTexture; }
+            set { m_TargetTexture = value; }
+        }
+
+        private Texture m_texture;
+
+        private Coroutine m_coroutine;
+
 
         /// <summary>
         /// 
@@ -83,8 +102,7 @@ namespace Unity.RenderStreaming
         /// <param name="mimeType"></param>
         public void SetCodec(VideoCodecInfo codec)
         {
-            m_codec = codec;
-
+            m_Codec = codec;
             if (Transceiver == null)
                 return;
             if (!string.IsNullOrEmpty(Transceiver.Mid))
@@ -92,7 +110,7 @@ namespace Unity.RenderStreaming
             if (Transceiver.Sender.Track.ReadyState == TrackState.Ended)
                 throw new InvalidOperationException("Track has already been ended.");
 
-            var codecs = new VideoCodecInfo[] { m_codec };
+            var codecs = new VideoCodecInfo[] { m_Codec };
             RTCErrorType error = Transceiver.SetCodecPreferences(SelectCodecCapabilities(codecs).ToArray());
             if (error != RTCErrorType.None)
                 throw new InvalidOperationException($"Set codec is failed. errorCode={error}");
@@ -115,16 +133,31 @@ namespace Unity.RenderStreaming
             {
                 videoTrack.OnVideoReceived += texture =>
                 {
-                    m_targetTexture = texture;
-                    OnUpdateReceiveTexture?.Invoke(m_targetTexture);
+                    m_texture = texture;
+                    OnUpdateReceiveTexture?.Invoke(m_texture);
                 };
             }
+            m_coroutine = StartCoroutine(Render());
         }
 
         private void StoppedStream(string connectionId)
         {
-            m_targetTexture = null;
-            OnUpdateReceiveTexture?.Invoke(m_targetTexture);
+            m_texture = null;
+            OnUpdateReceiveTexture?.Invoke(m_texture);
+            StopCoroutine(m_coroutine);
+        }
+
+        private IEnumerator Render()
+        {
+            while (true)
+            {
+                yield return new WaitForEndOfFrame();
+                if (m_RenderMode != VideoRenderMode.RenderTexture ||
+                    m_texture == null ||
+                    m_TargetTexture == null)
+                    continue;
+                Graphics.ConvertTexture(m_texture, m_TargetTexture);
+            }
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamReceiver.cs
@@ -160,7 +160,7 @@ namespace Unity.RenderStreaming
                     m_texture == null ||
                     m_TargetTexture == null)
                     continue;
-                Graphics.ConvertTexture(m_texture, m_TargetTexture);
+                Graphics.Blit(m_texture, m_TargetTexture);
             }
         }
     }

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamReceiver.cs
@@ -144,7 +144,11 @@ namespace Unity.RenderStreaming
         {
             m_texture = null;
             OnUpdateReceiveTexture?.Invoke(m_texture);
-            StopCoroutine(m_coroutine);
+            if(m_coroutine != null)
+            {
+                StopCoroutine(m_coroutine);
+                m_coroutine = null;
+            }
         }
 
         private IEnumerator Render()

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -122,40 +122,40 @@ namespace Unity.RenderStreaming
 
         //todo(kazuki): remove this value.
         [SerializeField, StreamingSize]
-        private Vector2Int m_textureSize = new Vector2Int(1280, 720);
+        private Vector2Int m_TextureSize = new Vector2Int(1280, 720);
 
         [SerializeField]
-        private VideoStreamSource m_source;
+        private VideoStreamSource m_Source;
 
         [SerializeField]
-        private Camera m_camera;
+        private Camera m_Camera;
 
         [SerializeField]
-        private Texture m_texture;
+        private Texture m_Texture;
 
         [SerializeField, WebCamDevice]
-        private int m_webCamDeviceIndex;
+        private int m_WebCamDeviceIndex;
 
         [SerializeField, RenderTextureDepthBuffer]
-        private int m_depth = s_defaultDepth;
+        private int m_Depth = s_defaultDepth;
 
         [SerializeField, RenderTextureAntiAliasing]
-        private int m_antiAliasing = 1;
+        private int m_AntiAliasing = 1;
 
         [SerializeField, Codec]
-        private VideoCodecInfo m_codec;
+        private VideoCodecInfo m_Codec;
 
         [SerializeField, FrameRate]
-        private float m_frameRate = s_defaultFrameRate;
+        private float m_FrameRate = s_defaultFrameRate;
 
         [SerializeField, Bitrate(0, 10000)]
-        private Range m_bitrate = new Range(s_defaultMinBitrate, s_defaultMaxBitrate);
+        private Range m_Bitrate = new Range(s_defaultMinBitrate, s_defaultMaxBitrate);
 
         [SerializeField, ScaleResolution]
-        private float m_scaleFactor = 1f;
+        private float m_ScaleFactor = 1f;
 
         [SerializeField]
-        private bool m_autoRequestUserAuthorization = true;
+        private bool m_AutoRequestUserAuthorization = true;
 
         private VideoStreamSourceImpl m_sourceImpl = null;
 
@@ -164,16 +164,16 @@ namespace Unity.RenderStreaming
         /// </summary>
         public VideoStreamSource source
         {
-            get { return m_source; }
+            get { return m_Source; }
             set
             {
                 if (isPlaying)
                     throw new InvalidOperationException("Can not change this parameter after the streaming is started.");
-                m_source = value;
-                if (m_texture != null)
+                m_Source = value;
+                if (m_Texture != null)
                 {
-                    m_textureSize.x = m_texture.width;
-                    m_textureSize.y = m_texture.height;
+                    m_TextureSize.x = m_Texture.width;
+                    m_TextureSize.y = m_Texture.height;
                 }
             }
         }
@@ -183,12 +183,12 @@ namespace Unity.RenderStreaming
         /// </summary>
         public Camera sourceCamera
         {
-            get { return m_camera; }
+            get { return m_Camera; }
             set
             {
                 if (isPlaying)
                     throw new InvalidOperationException("Can not change this parameter after the streaming is started.");
-                m_camera = value;
+                m_Camera = value;
             }
         }
 
@@ -197,14 +197,14 @@ namespace Unity.RenderStreaming
         /// </summary>
         public Texture sourceTexture
         {
-            get { return m_texture; }
+            get { return m_Texture; }
             set
             {
                 if (isPlaying)
                     throw new InvalidOperationException("Can not change this parameter after the streaming is started.");
-                m_texture = value;
-                m_textureSize.x = m_texture.width;
-                m_textureSize.y = m_texture.height;
+                m_Texture = value;
+                m_TextureSize.x = m_Texture.width;
+                m_TextureSize.y = m_Texture.height;
             }
         }
 
@@ -213,12 +213,12 @@ namespace Unity.RenderStreaming
         /// </summary>
         public int sourceDeviceIndex
         {
-            get { return m_webCamDeviceIndex; }
+            get { return m_WebCamDeviceIndex; }
             set
             {
                 if (isPlaying)
                     throw new InvalidOperationException("Can not change this parameter after the streaming is started.");
-                m_webCamDeviceIndex = value;
+                m_WebCamDeviceIndex = value;
             }
         }
 
@@ -243,7 +243,7 @@ namespace Unity.RenderStreaming
         /// </summary>
         public float frameRate
         {
-            get { return m_frameRate; }
+            get { return m_FrameRate; }
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace Unity.RenderStreaming
         /// </summary>
         public uint minBitrate
         {
-            get { return m_bitrate.min; }
+            get { return m_Bitrate.min; }
         }
 
         /// <summary>
@@ -259,7 +259,7 @@ namespace Unity.RenderStreaming
         /// </summary>
         public uint maxBitrate
         {
-            get { return m_bitrate.max; }
+            get { return m_Bitrate.max; }
         }
 
         /// <summary>
@@ -267,7 +267,7 @@ namespace Unity.RenderStreaming
         /// </summary>
         public float scaleResolutionDown
         {
-            get { return m_scaleFactor; }
+            get { return m_ScaleFactor; }
         }
 
         /// <summary>
@@ -275,10 +275,10 @@ namespace Unity.RenderStreaming
         /// </summary>
         public uint width
         {
-            get { return (uint)m_textureSize.x; }
+            get { return (uint)m_TextureSize.x; }
             set
             {
-                SetTextureSize(new Vector2Int((int)value, m_textureSize.y));
+                SetTextureSize(new Vector2Int((int)value, m_TextureSize.y));
             }
         }
 
@@ -287,10 +287,10 @@ namespace Unity.RenderStreaming
         /// </summary>
         public uint height
         {
-            get { return (uint)m_textureSize.y; }
+            get { return (uint)m_TextureSize.y; }
             set
             {
-                SetTextureSize(new Vector2Int(m_textureSize.x, (int)value));
+                SetTextureSize(new Vector2Int(m_TextureSize.x, (int)value));
             }
         }
 
@@ -299,14 +299,14 @@ namespace Unity.RenderStreaming
         /// </summary>
         public VideoCodecInfo codec
         {
-            get { return m_codec; }
+            get { return m_Codec; }
         }
 
 
         public bool autoRequestUserAuthorization
         {
-            get => m_autoRequestUserAuthorization;
-            set { m_autoRequestUserAuthorization = value; }
+            get => m_AutoRequestUserAuthorization;
+            set { m_AutoRequestUserAuthorization = value; }
         }
 
         /// <summary>
@@ -318,7 +318,7 @@ namespace Unity.RenderStreaming
             if (isPlaying)
                 throw new InvalidOperationException("Can not change this parameter after the streaming is started.");
 
-            m_codec = codec;
+            m_Codec = codec;
             foreach (var transceiver in Transceivers.Values)
             {
                 if (!string.IsNullOrEmpty(transceiver.Mid))
@@ -326,7 +326,7 @@ namespace Unity.RenderStreaming
                 if (transceiver.Sender.Track.ReadyState == TrackState.Ended)
                     continue;
 
-                var codecs = new VideoCodecInfo[] { m_codec };
+                var codecs = new VideoCodecInfo[] { m_Codec };
                 RTCErrorType error = transceiver.SetCodecPreferences(SelectCodecCapabilities(codecs).ToArray());
                 if (error != RTCErrorType.None)
                     throw new InvalidOperationException($"Set codec is failed. errorCode={error}");
@@ -352,10 +352,10 @@ namespace Unity.RenderStreaming
         {
             if (frameRate < 0)
                 throw new ArgumentOutOfRangeException("frameRate", frameRate, "The parameter must be greater than zero.");
-            m_frameRate = frameRate;
+            m_FrameRate = frameRate;
             foreach (var transceiver in Transceivers.Values)
             {
-                RTCError error = transceiver.Sender.SetFrameRate((uint)m_frameRate);
+                RTCError error = transceiver.Sender.SetFrameRate((uint)m_FrameRate);
                 if (error.errorType != RTCErrorType.None)
                     throw new InvalidOperationException($"Set framerate is failed. {error.message}");
             }
@@ -369,11 +369,11 @@ namespace Unity.RenderStreaming
         {
             if (minBitrate > maxBitrate)
                 throw new ArgumentException("The maxBitrate must be greater than minBitrate.", "maxBitrate");
-            m_bitrate.min = minBitrate;
-            m_bitrate.max = maxBitrate;
+            m_Bitrate.min = minBitrate;
+            m_Bitrate.max = maxBitrate;
             foreach (var transceiver in Transceivers.Values)
             {
-                RTCError error = transceiver.Sender.SetBitrate(m_bitrate.min, m_bitrate.max);
+                RTCError error = transceiver.Sender.SetBitrate(m_Bitrate.min, m_Bitrate.max);
                 if (error.errorType != RTCErrorType.None)
                     throw new InvalidOperationException($"Set codec is failed. {error.message}");
             }
@@ -388,10 +388,10 @@ namespace Unity.RenderStreaming
             if (scaleFactor < 1.0f)
                 throw new ArgumentOutOfRangeException("scaleFactor", scaleFactor, "The parameter must be greater than 1.0f. Scaleup is not allowed.");
 
-            m_scaleFactor = scaleFactor;
+            m_ScaleFactor = scaleFactor;
             foreach (var transceiver in Transceivers.Values)
             {
-                double? value = Mathf.Approximately(m_scaleFactor, 1) ? (double?)null : m_scaleFactor;
+                double? value = Mathf.Approximately(m_ScaleFactor, 1) ? (double?)null : m_ScaleFactor;
                 RTCError error = transceiver.Sender.SetScaleResolutionDown(value);
                 if (error.errorType != RTCErrorType.None)
                     throw new InvalidOperationException($"Set codec is failed. {error.message}");
@@ -400,9 +400,9 @@ namespace Unity.RenderStreaming
 
         public void SetTextureSize(Vector2Int size)
         {
-            if (m_source == VideoStreamSource.Texture)
+            if (m_Source == VideoStreamSource.Texture)
                 throw new InvalidOperationException("Video source is set Texture.");
-            m_textureSize = size;
+            m_TextureSize = size;
 
             if (isPlaying)
                 ReplaceTrack(CreateTrack());
@@ -417,7 +417,7 @@ namespace Unity.RenderStreaming
 
         VideoStreamSourceImpl CreateVideoStreamSource()
         {
-            switch (m_source)
+            switch (m_Source)
             {
                 case VideoStreamSource.Camera:
                     return new VideoStreamSourceCamera(this);
@@ -437,8 +437,8 @@ namespace Unity.RenderStreaming
             {
                 width = (int)parent.width;
                 height = (int)parent.height;
-                depth = parent.m_depth;
-                antiAliasing = parent.m_antiAliasing;
+                depth = parent.m_Depth;
+                antiAliasing = parent.m_AntiAliasing;
             }
             public abstract VideoStreamTrack CreateTrack();
             public abstract void Dispose();
@@ -454,7 +454,7 @@ namespace Unity.RenderStreaming
             private RenderTexture m_renderTexture;
             public VideoStreamSourceCamera(VideoStreamSender parent) : base(parent)
             {
-                Camera camera = parent.m_camera;
+                Camera camera = parent.m_Camera;
                 if (camera == null)
                     throw new ArgumentNullException("camera", "The sourceCamera is not assigned.");
                 m_camera = camera;
@@ -521,7 +521,7 @@ namespace Unity.RenderStreaming
 
             public VideoStreamSourceTexture(VideoStreamSender parent) : base(parent)
             {
-                Texture texture = parent.m_texture;
+                Texture texture = parent.m_Texture;
                 if (texture == null)
                     throw new ArgumentNullException("texture", "The sourceTexture is not assigned.");
                 m_texture = texture;
@@ -673,12 +673,12 @@ namespace Unity.RenderStreaming
 
             public VideoStreamSourceWebCam(VideoStreamSender parent) : base(parent)
             {
-                int deviceIndex = parent.m_webCamDeviceIndex;
+                int deviceIndex = parent.m_WebCamDeviceIndex;
                 if (deviceIndex < 0 || WebCamTexture.devices.Length <= deviceIndex)
                     throw new ArgumentOutOfRangeException("deviceIndex", deviceIndex, "The deviceIndex is out of range");
                 m_deviceIndex = deviceIndex;
-                m_frameRate = parent.m_frameRate;
-                m_autoRequestUserAuthorization = parent.m_autoRequestUserAuthorization;
+                m_frameRate = parent.m_FrameRate;
+                m_autoRequestUserAuthorization = parent.m_AutoRequestUserAuthorization;
             }
 
             public override VideoStreamTrack CreateTrack()

--- a/com.unity.renderstreaming/Samples~/Example/ARFoundation/ARFoundation.unity
+++ b/com.unity.renderstreaming/Samples~/Example/ARFoundation/ARFoundation.unity
@@ -152,7 +152,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 948060001}
   - {fileID: 1275633381}
@@ -258,7 +257,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1275633381}
   m_RootOrder: 0
@@ -336,7 +334,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 908346561}
   m_Father: {fileID: 1489100468}
@@ -375,7 +372,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 737849729}
   m_RootOrder: 1
@@ -453,7 +449,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1551390900}
   - {fileID: 545070958}
@@ -493,7 +488,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 948060001}
   m_RootOrder: 0
@@ -573,7 +567,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1584351904}
   m_RootOrder: 0
@@ -654,7 +647,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 514647105}
   m_Father: {fileID: 743595808}
@@ -775,7 +767,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 395898785}
   m_RootOrder: 0
@@ -855,7 +846,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1796556987}
   m_RootOrder: 1
@@ -997,7 +987,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1363584100}
   - {fileID: 743595808}
@@ -1040,7 +1029,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 328030559}
   m_RootOrder: 1
@@ -1151,7 +1139,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1853327866}
   m_RootOrder: 1
@@ -1491,7 +1478,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 662432478}
   m_RootOrder: 0
@@ -1702,7 +1688,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 576362884}
   m_Father: {fileID: 743595808}
@@ -1823,7 +1808,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 737849729}
   m_RootOrder: 0
@@ -1901,7 +1885,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 710769079}
   - {fileID: 289531840}
@@ -1939,7 +1922,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 662432478}
   - {fileID: 395898785}
@@ -1979,7 +1961,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1489100468}
   m_Father: {fileID: 743595808}
@@ -2018,7 +1999,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 284772626}
   m_RootOrder: 0
@@ -2096,7 +2076,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 95690758}
   m_Father: {fileID: 743595808}
@@ -2133,7 +2112,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 346410477}
   m_Father: {fileID: 95690758}
@@ -2260,7 +2238,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1420951684}
   m_RootOrder: 0
@@ -2291,7 +2268,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 131599903}
   - {fileID: 1594806527}
@@ -2386,7 +2362,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -2419,7 +2394,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1796556987}
   m_RootOrder: 0
@@ -2500,7 +2474,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 528948626}
   m_RootOrder: 0
@@ -2599,7 +2572,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1161244843}
   m_Father: {fileID: 0}
@@ -2634,7 +2606,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 284772626}
   - {fileID: 328030559}
@@ -2740,7 +2711,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 328030559}
   m_RootOrder: 0
@@ -2818,7 +2788,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 355025565}
   - {fileID: 1589093482}
@@ -2858,7 +2827,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1584351904}
   m_RootOrder: 1
@@ -2939,7 +2907,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1275633381}
   m_RootOrder: 1
@@ -3077,7 +3044,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -3108,7 +3074,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1356000875}
   - {fileID: 523210253}
@@ -3148,7 +3113,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1853327866}
   m_RootOrder: 0
@@ -3226,7 +3190,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1837722695}
   - {fileID: 556513336}
@@ -3271,7 +3234,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4872c2e12a0e07b498876d68f1e51143, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  streamingSize: {x: 1280, y: 720}
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_RenderMode: 1
+  m_TargetTexture: {fileID: 0}
 --- !u!114 &1915034402
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3306,7 +3273,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0

--- a/com.unity.renderstreaming/Samples~/Example/Bidirectional/Bidirectional.unity
+++ b/com.unity.renderstreaming/Samples~/Example/Bidirectional/Bidirectional.unity
@@ -4706,7 +4706,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_TextureSize: {x: 1280, y: 720}
-  m_Source: 0
+  m_Source: 2
   m_Camera: {fileID: 0}
   m_Texture: {fileID: 0}
   m_WebCamDeviceIndex: 0

--- a/com.unity.renderstreaming/Samples~/Example/Bidirectional/Bidirectional.unity
+++ b/com.unity.renderstreaming/Samples~/Example/Bidirectional/Bidirectional.unity
@@ -4705,19 +4705,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bcc82901c3f48a88d3408251afa3365, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_textureSize: {x: 1280, y: 720}
-  m_source: 2
-  m_camera: {fileID: 0}
-  m_texture: {fileID: 0}
-  m_webCamDeviceIndex: 0
-  m_depth: 0
-  m_antiAliasing: 1
-  m_frameRate: 30
-  m_bitrate:
+  m_TextureSize: {x: 1280, y: 720}
+  m_Source: 0
+  m_Camera: {fileID: 0}
+  m_Texture: {fileID: 0}
+  m_WebCamDeviceIndex: 0
+  m_Depth: 16
+  m_AntiAliasing: 1
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_FrameRate: 30
+  m_Bitrate:
     min: 0
     max: 1000
-  m_scaleFactor: 1
-  m_autoRequestUserAuthorization: 1
+  m_ScaleFactor: 1
+  m_AutoRequestUserAuthorization: 1
 --- !u!114 &1915034405
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4730,7 +4733,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4872c2e12a0e07b498876d68f1e51143, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_targetTexture: {fileID: 0}
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_RenderMode: 1
+  m_TargetTexture: {fileID: 0}
 --- !u!114 &1915034406
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/Broadcast.unity
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/Broadcast.unity
@@ -2890,19 +2890,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bcc82901c3f48a88d3408251afa3365, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_textureSize: {x: 1280, y: 720}
-  m_source: 1
-  m_camera: {fileID: 0}
-  m_texture: {fileID: 0}
-  m_webCamDeviceIndex: 0
-  m_depth: 0
-  m_antiAliasing: 1
-  m_frameRate: 30
-  m_bitrate:
+  m_TextureSize: {x: 1280, y: 720}
+  m_Source: 1
+  m_Camera: {fileID: 0}
+  m_Texture: {fileID: 0}
+  m_WebCamDeviceIndex: 0
+  m_Depth: 16
+  m_AntiAliasing: 1
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_FrameRate: 30
+  m_Bitrate:
     min: 0
     max: 1000
-  m_scaleFactor: 1
-  m_autoRequestUserAuthorization: 1
+  m_ScaleFactor: 1
+  m_AutoRequestUserAuthorization: 1
 --- !u!114 &725451157
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/com.unity.renderstreaming/Samples~/Example/Gyro/Gyro.unity
+++ b/com.unity.renderstreaming/Samples~/Example/Gyro/Gyro.unity
@@ -149,7 +149,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 908346561}
   m_Father: {fileID: 1489100468}
@@ -188,7 +187,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 737849729}
   m_RootOrder: 1
@@ -266,7 +264,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1551390900}
   - {fileID: 545070958}
@@ -431,7 +428,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1796556987}
   m_RootOrder: 1
@@ -573,7 +569,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1363584100}
   - {fileID: 743595808}
@@ -616,7 +611,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 328030559}
   m_RootOrder: 1
@@ -727,7 +721,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 662432478}
   m_RootOrder: 0
@@ -808,7 +801,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 576362884}
   m_Father: {fileID: 743595808}
@@ -980,7 +972,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -1013,7 +1004,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 737849729}
   m_RootOrder: 0
@@ -1091,7 +1081,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 710769079}
   - {fileID: 289531840}
@@ -1129,7 +1118,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 662432478}
   - {fileID: 844007571}
@@ -1167,7 +1155,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1489100468}
   m_Father: {fileID: 743595808}
@@ -1206,7 +1193,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 284772626}
   m_RootOrder: 0
@@ -1341,7 +1327,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -1374,7 +1359,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1796556987}
   m_RootOrder: 0
@@ -1455,7 +1439,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 528948626}
   m_RootOrder: 0
@@ -1543,7 +1526,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 284772626}
   - {fileID: 328030559}
@@ -1649,7 +1631,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 328030559}
   m_RootOrder: 0
@@ -1997,7 +1978,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1356000875}
   - {fileID: 523210253}
@@ -2042,7 +2022,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4872c2e12a0e07b498876d68f1e51143, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  streamingSize: {x: 1280, y: 720}
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_RenderMode: 1
+  m_TargetTexture: {fileID: 0}
 --- !u!114 &1915034402
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2077,7 +2061,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1

--- a/com.unity.renderstreaming/Samples~/Example/Multiplay/Guest.prefab
+++ b/com.unity.renderstreaming/Samples~/Example/Multiplay/Guest.prefab
@@ -76,7 +76,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4872c2e12a0e07b498876d68f1e51143, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  streamingSize: {x: 1280, y: 720}
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_RenderMode: 1
+  m_TargetTexture: {fileID: 0}
 --- !u!114 &1206473709398235252
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -91,6 +95,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   local: 1
   label: 
-  onChangeLabel:
+  OnChangeLabel:
     m_PersistentCalls:
       m_Calls: []

--- a/com.unity.renderstreaming/Samples~/Example/Multiplay/Player.prefab
+++ b/com.unity.renderstreaming/Samples~/Example/Multiplay/Player.prefab
@@ -436,19 +436,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bcc82901c3f48a88d3408251afa3365, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_textureSize: {x: 1280, y: 720}
-  m_source: 0
-  m_camera: {fileID: 8182600240721872744}
-  m_texture: {fileID: 0}
-  m_webCamDeviceIndex: 0
-  m_depth: 16
-  m_antiAliasing: 1
-  m_frameRate: 30
-  m_bitrate:
+  m_TextureSize: {x: 1280, y: 720}
+  m_Source: 0
+  m_Camera: {fileID: 8182600240721872744}
+  m_Texture: {fileID: 0}
+  m_WebCamDeviceIndex: 0
+  m_Depth: 16
+  m_AntiAliasing: 1
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_FrameRate: 30
+  m_Bitrate:
     min: 0
     max: 1000
-  m_scaleFactor: 1
-  m_autoRequestUserAuthorization: 1
+  m_ScaleFactor: 1
+  m_AutoRequestUserAuthorization: 1
 --- !u!1 &1474066182485874884
 GameObject:
   m_ObjectHideFlags: 0

--- a/com.unity.renderstreaming/Samples~/Example/Receiver/Receiver.unity
+++ b/com.unity.renderstreaming/Samples~/Example/Receiver/Receiver.unity
@@ -277,7 +277,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1497684901}
   m_Father: {fileID: 1537721409}
@@ -460,7 +459,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1221357425}
   - {fileID: 1537721409}
@@ -502,7 +500,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 662432478}
   m_RootOrder: 0
@@ -583,7 +580,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 576362884}
   m_Father: {fileID: 1537721409}
@@ -755,7 +751,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -789,7 +784,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1121022088}
   - {fileID: 1809130295}
@@ -852,10 +846,7 @@ MonoBehaviour:
   m_HideMobileInput: 0
   m_CharacterValidation: 0
   m_CharacterLimit: 0
-  m_OnSubmit:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnDidEndEdit:
+  m_OnEndEdit:
     m_PersistentCalls:
       m_Calls: []
   m_OnValueChanged:
@@ -935,7 +926,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 935674849}
   m_RootOrder: 0
@@ -1013,7 +1003,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1363584100}
   - {fileID: 1829034365312341185}
@@ -1108,7 +1097,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -1142,7 +1130,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1221357425}
   m_RootOrder: 0
@@ -1229,7 +1216,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 159113883}
   m_RootOrder: 0
@@ -1498,7 +1484,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 935674849}
   - {fileID: 662432478}
@@ -1565,7 +1550,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 935674849}
   m_RootOrder: 1
@@ -1651,7 +1635,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4872c2e12a0e07b498876d68f1e51143, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  streamingSize: {x: 1280, y: 720}
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_RenderMode: 1
+  m_TargetTexture: {fileID: 0}
 --- !u!114 &1915034402
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1686,7 +1674,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -1769,7 +1756,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5036778817534049989}
   m_Father: {fileID: 1221357425}
@@ -1844,7 +1830,6 @@ LineRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -1950,7 +1935,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1829034365312341185}
   m_RootOrder: 0

--- a/com.unity.renderstreaming/Samples~/Example/RenderPipeline/HDRP.unity
+++ b/com.unity.renderstreaming/Samples~/Example/RenderPipeline/HDRP.unity
@@ -3929,19 +3929,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bcc82901c3f48a88d3408251afa3365, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_textureSize: {x: 1280, y: 720}
-  m_source: 1
-  m_camera: {fileID: 0}
-  m_texture: {fileID: 0}
-  m_webCamDeviceIndex: 0
-  m_depth: 16
-  m_antiAliasing: 1
-  m_frameRate: 30
-  m_bitrate:
+  m_TextureSize: {x: 1280, y: 720}
+  m_Source: 1
+  m_Camera: {fileID: 0}
+  m_Texture: {fileID: 0}
+  m_WebCamDeviceIndex: 0
+  m_Depth: 16
+  m_AntiAliasing: 1
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_FrameRate: 30
+  m_Bitrate:
     min: 0
     max: 1000
-  m_scaleFactor: 1
-  m_autoRequestUserAuthorization: 1
+  m_ScaleFactor: 1
+  m_AutoRequestUserAuthorization: 1
 --- !u!81 &1299133683
 AudioListener:
   m_ObjectHideFlags: 0

--- a/com.unity.renderstreaming/Samples~/Example/RenderPipeline/URP.unity
+++ b/com.unity.renderstreaming/Samples~/Example/RenderPipeline/URP.unity
@@ -2063,19 +2063,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bcc82901c3f48a88d3408251afa3365, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_textureSize: {x: 1280, y: 720}
-  m_source: 1
-  m_camera: {fileID: 0}
-  m_texture: {fileID: 0}
-  m_webCamDeviceIndex: 0
-  m_depth: 16
-  m_antiAliasing: 1
-  m_frameRate: 30
-  m_bitrate:
+  m_TextureSize: {x: 1280, y: 720}
+  m_Source: 1
+  m_Camera: {fileID: 0}
+  m_Texture: {fileID: 0}
+  m_WebCamDeviceIndex: 0
+  m_Depth: 16
+  m_AntiAliasing: 1
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_FrameRate: 30
+  m_Bitrate:
     min: 0
     max: 1000
-  m_scaleFactor: 1
-  m_autoRequestUserAuthorization: 1
+  m_ScaleFactor: 1
+  m_AutoRequestUserAuthorization: 1
 --- !u!114 &725451157
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2839,7 +2842,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 16.457764, y: 9.257721}
+  m_AnchoredPosition: {x: 16.457764, y: 9.25769}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &930090859

--- a/com.unity.renderstreaming/Samples~/Example/WebBrowserInput/WebBrowserInput.unity
+++ b/com.unity.renderstreaming/Samples~/Example/WebBrowserInput/WebBrowserInput.unity
@@ -856,19 +856,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bcc82901c3f48a88d3408251afa3365, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_textureSize: {x: 1280, y: 720}
-  m_source: 0
-  m_camera: {fileID: 725451154}
-  m_texture: {fileID: 0}
-  m_webCamDeviceIndex: 0
-  m_depth: 16
-  m_antiAliasing: 1
-  m_frameRate: 30
-  m_bitrate:
+  m_TextureSize: {x: 1280, y: 720}
+  m_Source: 0
+  m_Camera: {fileID: 725451154}
+  m_Texture: {fileID: 0}
+  m_WebCamDeviceIndex: 0
+  m_Depth: 16
+  m_AntiAliasing: 1
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_FrameRate: 30
+  m_Bitrate:
     min: 0
     max: 1000
-  m_scaleFactor: 1
-  m_autoRequestUserAuthorization: 1
+  m_ScaleFactor: 1
+  m_AutoRequestUserAuthorization: 1
 --- !u!1 &775980371
 GameObject:
   m_ObjectHideFlags: 0
@@ -1792,19 +1795,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8bcc82901c3f48a88d3408251afa3365, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_textureSize: {x: 1280, y: 720}
-  m_source: 0
-  m_camera: {fileID: 1112556118}
-  m_texture: {fileID: 0}
-  m_webCamDeviceIndex: 0
-  m_depth: 16
-  m_antiAliasing: 1
-  m_frameRate: 30
-  m_bitrate:
+  m_TextureSize: {x: 1280, y: 720}
+  m_Source: 0
+  m_Camera: {fileID: 1112556118}
+  m_Texture: {fileID: 0}
+  m_WebCamDeviceIndex: 0
+  m_Depth: 16
+  m_AntiAliasing: 1
+  m_Codec:
+    m_MimeType: 
+    m_SdpFmtpLine: 
+  m_FrameRate: 30
+  m_Bitrate:
     min: 0
     max: 1000
-  m_scaleFactor: 1
-  m_autoRequestUserAuthorization: 1
+  m_ScaleFactor: 1
+  m_AutoRequestUserAuthorization: 1
 --- !u!114 &1112556117
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -244,6 +244,24 @@ namespace Unity.RenderStreaming.RuntimeTest
                 }
             }
         }
+
+        [Test]
+        public void SetCodec()
+        {
+            var go = new GameObject();
+            var receiver = go.AddComponent<VideoStreamReceiver>();
+            Assert.That(receiver.codec, Is.Null);
+
+            var codecs = VideoStreamReceiver.GetAvailableCodecs();
+            Assert.That(codecs, Is.Not.Empty);
+
+            var codec = codecs.First();
+            receiver.SetCodec(codec);
+            Assert.That(receiver.codec, Is.EqualTo(codec));
+
+            receiver.SetCodec(null);
+            Assert.That(receiver.codec, Is.Null);
+        }
     }
 
     class AudioStreamSenderTest


### PR DESCRIPTION
This pull request adds the custom component of `VideoStreamReceiver`.
<img width="344" alt="image" src="https://user-images.githubusercontent.com/1132081/188058729-ab8274c3-b2ff-48bb-b6e8-a648d1fea646.png">

There are two options for receiving video streaming.

- Render Texture
- API Only

If you select **Render Texture** option, receiving texture will be copyed to Render Texture attaching the component. 
**API Only** is for fetching received texture with script instead of texture copy.