### PR TITLE
fix: Avoid exception when using VideoStreamSource.Texture as  in the Broadcast sample

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -302,7 +302,9 @@ namespace Unity.RenderStreaming
             get { return m_Codec; }
         }
 
-
+        /// <summary>
+        /// 
+        /// </summary>
         public bool autoRequestUserAuthorization
         {
             get => m_AutoRequestUserAuthorization;
@@ -398,6 +400,10 @@ namespace Unity.RenderStreaming
             }
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="size"></param>
         public void SetTextureSize(Vector2Int size)
         {
             if (m_Source == VideoStreamSource.Texture)

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
@@ -79,9 +79,11 @@ namespace Unity.RenderStreaming.Samples
             );
 #endif
 
-            videoStreamSender.width = (uint)RenderStreamingSettings.StreamSize.x;
-            videoStreamSender.height = (uint)RenderStreamingSettings.StreamSize.y;
-
+            if (videoStreamSender.source != VideoStreamSource.Texture)
+            {
+                videoStreamSender.width = (uint)RenderStreamingSettings.StreamSize.x;
+                videoStreamSender.height = (uint)RenderStreamingSettings.StreamSize.y;
+            }
             videoStreamSender.SetCodec(RenderStreamingSettings.SenderVideoCodec);
 
             bandwidthSelector.options = bandwidthOptions
@@ -129,7 +131,8 @@ namespace Unity.RenderStreaming.Samples
         {
             var resolution = resolutionOptions.Values.ElementAt(index);
 
-            videoStreamSender.SetTextureSize(resolution);
+            if(videoStreamSender.source != VideoStreamSource.Texture)
+                videoStreamSender.SetTextureSize(resolution);
         }
 
         private void Start()


### PR DESCRIPTION
This pull request avoids the exception in Broadcast sample.
`VideoStreamSender` class throw **InvalidOperationException** during calling the `SetTextureSize` method when VideoStreamSource.Texture as the VideoStreamSender.source property.