### PR TITLE
chore: Add Unity2021.3 to the list of test environment when publishing the package

### DIFF
--- a/.yamato/meta/environments.yml
+++ b/.yamato/meta/environments.yml
@@ -6,6 +6,7 @@ editors:
   - version: 2020.3
   - version: 2021.3
   - version: 2022.1
+  - version: trunk
 platforms:
   - name: win
     type: Unity::VM::GPU

--- a/.yamato/meta/environments.yml
+++ b/.yamato/meta/environments.yml
@@ -3,7 +3,6 @@ upm:
   package_version: stable
 intra_pypi_url: https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
 editors:
-  - version: 2019.4
   - version: 2020.3
   - version: 2021.3
   - version: 2022.1
@@ -17,7 +16,7 @@ platforms:
     packed_webapp_platform: win
     test_params:
 # todo(kazuki) : this comment is workaround for avoiding template test error on Yamato.
-# "PackageTestSuite.PackageValidationTests.PackageHasTests" unittest is failed 
+# "PackageTestSuite.PackageValidationTests.PackageHasTests" unittest is failed
 # Error message : A package must have either playmode or editor tests in it. If you are using a different package for your tests, make sure to use the 'relatedPackages' field in your main package's manifest like explained here: https://confluence.hq.unity3d.com/display/PAK/How+to+add+a+test+project+for+your+package
       - backend: mono
         platform: editmode

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -404,8 +404,6 @@ publish_{{ package.name }}:
   dependencies:
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
 {% for editor in editors %}
-{% if editor.version != "2021.2" -%} # exclude editor version 2021.2
     - .yamato/upm-ci-renderstreaming-packages.yml#trigger_test_{{ package.name }}_{{ editor.version }}
-{% endif %}
 {% endfor %}
 {% endfor %}

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -404,6 +404,8 @@ publish_{{ package.name }}:
   dependencies:
     - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
 {% for editor in editors %}
+{% if editor.version != "trunk" -%} # exclude trunk to test
     - .yamato/upm-ci-renderstreaming-packages.yml#trigger_test_{{ package.name }}_{{ editor.version }}
+{% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
## Summary

This PR revert the previous PR #603.
Additionally, Removed Unity2019.4 from the supporting Unity version list.