### PR TITLE
Fix: deadconnection handle httpsingaling

### DIFF
--- a/WebApp/src/class/httphandler.ts
+++ b/WebApp/src/class/httphandler.ts
@@ -75,17 +75,26 @@ function checkSessionId(req: Request, res: Response, next): void {
 function _deleteConnection(sessionId:string, connectionId:string) {
   clients.get(sessionId).delete(connectionId);
 
-  if (connectionPair.has(connectionId)) {
-    const pair = connectionPair.get(connectionId);
-    const otherSessionId = pair[0] == sessionId ? pair[1] : pair[0];
-    if (otherSessionId) {
-      if (clients.has(otherSessionId)) {
-        clients.get(otherSessionId).delete(connectionId);
-        const array1 = disconnections.get(otherSessionId);
-        array1.push(new Disconnection(connectionId, Date.now()));
+  if(isPrivate) {
+    if (connectionPair.has(connectionId)) {
+      const pair = connectionPair.get(connectionId);
+      const otherSessionId = pair[0] == sessionId ? pair[1] : pair[0];
+      if (otherSessionId) {
+        if (clients.has(otherSessionId)) {
+          clients.get(otherSessionId).delete(connectionId);
+          const array1 = disconnections.get(otherSessionId);
+          array1.push(new Disconnection(connectionId, Date.now()));
+        }
       }
     }
+  } else {
+    disconnections.forEach((array, id) => {
+      if (id == sessionId)
+        return;
+      array.push(new Disconnection(connectionId, Date.now()));
+    });
   }
+
   connectionPair.delete(connectionId);
   offers.get(sessionId).delete(connectionId);
   answers.get(sessionId).delete(connectionId);
@@ -333,6 +342,7 @@ function postOffer(req: Request, res: Response): void {
 
   connectionPair.set(connectionId, [sessionId, null]);
   keySessionId = sessionId;
+  console.log(keySessionId);
   const map = offers.get(keySessionId);
   map.set(connectionId, new Offer(req.body.sdp, Date.now(), polite));
 

--- a/WebApp/src/class/httphandler.ts
+++ b/WebApp/src/class/httphandler.ts
@@ -342,7 +342,6 @@ function postOffer(req: Request, res: Response): void {
 
   connectionPair.set(connectionId, [sessionId, null]);
   keySessionId = sessionId;
-  console.log(keySessionId);
   const map = offers.get(keySessionId);
   map.set(connectionId, new Offer(req.body.sdp, Date.now(), polite));
 

--- a/WebApp/test/httphandler.test.ts
+++ b/WebApp/test/httphandler.test.ts
@@ -9,8 +9,8 @@ describe('http signaling test in public mode', () => {
   const testsdp = "test sdp";
 
   const { res, next, mockClear } = getMockRes();
-  const req = getMockReq({ header: (): string => sessionId });
-  const req2 = getMockReq({ header: (): string => sessionId2 });
+  const req = getMockReq({ header: jest.fn(() => sessionId) });
+  const req2 = getMockReq({ header: jest.fn(() => sessionId2) });
 
   beforeAll(() => {
     httpHandler.reset("public");
@@ -131,13 +131,13 @@ describe('http signaling test in public mode', () => {
   });
 
   test('delete session1', async () => {
-    const req = getMockReq({ header: (): string => sessionId });
+    const req = getMockReq({ header: jest.fn(() => sessionId) });
     await httpHandler.deleteSession(req, res);
     expect(res.sendStatus).toHaveBeenCalledWith(200);
   });
 
   test('delete session2', async () => {
-    const req2 = getMockReq({ header: (): string => sessionId2 });
+    const req2 = getMockReq({ header: jest.fn(() => sessionId2) });
     await httpHandler.deleteSession(req2, res);
     expect(res.sendStatus).toHaveBeenCalledWith(200);
   });
@@ -150,8 +150,8 @@ describe('http signaling test in private mode', () => {
   const testsdp = "test sdp";
 
   const { res, next, mockClear } = getMockRes();
-  const req = getMockReq({ header: (): string => sessionId });
-  const req2 = getMockReq({ header: (): string => sessionId2 });
+  const req = getMockReq({ header: jest.fn(() => sessionId) });
+  const req2 = getMockReq({ header: jest.fn(() => sessionId2) });
 
   beforeAll(() => {
     httpHandler.reset("private");
@@ -192,7 +192,7 @@ describe('http signaling test in private mode', () => {
   });
 
   test('response status 400 if connecctionId does not set', async () => {
-    const req3 = getMockReq({ header: (): string => sessionId });
+    const req3 = getMockReq({ header: jest.fn(() => sessionId) });
     await httpHandler.createConnection(req3, res);
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.send).toHaveBeenCalledWith({ error: new Error(`connectionId is required`) });
@@ -202,7 +202,7 @@ describe('http signaling test in private mode', () => {
     const sessionId3 = "session3";
     await httpHandler.createSession(sessionId3, res);
     const body = { connectionId: connectionId };
-    const req3 = getMockReq({ header: (): string => sessionId3 });
+    const req3 = getMockReq({ header: jest.fn(() => sessionId3) });
     req3.body = body;
     await httpHandler.createConnection(req3, res);
     expect(res.status).toHaveBeenCalledWith(400);
@@ -285,13 +285,13 @@ describe('http signaling test in private mode', () => {
   });
 
   test('delete session1', async () => {
-    const req = getMockReq({ header: (): string => sessionId });
+    const req = getMockReq({ header: jest.fn(() => sessionId) });
     await httpHandler.deleteSession(req, res);
     expect(res.sendStatus).toHaveBeenCalledWith(200);
   });
 
   test('delete session2', async () => {
-    const req2 = getMockReq({ header: (): string => sessionId2 });
+    const req2 = getMockReq({ header: jest.fn(() => sessionId2) });
     await httpHandler.deleteSession(req2, res);
     expect(res.sendStatus).toHaveBeenCalledWith(200);
   });

--- a/WebApp/test/httphandler.test.ts
+++ b/WebApp/test/httphandler.test.ts
@@ -52,12 +52,16 @@ describe('http signaling test in public mode', () => {
 
   test('get connection from session1', async () => {
     await httpHandler.getConnection(req, res);
-    expect(res.json).toHaveBeenCalledWith({ connections: [{ connectionId: connectionId, datetime: expect.anything(), type: "connect" }] });
+    const arrayContain = expect.arrayContaining([{ connectionId: connectionId, datetime: expect.anything(), type: "connect" }])
+    const objContain = expect.objectContaining({ connections: arrayContain });
+    expect(res.json).toHaveBeenCalledWith(objContain);
   });
 
   test('get all from session1', async () => {
     await httpHandler.getAll(req, res);
-    expect(res.json).toHaveBeenCalledWith({ messages: [{ connectionId: connectionId, datetime: expect.anything(), type: "connect" }] });
+    const arrayContain = expect.arrayContaining([{ connectionId: connectionId, datetime: expect.anything(), type: "connect" }])
+    const objContain = expect.objectContaining({ messages: arrayContain });
+    expect(res.json).toHaveBeenCalledWith(objContain);
   });
 
   test('post offer from session1', async () => {
@@ -118,9 +122,11 @@ describe('http signaling test in public mode', () => {
     expect(res.json).toHaveBeenCalledWith({ connectionId: connectionId });
   });
 
-  test('no connection get from session1', async () => {
-    await httpHandler.getConnection(req, res);
-    expect(res.json).toHaveBeenCalledWith({ connections: [] });
+  test('disconnection get from session1', async () => {
+    await httpHandler.getAll(req, res);
+    const arrayContain = expect.arrayContaining([{ connectionId: connectionId, datetime: expect.anything(), type: "disconnect" }])
+    const objContain = expect.objectContaining({ messages: arrayContain });
+    expect(res.json).toHaveBeenCalledWith(objContain);
   });
 
   test('delete connection from session1', async () => {

--- a/WebApp/test/httphandler.test.ts
+++ b/WebApp/test/httphandler.test.ts
@@ -52,16 +52,14 @@ describe('http signaling test in public mode', () => {
 
   test('get connection from session1', async () => {
     await httpHandler.getConnection(req, res);
-    const arrayContain = expect.arrayContaining([{ connectionId: connectionId, datetime: expect.anything(), type: "connect" }])
-    const objContain = expect.objectContaining({ connections: arrayContain });
-    expect(res.json).toHaveBeenCalledWith(objContain);
+    const connect = { connectionId: connectionId, datetime: expect.anything(), type: "connect" };
+    expect(res.json).toHaveBeenCalledWith({ connections: expect.arrayContaining([connect]) });
   });
 
   test('get all from session1', async () => {
     await httpHandler.getAll(req, res);
-    const arrayContain = expect.arrayContaining([{ connectionId: connectionId, datetime: expect.anything(), type: "connect" }])
-    const objContain = expect.objectContaining({ messages: arrayContain });
-    expect(res.json).toHaveBeenCalledWith(objContain);
+    const connect = { connectionId: connectionId, datetime: expect.anything(), type: "connect" };
+    expect(res.json).toHaveBeenCalledWith({ messages: expect.arrayContaining([connect]) });
   });
 
   test('post offer from session1', async () => {
@@ -124,9 +122,8 @@ describe('http signaling test in public mode', () => {
 
   test('disconnection get from session1', async () => {
     await httpHandler.getAll(req, res);
-    const arrayContain = expect.arrayContaining([{ connectionId: connectionId, datetime: expect.anything(), type: "disconnect" }])
-    const objContain = expect.objectContaining({ messages: arrayContain });
-    expect(res.json).toHaveBeenCalledWith(objContain);
+    const disconnect = { connectionId: connectionId, datetime: expect.anything(), type: "disconnect" };
+    expect(res.json).toHaveBeenCalledWith({ messages: expect.arrayContaining([disconnect]) });
   });
 
   test('delete connection from session1', async () => {


### PR DESCRIPTION
Fix disconnection can't get when session2 disconnects before session1 answer. e42306352aa4485b97626ed7af1934e2075b739a

And add test about this case.