### PR TITLE
fix: Fix a bug about serializing VideoCodecInfo/AudioCodecInfo

### DIFF
--- a/com.unity.renderstreaming/Editor/PropertyDrawers/CodecDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/CodecDrawer.cs
@@ -139,6 +139,8 @@ namespace Unity.RenderStreaming.Editor
                     selectCodecIndex = Array.FindIndex(codecNames, codec => codec == codecName);
                 codecLabel = GetCodecLabel(property.serializedObject.targetObject);
                 hasCodecOptions = codecOptions.Length > 1;
+                if (hasCodecOptions)
+                    selectSdpFmtpLineIndex = Array.FindIndex(sdpFmtpLines, sdp => sdp == propertySdpFmtpLine.stringValue);
                 cache = true;
             }
 
@@ -194,15 +196,17 @@ namespace Unity.RenderStreaming.Editor
 
             if (changed)
             {
-                if (Application.isPlaying)
-                {
-                    var objectReferenceValue = property.serializedObject.targetObject;
-                    var type = objectReferenceValue.GetType();
-                    var attribute = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-                    var methodName = "SetCodec";
-                    var method = type.GetMethod(methodName, attribute);
-//                    method.Invoke(objectReferenceValue, new object[] { newValue });
-                }
+                // todo: not supported changing codecs in play mode.
+
+                //if (Application.isPlaying)
+                //{
+                //    var objectReferenceValue = property.serializedObject.targetObject;
+                //    var type = objectReferenceValue.GetType();
+                //    var attribute = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+                //    var methodName = "SetCodec";
+                //    var method = type.GetMethod(methodName, attribute);
+                //    method.Invoke(objectReferenceValue, new object[] { newValue });
+                //}
                 changed = false;
             }
         }

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using Unity.WebRTC;
 
@@ -60,16 +59,31 @@ namespace Unity.RenderStreaming
                 && this.sampleRate == other.sampleRate;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
         public override bool Equals(object obj)
         {
             return obj is AudioCodecInfo ? Equals((AudioCodecInfo)obj) : base.Equals(obj);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
         public override int GetHashCode()
         {
             return new { mimeType, sdpFmtpLine, channelCount, sampleRate }.GetHashCode();
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
         public static bool operator ==(AudioCodecInfo left, AudioCodecInfo right)
         {
             if (ReferenceEquals(left, null))
@@ -81,7 +95,13 @@ namespace Unity.RenderStreaming
                 return left.Equals(right);
             }
         }
-        
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
         public static bool operator !=(AudioCodecInfo left, AudioCodecInfo right)
         {
             return !(left == right);
@@ -93,6 +113,16 @@ namespace Unity.RenderStreaming
             m_SdpFmtpLine = cap.sdpFmtpLine;
             m_ChannelCount = cap.channels.GetValueOrDefault();
             m_SampleRate = cap.clockRate.GetValueOrDefault();
+        }
+
+        internal bool Equals(RTCRtpCodecCapability other)
+        {
+            if (other == null)
+                return false;
+            return this.mimeType == other.mimeType
+                && this.sdpFmtpLine == other.sdpFmtpLine
+                && this.channelCount == other.channels
+                && this.sampleRate == other.clockRate;
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using Unity.WebRTC;
 
@@ -22,7 +23,7 @@ namespace Unity.RenderStreaming
         /// <summary>
         /// 
         /// </summary>
-        public string name { get { return m_MimeType.Split('/')[1]; } }
+        public string name { get { return m_MimeType.GetCodecName(); } }
 
         /// <summary>
         /// 
@@ -51,22 +52,30 @@ namespace Unity.RenderStreaming
         /// <returns></returns>
         public bool Equals(AudioCodecInfo other)
         {
-            if (other == null)
-                return false;
             return this.mimeType == other.mimeType
                 && this.sdpFmtpLine == other.sdpFmtpLine
                 && this.channelCount == other.channelCount
                 && this.sampleRate == other.sampleRate;
         }
 
-        internal bool Equals(RTCRtpCodecCapability other)
+        public override bool Equals(object obj)
         {
-            if (other == null)
-                return false;
-            return this.mimeType == other.mimeType
-                && this.sdpFmtpLine == other.sdpFmtpLine
-                && this.channelCount == other.channels
-                && this.sampleRate == other.clockRate;
+            return obj is AudioCodecInfo ? Equals((AudioCodecInfo)obj) : base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(mimeType, sdpFmtpLine, channelCount, sampleRate);
+        }
+
+        public static bool operator ==(AudioCodecInfo left, AudioCodecInfo right)
+        {
+            return left.Equals(right);
+        }
+        
+        public static bool operator !=(AudioCodecInfo left, AudioCodecInfo right)
+        {
+            return !(left == right);
         }
 
         internal AudioCodecInfo(RTCRtpCodecCapability cap)

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
@@ -52,6 +52,8 @@ namespace Unity.RenderStreaming
         /// <returns></returns>
         public bool Equals(AudioCodecInfo other)
         {
+            if (other == null)
+                return false;
             return this.mimeType == other.mimeType
                 && this.sdpFmtpLine == other.sdpFmtpLine
                 && this.channelCount == other.channelCount
@@ -70,7 +72,14 @@ namespace Unity.RenderStreaming
 
         public static bool operator ==(AudioCodecInfo left, AudioCodecInfo right)
         {
-            return left.Equals(right);
+            if (ReferenceEquals(left, null))
+            {
+                return ReferenceEquals(left, null);
+            }
+            else
+            {
+                return left.Equals(right);
+            }
         }
         
         public static bool operator !=(AudioCodecInfo left, AudioCodecInfo right)

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
@@ -67,7 +67,7 @@ namespace Unity.RenderStreaming
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(mimeType, sdpFmtpLine, channelCount, sampleRate);
+            return new { mimeType, sdpFmtpLine, channelCount, sampleRate }.GetHashCode();
         }
 
         public static bool operator ==(AudioCodecInfo left, AudioCodecInfo right)

--- a/com.unity.renderstreaming/Runtime/Scripts/Codec.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Codec.cs
@@ -6,9 +6,14 @@ namespace Unity.RenderStreaming
 {
     internal static class RTCRtpCodecCapabilityExtension
     {
-        public static string GetCodecName(this RTCRtpCodecCapability cap)
+        public static string GetCodecName(this string mimeType)
         {
-            return cap?.mimeType.Split('/')[1];
+            if (mimeType == null)
+                return null;
+            string[] substrings = mimeType.Split('/');
+            if (substrings.Length > 1)
+                return substrings[1];
+            return null;
         }
 
         public static IEnumerable<RTCRtpCodecCapability> SelectCodecCapabilities(this RTCRtpCapabilities capabilities, IEnumerable<VideoCodecInfo> codecs)

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
@@ -18,6 +18,8 @@ namespace Unity.RenderStreaming
         [SerializeField]
         private string m_SdpFmtpLine;
 
+        readonly Dictionary<string, string> m_parameters = new Dictionary<string, string>();
+
         /// <summary>
         /// 
         /// </summary>
@@ -51,16 +53,31 @@ namespace Unity.RenderStreaming
                 && this.sdpFmtpLine == other.sdpFmtpLine;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
         public override bool Equals(object obj)
         {
             return obj is VideoCodecInfo ? Equals((VideoCodecInfo)obj) : base.Equals(obj);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
         public override int GetHashCode()
         {
             return new { mimeType, sdpFmtpLine }.GetHashCode();
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
         public static bool operator ==(VideoCodecInfo left, VideoCodecInfo right)
         {
             if (ReferenceEquals(left, null))
@@ -73,6 +90,12 @@ namespace Unity.RenderStreaming
             }
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
         public static bool operator !=(VideoCodecInfo left, VideoCodecInfo right)
         {
             return !(left == right);
@@ -96,9 +119,8 @@ namespace Unity.RenderStreaming
                 return m_parameters;
             }
         }
-        readonly Dictionary<string, string> m_parameters = new Dictionary<string, string>();
 
-        static public VideoCodecInfo Create(RTCRtpCodecCapability caps)
+        static internal VideoCodecInfo Create(RTCRtpCodecCapability caps)
         {
             switch(caps.mimeType)
             {
@@ -109,6 +131,14 @@ namespace Unity.RenderStreaming
                 default:
                     return new VideoCodecInfo(caps);
             }
+        }
+
+        internal bool Equals(RTCRtpCodecCapability other)
+        {
+            if (other == null)
+                return false;
+            return this.mimeType == other.mimeType
+                && this.sdpFmtpLine == other.sdpFmtpLine;
         }
 
         protected VideoCodecInfo(RTCRtpCodecCapability caps)

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
@@ -58,7 +58,7 @@ namespace Unity.RenderStreaming
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(mimeType, sdpFmtpLine);
+            return new { mimeType, sdpFmtpLine }.GetHashCode();
         }
 
         public static bool operator ==(VideoCodecInfo left, VideoCodecInfo right)

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
@@ -45,6 +45,8 @@ namespace Unity.RenderStreaming
         /// <returns></returns>
         public bool Equals(VideoCodecInfo other)
         {
+            if (other == null)
+                return false;
             return this.mimeType == other.mimeType
                 && this.sdpFmtpLine == other.sdpFmtpLine;
         }
@@ -61,8 +63,16 @@ namespace Unity.RenderStreaming
 
         public static bool operator ==(VideoCodecInfo left, VideoCodecInfo right)
         {
-            return left.Equals(right);
+            if (ReferenceEquals(left, null))
+            {
+                return ReferenceEquals(left, null);
+            }
+            else
+            {
+                return left.Equals(right);
+            }
         }
+
         public static bool operator !=(VideoCodecInfo left, VideoCodecInfo right)
         {
             return !(left == right);

--- a/com.unity.renderstreaming/Tests/Editor/AudioCodecInfoObject.cs
+++ b/com.unity.renderstreaming/Tests/Editor/AudioCodecInfoObject.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace Unity.RenderStreaming.EditorTest
+{
+    class AudioCodecInfoObject : ScriptableObject
+    {
+        [SerializeField]
+        public AudioCodecInfo info;
+    }
+}

--- a/com.unity.renderstreaming/Tests/Editor/AudioCodecInfoObject.cs.meta
+++ b/com.unity.renderstreaming/Tests/Editor/AudioCodecInfoObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da0addfcdf084a04eb2a503e3acc546f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Tests/Editor/EditorTest.cs
+++ b/com.unity.renderstreaming/Tests/Editor/EditorTest.cs
@@ -6,6 +6,53 @@ using UnityEditor;
 
 namespace Unity.RenderStreaming.EditorTest
 {
+
+    class VideoCodecInfoTest
+    {
+        [Test]
+        public void EqualityOperator()
+        {
+            VideoCodecInfo info = null;
+            Assert.That(info == null, Is.True);
+            Assert.That(info != null, Is.False);
+
+            VideoCodecInfo otherInfo = info;
+            Assert.That(info == otherInfo, Is.True);
+            Assert.That(info != otherInfo, Is.False);
+
+            info = VideoStreamSender.GetAvailableCodecs().First();
+            Assert.That(info == otherInfo, Is.False);
+            Assert.That(info == (object)otherInfo, Is.False);
+
+            otherInfo = info;
+            Assert.That(info == otherInfo, Is.True);
+            Assert.That(info == (object)otherInfo, Is.True);
+        }
+    }
+
+    class AudioCodecInfoTest
+    {
+        [Test]
+        public void EqualityOperator()
+        {
+            AudioCodecInfo info = null;
+            Assert.That(info == null, Is.True);
+            Assert.That(info != null, Is.False);
+
+            AudioCodecInfo otherInfo = info;
+            Assert.That(info == otherInfo, Is.True);
+            Assert.That(info != otherInfo, Is.False);
+
+            info = AudioStreamSender.GetAvailableCodecs().First();
+            Assert.That(info == otherInfo, Is.False);
+            Assert.That(info == (object)otherInfo, Is.False);
+
+            otherInfo = info;
+            Assert.That(info == otherInfo, Is.True);
+            Assert.That(info == (object)otherInfo, Is.True);
+        }
+    }
+
     class VideoStreamSenderTest
     {
         [Test]

--- a/com.unity.renderstreaming/Tests/Editor/EditorTest.cs
+++ b/com.unity.renderstreaming/Tests/Editor/EditorTest.cs
@@ -1,4 +1,8 @@
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
+using UnityEngine;
+using UnityEditor;
 
 namespace Unity.RenderStreaming.EditorTest
 {
@@ -44,5 +48,51 @@ namespace Unity.RenderStreaming.EditorTest
             Assert.That(codecs, Is.Not.Null.Or.Empty);
             Assert.That(codecs, Is.Not.Contains(null));
         }
+    }
+
+    class SerializeTest
+    {
+        [Test]
+        public void SerializeVideoCodecInfo()
+        {
+            IEnumerable<VideoCodecInfo> codecs = VideoStreamSender.GetAvailableCodecs();
+            var asset = ScriptableObject.CreateInstance<VideoCodecInfoObject>();
+            asset.info = codecs.First();
+
+            string exportPath = "Assets/test.asset";
+            AssetDatabase.CreateAsset(asset, exportPath);
+
+            EditorUtility.SetDirty(asset);
+            AssetDatabase.SaveAssets();
+
+            var otherAsset = AssetDatabase.LoadAssetAtPath<VideoCodecInfoObject>(exportPath);
+            Assert.That(asset.info, Is.Not.Null);
+            Assert.That(otherAsset.info, Is.Not.Null);
+            Assert.That(asset.info, Is.EqualTo(otherAsset.info));
+            Assert.That(asset.info.Equals(otherAsset.info), Is.True);
+            AssetDatabase.DeleteAsset(exportPath);
+        }
+
+        [Test]
+        public void SerializeAudioCodecInfo()
+        {
+            IEnumerable<AudioCodecInfo> codecs = AudioStreamSender.GetAvailableCodecs();
+            var asset = ScriptableObject.CreateInstance<AudioCodecInfoObject>();
+            asset.info = codecs.First();
+
+            string exportPath = "Assets/test.asset";
+            AssetDatabase.CreateAsset(asset, exportPath);
+
+            EditorUtility.SetDirty(asset);
+            AssetDatabase.SaveAssets();
+
+            var otherAsset = AssetDatabase.LoadAssetAtPath<AudioCodecInfoObject>(exportPath);
+            Assert.That(asset.info, Is.Not.Null);
+            Assert.That(otherAsset.info, Is.Not.Null);
+            Assert.That(asset.info, Is.EqualTo(otherAsset.info));
+            Assert.That(asset.info.Equals(otherAsset.info), Is.True);
+            AssetDatabase.DeleteAsset(exportPath);
+        }
+
     }
 }

--- a/com.unity.renderstreaming/Tests/Editor/EditorTest.cs
+++ b/com.unity.renderstreaming/Tests/Editor/EditorTest.cs
@@ -28,6 +28,17 @@ namespace Unity.RenderStreaming.EditorTest
             Assert.That(info == otherInfo, Is.True);
             Assert.That(info == (object)otherInfo, Is.True);
         }
+
+        [Test]
+        public void HashCode()
+        {
+            VideoCodecInfo info = VideoStreamSender.GetAvailableCodecs().First();
+            VideoCodecInfo otherInfo = info;
+            Assert.That(info.GetHashCode() == otherInfo.GetHashCode(), Is.True);
+
+            otherInfo = VideoStreamSender.GetAvailableCodecs().Last();
+            Assert.That(info.GetHashCode() == otherInfo.GetHashCode(), Is.False);
+        }
     }
 
     class AudioCodecInfoTest
@@ -51,6 +62,18 @@ namespace Unity.RenderStreaming.EditorTest
             Assert.That(info == otherInfo, Is.True);
             Assert.That(info == (object)otherInfo, Is.True);
         }
+
+        [Test]
+        public void HashCode()
+        {
+            AudioCodecInfo info = AudioStreamSender.GetAvailableCodecs().First();
+            AudioCodecInfo otherInfo = info;
+            Assert.That(info.GetHashCode() == otherInfo.GetHashCode(), Is.True);
+
+            otherInfo = AudioStreamSender.GetAvailableCodecs().Last();
+            Assert.That(info.GetHashCode() == otherInfo.GetHashCode(), Is.False);
+        }
+
     }
 
     class VideoStreamSenderTest

--- a/com.unity.renderstreaming/Tests/Editor/Unity.RenderStreaming.EditorTests.asmdef
+++ b/com.unity.renderstreaming/Tests/Editor/Unity.RenderStreaming.EditorTests.asmdef
@@ -5,7 +5,8 @@
         "GUID:40a5acf76f04c4c8ebb69605e4b0d5c7",
         "GUID:7e479a0c97f111c48b6a279fad867f28",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
-        "GUID:0acc523941302664db1f4e527237feb3"
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:f12aafacab75a87499e7e45c873ffab8"
     ],
     "includePlatforms": [
         "Editor"

--- a/com.unity.renderstreaming/Tests/Editor/VideoCodecInfoObject.cs
+++ b/com.unity.renderstreaming/Tests/Editor/VideoCodecInfoObject.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace Unity.RenderStreaming.EditorTest
+{
+    class VideoCodecInfoObject : ScriptableObject
+    {
+        [SerializeField]
+        public VideoCodecInfo info;
+    }
+}

--- a/com.unity.renderstreaming/Tests/Editor/VideoCodecInfoObject.cs.meta
+++ b/com.unity.renderstreaming/Tests/Editor/VideoCodecInfoObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5af727ab10be4f04bb58e0669047d3a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 using Unity.WebRTC;
-using UnityEngine.TestTools;
 
 namespace Unity.RenderStreaming.RuntimeTest
 {

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -42,6 +42,14 @@ namespace Unity.RenderStreaming.RuntimeTest
         }
 
         [Test]
+        public void SelectCodecCapabilities()
+        {
+            var codecs = VideoStreamSender.GetAvailableCodecs();
+            var caps = RTCRtpSender.GetCapabilities(TrackKind.Video).SelectCodecCapabilities(codecs);
+            Assert.That(codecs.Count(), Is.EqualTo(caps.Count()));
+        }
+
+        [Test]
         public void SetEnabled()
         {
             var go = new GameObject();
@@ -245,6 +253,14 @@ namespace Unity.RenderStreaming.RuntimeTest
         }
 
         [Test]
+        public void SelectCodecCapabilities()
+        {
+            var codecs = VideoStreamReceiver.GetAvailableCodecs();
+            var caps = RTCRtpReceiver.GetCapabilities(TrackKind.Video).SelectCodecCapabilities(codecs);
+            Assert.That(codecs.Count(), Is.EqualTo(caps.Count()));
+        }
+
+        [Test]
         public void SetCodec()
         {
             var go = new GameObject();
@@ -278,6 +294,15 @@ namespace Unity.RenderStreaming.RuntimeTest
                 Assert.That(codec.sampleRate, Is.GreaterThan(0));
             }
         }
+
+        [Test]
+        public void SelectCodecCapabilities()
+        {
+            var codecs = AudioStreamSender.GetAvailableCodecs();
+            var caps = RTCRtpSender.GetCapabilities(TrackKind.Audio).SelectCodecCapabilities(codecs);
+            Assert.That(codecs.Count(), Is.EqualTo(caps.Count()));
+        }
+
 
         [Test]
         public void SetEnabled()
@@ -353,6 +378,14 @@ namespace Unity.RenderStreaming.RuntimeTest
                 Assert.That(codec.channelCount, Is.GreaterThan(0));
                 Assert.That(codec.sampleRate, Is.GreaterThan(0));
             }
+        }
+
+        [Test]
+        public void SelectCodecCapabilities()
+        {
+            var codecs = AudioStreamReceiver.GetAvailableCodecs();
+            var caps = RTCRtpReceiver.GetCapabilities(TrackKind.Audio).SelectCodecCapabilities(codecs);
+            Assert.That(codecs.Count(), Is.EqualTo(caps.Count()));
         }
 
         [Test]


### PR DESCRIPTION
Fix a bug about serializing VideoCodecInfo/AudioCodecInfo.
To test this fix, added the two unit-tests.

-  EditorTest.SerializeVideoCodecInfo
-  EditorTest.SerializeAudioCodecInfo