### PR TITLE
fix: Add SampleManager to manage global settings for sample

### DIFF
--- a/com.unity.renderstreaming/Samples~/Example/ARFoundation/ARFoundationSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/ARFoundation/ARFoundationSample.cs
@@ -29,6 +29,7 @@ namespace Unity.RenderStreaming.Samples
 #pragma warning restore 0649
 
         private string _connectionId;
+        private RenderStreamingSettings settings;
 
         void Awake()
         {
@@ -39,13 +40,15 @@ namespace Unity.RenderStreaming.Samples
             stopButton.gameObject.SetActive(false);
 
             receiveVideoViewer.OnUpdateReceiveTexture += texture => remoteVideoImage.texture = texture;
+
+            settings = SampleManager.Instance.Settings;
         }
 
         IEnumerator Start()
         {
             if (!renderStreaming.runOnAwake)
             {
-                renderStreaming.Run(signaling: RenderStreamingSettings.Signaling);
+                renderStreaming.Run(signaling: settings?.Signaling);
             }
 
             if ((ARSession.state == ARSessionState.None ) ||
@@ -117,7 +120,8 @@ namespace Unity.RenderStreaming.Samples
 
         void CreateConnection()
         {
-            receiveVideoViewer.SetCodec(RenderStreamingSettings.ReceiverVideoCodec);
+            if(settings != null)
+                receiveVideoViewer.SetCodec(settings.ReceiverVideoCodec);
 
             _connectionId = System.Guid.NewGuid().ToString("N");
             connection.CreateConnection(_connectionId);

--- a/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
@@ -25,6 +25,7 @@ namespace Unity.RenderStreaming.Samples
 #pragma warning restore 0649
 
         private string connectionId;
+        private RenderStreamingSettings settings;
 
         void Awake()
         {
@@ -51,8 +52,12 @@ namespace Unity.RenderStreaming.Samples
             webCamStreamer.OnStartedStream += id => receiveVideoViewer.enabled = true;
             webCamStreamer.OnStartedStream += _ => localVideoImage.texture = webCamStreamer.sourceWebCamTexture;
 
-            webCamStreamer.width = (uint)RenderStreamingSettings.StreamSize.x;
-            webCamStreamer.height = (uint)RenderStreamingSettings.StreamSize.y;
+            settings = SampleManager.Instance.Settings;
+            if (settings != null)
+            {
+                webCamStreamer.width = (uint)settings.StreamSize.x;
+                webCamStreamer.height = (uint)settings.StreamSize.y;
+            }
 
             receiveVideoViewer.OnUpdateReceiveTexture += texture => remoteVideoImage.texture = texture;
 
@@ -71,7 +76,7 @@ namespace Unity.RenderStreaming.Samples
         {
             if (renderStreaming.runOnAwake)
                 return;
-            renderStreaming.Run(signaling: RenderStreamingSettings.Signaling);
+            renderStreaming.Run(signaling: settings?.Signaling);
         }
 
         private void SetUp()
@@ -79,8 +84,11 @@ namespace Unity.RenderStreaming.Samples
             setUpButton.interactable = false;
             hangUpButton.interactable = true;
             connectionIdInput.interactable = false;
-            receiveVideoViewer.SetCodec(RenderStreamingSettings.ReceiverVideoCodec);
-            webCamStreamer.SetCodec(RenderStreamingSettings.SenderVideoCodec);
+            if(settings != null)
+            {
+                receiveVideoViewer.SetCodec(settings.ReceiverVideoCodec);
+                webCamStreamer.SetCodec(settings.SenderVideoCodec);
+            }
 
             singleConnection.CreateConnection(connectionId);
         }

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
@@ -79,7 +79,8 @@ namespace Unity.RenderStreaming.Samples
                     .WithInterface(XRUtilities.InterfaceMatchAnyVersion)
             );
 #endif
-            if(settings != null)
+            settings = SampleManager.Instance.Settings;
+            if (settings != null)
             {
                 if (videoStreamSender.source != VideoStreamSource.Texture)
                 {
@@ -110,8 +111,6 @@ namespace Unity.RenderStreaming.Samples
                 .ToList();
             resolutionSelector.SetValueWithoutNotify(1); // todo: detect default select index
             resolutionSelector.onValueChanged.AddListener(ChangeResolution);
-
-            settings = SampleManager.Instance.Settings;
         }
 
         private void ChangeBandwidth(int index)

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
@@ -69,6 +69,7 @@ namespace Unity.RenderStreaming.Samples
                 { "2560x1440", new Vector2Int(2560, 1440) },
             };
 
+        private RenderStreamingSettings settings;
 
         private void Awake()
         {
@@ -78,13 +79,15 @@ namespace Unity.RenderStreaming.Samples
                     .WithInterface(XRUtilities.InterfaceMatchAnyVersion)
             );
 #endif
-
-            if (videoStreamSender.source != VideoStreamSource.Texture)
+            if(settings != null)
             {
-                videoStreamSender.width = (uint)RenderStreamingSettings.StreamSize.x;
-                videoStreamSender.height = (uint)RenderStreamingSettings.StreamSize.y;
+                if (videoStreamSender.source != VideoStreamSource.Texture)
+                {
+                    videoStreamSender.width = (uint)settings.StreamSize.x;
+                    videoStreamSender.height = (uint)settings.StreamSize.y;
+                }
+                videoStreamSender.SetCodec(settings.SenderVideoCodec);
             }
-            videoStreamSender.SetCodec(RenderStreamingSettings.SenderVideoCodec);
 
             bandwidthSelector.options = bandwidthOptions
                 .Select(pair => new Dropdown.OptionData { text = pair.Key })
@@ -107,6 +110,8 @@ namespace Unity.RenderStreaming.Samples
                 .ToList();
             resolutionSelector.SetValueWithoutNotify(1); // todo: detect default select index
             resolutionSelector.onValueChanged.AddListener(ChangeResolution);
+
+            settings = SampleManager.Instance.Settings;
         }
 
         private void ChangeBandwidth(int index)
@@ -139,7 +144,7 @@ namespace Unity.RenderStreaming.Samples
         {
             if (renderStreaming.runOnAwake)
                 return;
-            renderStreaming.Run(signaling: RenderStreamingSettings.Signaling);
+            renderStreaming.Run(signaling: settings?.Signaling);
 
             inputReceiver.OnStartedChannel += OnStartedChannel;
         }

--- a/com.unity.renderstreaming/Samples~/Example/Gyro/GyroSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Gyro/GyroSample.cs
@@ -21,6 +21,7 @@ namespace Unity.RenderStreaming.Samples
             [SerializeField] private Text textVelocityZ;
             [SerializeField] private InputAction vector3Action;
 #pragma warning restore 0649
+        private RenderStreamingSettings settings;
 
         void Awake()
         {
@@ -30,6 +31,8 @@ namespace Unity.RenderStreaming.Samples
                 Debug.LogError("Gyroscope is not supported on this device.");
             sendOfferButton.onClick.AddListener(SendOffer);
             receiveVideoViewer.OnUpdateReceiveTexture += texture => remoteVideoImage.texture = texture;
+
+            settings = SampleManager.Instance.Settings;
         }
 
         void OnDestroy()
@@ -43,7 +46,7 @@ namespace Unity.RenderStreaming.Samples
         {
             if (renderStreaming.runOnAwake)
                 return;
-            renderStreaming.Run(signaling: RenderStreamingSettings.Signaling);
+            renderStreaming.Run(signaling: settings?.Signaling);
         }
 
         void OnEnable()
@@ -75,7 +78,8 @@ namespace Unity.RenderStreaming.Samples
 
         void SendOffer()
         {
-            receiveVideoViewer.SetCodec(RenderStreamingSettings.ReceiverVideoCodec);
+            if(settings != null)
+                receiveVideoViewer.SetCodec(settings.ReceiverVideoCodec);
 
             var connectionId = System.Guid.NewGuid().ToString("N");
             connection.CreateConnection(connectionId);

--- a/com.unity.renderstreaming/Samples~/Example/Multiplay/Multiplay.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Multiplay/Multiplay.cs
@@ -13,6 +13,13 @@ namespace Unity.RenderStreaming.Samples
         private List<Component> streams = new List<Component>();
         private Dictionary<string, GameObject> dictObj = new Dictionary<string, GameObject>();
 
+        private RenderStreamingSettings settings;
+
+        void Awake()
+        {
+            settings = SampleManager.Instance.Settings;
+        }
+
         public override IEnumerable<Component> Streams => streams;
 
         public void OnDeletedConnection(SignalingEventData eventData)
@@ -66,11 +73,11 @@ namespace Unity.RenderStreaming.Samples
 
             var sender = newObj.GetComponentInChildren<StreamSenderBase>();
 
-            if (sender is VideoStreamSender videoStreamSender)
+            if (sender is VideoStreamSender videoStreamSender && settings != null)
             {
-                videoStreamSender.width = (uint)RenderStreamingSettings.StreamSize.x;
-                videoStreamSender.height = (uint)RenderStreamingSettings.StreamSize.y;
-                videoStreamSender.SetCodec(RenderStreamingSettings.SenderVideoCodec);
+                videoStreamSender.width = (uint)settings.StreamSize.x;
+                videoStreamSender.height = (uint)settings.StreamSize.y;
+                videoStreamSender.SetCodec(settings.SenderVideoCodec);
             }
 
             var inputChannel = newObj.GetComponentInChildren<InputReceiver>();

--- a/com.unity.renderstreaming/Samples~/Example/Multiplay/MultiplaySample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Multiplay/MultiplaySample.cs
@@ -26,6 +26,14 @@ namespace Unity.RenderStreaming.Samples
             Guest = 1
         }
 
+        private RenderStreamingSettings settings;
+
+
+        private void Awake()
+        {
+            settings = SampleManager.Instance.Settings;
+        }
+
         void Start()
         {
             buttonStart.onClick.AddListener(OnClickButtonStart);
@@ -79,7 +87,7 @@ namespace Unity.RenderStreaming.Samples
             playerController.CheckPairedDevices();
 
             statsUI.AddSignalingHandler(handler);
-            renderStreaming.Run(signaling: RenderStreamingSettings.Signaling,
+            renderStreaming.Run(signaling: settings?.Signaling,
                 handlers: new SignalingHandlerBase[] {handler}
             );
         }
@@ -90,7 +98,7 @@ namespace Unity.RenderStreaming.Samples
             var handler = guestPlayer.GetComponent<SingleConnection>();
 
             statsUI.AddSignalingHandler(handler);
-            renderStreaming.Run(signaling: RenderStreamingSettings.Signaling,
+            renderStreaming.Run(signaling: settings?.Signaling,
                 handlers: new SignalingHandlerBase[] {handler}
             );
 
@@ -101,7 +109,8 @@ namespace Unity.RenderStreaming.Samples
             var channel = guestPlayer.GetComponent<MultiplayChannel>();
             channel.OnStartedChannel += _ => { StartCoroutine(ChangeLabel(channel, username)); };
 
-            receiveVideoViewer.SetCodec(RenderStreamingSettings.ReceiverVideoCodec);
+            if(settings != null)
+                receiveVideoViewer.SetCodec(settings.ReceiverVideoCodec);
 
             // todo(kazuki):
             yield return new WaitForSeconds(1f);

--- a/com.unity.renderstreaming/Samples~/Example/Receiver/ReceiverSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Receiver/ReceiverSample.cs
@@ -42,6 +42,7 @@ namespace Unity.RenderStreaming.Samples
 
         private string connectionId;
         private InputSender inputSender;
+        private RenderStreamingSettings settings;
 
         void Awake()
         {
@@ -59,13 +60,15 @@ namespace Unity.RenderStreaming.Samples
 
             inputSender = GetComponent<InputSender>();
             inputSender.OnStartedChannel += OnStartedChannel;
+
+            settings = SampleManager.Instance.Settings;
         }
 
         void Start()
         {
             if (renderStreaming.runOnAwake)
                 return;
-            renderStreaming.Run(signaling: RenderStreamingSettings.Signaling);
+            renderStreaming.Run(signaling: settings?.Signaling);
         }
 
         void OnUpdateReceiveTexture(Texture texture)
@@ -95,7 +98,8 @@ namespace Unity.RenderStreaming.Samples
                 connectionIdInput.text = connectionId;
             }
             connectionIdInput.interactable = false;
-            receiveVideoViewer.SetCodec(RenderStreamingSettings.ReceiverVideoCodec);
+            if(settings != null)
+                receiveVideoViewer.SetCodec(settings.ReceiverVideoCodec);
             receiveAudioViewer.targetAudioSource = remoteAudioSource;
 
             connection.CreateConnection(connectionId);

--- a/com.unity.renderstreaming/Samples~/Example/RenderPipeline/RenderPipelineSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/RenderPipeline/RenderPipelineSample.cs
@@ -56,11 +56,18 @@ namespace Unity.RenderStreaming.Samples
                 { "2560x1440", new Vector2Int(2560, 1440) },
             };
 
+        private RenderStreamingSettings settings;
+
         private void Awake()
         {
-            videoStreamSender.width = (uint)RenderStreamingSettings.StreamSize.x;
-            videoStreamSender.height = (uint)RenderStreamingSettings.StreamSize.y;
-            videoStreamSender.SetCodec(RenderStreamingSettings.SenderVideoCodec);
+            settings = SampleManager.Instance.Settings;
+
+            if(settings != null)
+            {
+                videoStreamSender.width = (uint)settings.StreamSize.x;
+                videoStreamSender.height = (uint)settings.StreamSize.y;
+                videoStreamSender.SetCodec(settings.SenderVideoCodec);
+            }
 
             bandwidthSelector.options = bandwidthOptions
                 .Select(pair => new Dropdown.OptionData { text = pair.Key })
@@ -114,7 +121,7 @@ namespace Unity.RenderStreaming.Samples
         {
             if (!renderStreaming.runOnAwake)
             {
-                renderStreaming.Run(signaling: RenderStreamingSettings.Signaling);
+                renderStreaming.Run(signaling: settings?.Signaling);
             }
         }
     }

--- a/com.unity.renderstreaming/Samples~/Example/Scripts/SampleManager.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Scripts/SampleManager.cs
@@ -27,7 +27,8 @@ namespace Unity.RenderStreaming.Samples
 
         public void Initialize()
         {
-            m_settings = new RenderStreamingSettings();
+            if(m_settings == null)
+                m_settings = new RenderStreamingSettings();
         }
     }
 }

--- a/com.unity.renderstreaming/Samples~/Example/Scripts/SampleManager.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Scripts/SampleManager.cs
@@ -1,0 +1,33 @@
+namespace Unity.RenderStreaming.Samples
+{
+
+    internal class SampleManager
+    {
+        static SampleManager s_instance;
+
+        public static SampleManager Instance
+        {
+            get
+            {
+                if (s_instance == null)
+                    s_instance = new SampleManager();
+                return s_instance;
+            }
+        }
+
+        public RenderStreamingSettings Settings
+        {
+            get
+            {
+                return m_settings;
+            }
+        }
+
+        RenderStreamingSettings m_settings;
+
+        public void Initialize()
+        {
+            m_settings = new RenderStreamingSettings();
+        }
+    }
+}

--- a/com.unity.renderstreaming/Samples~/Example/Scripts/SampleManager.cs.meta
+++ b/com.unity.renderstreaming/Samples~/Example/Scripts/SampleManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8a6107a68b5bce4cac619a3a2a37e88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
@@ -28,61 +28,61 @@ namespace Unity.RenderStreaming.Samples
         public const int DefaultStreamWidth = 1280;
         public const int DefaultStreamHeight = 720;
 
-        private SignalingType s_signalingType = SignalingType.WebSocket;
-        private string s_signalingAddress = "localhost";
-        private float s_signalingInterval = 5;
-        private bool s_signalingSecured = false;
-        private Vector2Int s_streamSize = new Vector2Int(DefaultStreamWidth, DefaultStreamHeight);
-        private VideoCodecInfo s_receiverVideoCodec = null;
-        private VideoCodecInfo s_senderVideoCodec = null;
+        private SignalingType signalingType = SignalingType.WebSocket;
+        private string signalingAddress = "localhost";
+        private float signalingInterval = 5;
+        private bool signalingSecured = false;
+        private Vector2Int streamSize = new Vector2Int(DefaultStreamWidth, DefaultStreamHeight);
+        private VideoCodecInfo receiverVideoCodec = null;
+        private VideoCodecInfo senderVideoCodec = null;
 
         public SignalingType SignalingType
         {
-            get { return s_signalingType; }
-            set { s_signalingType = value; }
+            get { return signalingType; }
+            set { signalingType = value; }
         }
 
         public string SignalingAddress
         {
-            get { return s_signalingAddress; }
-            set { s_signalingAddress = value; }
+            get { return signalingAddress; }
+            set { signalingAddress = value; }
         }
 
         public bool SignalingSecured
         {
-            get { return s_signalingSecured; }
-            set { s_signalingSecured = value; }
+            get { return signalingSecured; }
+            set { signalingSecured = value; }
         }
 
         public float SignalingInterval
         {
-            get { return s_signalingInterval; }
-            set { s_signalingInterval = value; }
+            get { return signalingInterval; }
+            set { signalingInterval = value; }
         }
 
         public ISignaling Signaling
         {
             get
             {
-                switch (s_signalingType)
+                switch (signalingType)
                 {
                     case SignalingType.Furioos:
                         {
-                            var schema = s_signalingSecured ? "https" : "http";
+                            var schema = signalingSecured ? "https" : "http";
                             return new FurioosSignaling(
-                                $"{schema}://{s_signalingAddress}", s_signalingInterval, SynchronizationContext.Current);
+                                $"{schema}://{signalingAddress}", signalingInterval, SynchronizationContext.Current);
                         }
                     case SignalingType.WebSocket:
                         {
-                            var schema = s_signalingSecured ? "wss" : "ws";
+                            var schema = signalingSecured ? "wss" : "ws";
                             return new WebSocketSignaling(
-                                $"{schema}://{s_signalingAddress}", s_signalingInterval, SynchronizationContext.Current);
+                                $"{schema}://{signalingAddress}", signalingInterval, SynchronizationContext.Current);
                         }
                     case SignalingType.Http:
                         {
-                            var schema = s_signalingSecured ? "https" : "http";
+                            var schema = signalingSecured ? "https" : "http";
                             return new HttpSignaling(
-                                $"{schema}://{s_signalingAddress}", s_signalingInterval, SynchronizationContext.Current);
+                                $"{schema}://{signalingAddress}", signalingInterval, SynchronizationContext.Current);
                         }
                 }
 
@@ -92,20 +92,20 @@ namespace Unity.RenderStreaming.Samples
 
         public Vector2Int StreamSize
         {
-            get { return s_streamSize; }
-            set { s_streamSize = value; }
+            get { return streamSize; }
+            set { streamSize = value; }
         }
 
         public VideoCodecInfo ReceiverVideoCodec
         {
-            get { return s_receiverVideoCodec; }
-            set { s_receiverVideoCodec = value; }
+            get { return receiverVideoCodec; }
+            set { receiverVideoCodec = value; }
         }
 
         public VideoCodecInfo SenderVideoCodec
         {
-            get { return s_senderVideoCodec; }
-            set { s_senderVideoCodec = value; }
+            get { return senderVideoCodec; }
+            set { senderVideoCodec = value; }
         }
     }
 

--- a/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
@@ -23,44 +23,44 @@ namespace Unity.RenderStreaming.Samples
         Furioos
     }
 
-    internal static class RenderStreamingSettings
+    internal class RenderStreamingSettings
     {
         public const int DefaultStreamWidth = 1280;
         public const int DefaultStreamHeight = 720;
 
-        private static SignalingType s_signalingType = SignalingType.WebSocket;
-        private static string s_signalingAddress = "localhost";
-        private static float s_signalingInterval = 5;
-        private static bool s_signalingSecured = false;
-        private static Vector2Int s_streamSize = new Vector2Int(DefaultStreamWidth, DefaultStreamHeight);
-        private static VideoCodecInfo s_receiverVideoCodec = null;
-        private static VideoCodecInfo s_senderVideoCodec = null;
+        private SignalingType s_signalingType = SignalingType.WebSocket;
+        private string s_signalingAddress = "localhost";
+        private float s_signalingInterval = 5;
+        private bool s_signalingSecured = false;
+        private Vector2Int s_streamSize = new Vector2Int(DefaultStreamWidth, DefaultStreamHeight);
+        private VideoCodecInfo s_receiverVideoCodec = null;
+        private VideoCodecInfo s_senderVideoCodec = null;
 
-        public static SignalingType SignalingType
+        public SignalingType SignalingType
         {
             get { return s_signalingType; }
             set { s_signalingType = value; }
         }
 
-        public static string SignalingAddress
+        public string SignalingAddress
         {
             get { return s_signalingAddress; }
             set { s_signalingAddress = value; }
         }
 
-        public static bool SignalingSecured
+        public bool SignalingSecured
         {
             get { return s_signalingSecured; }
             set { s_signalingSecured = value; }
         }
 
-        public static float SignalingInterval
+        public float SignalingInterval
         {
             get { return s_signalingInterval; }
             set { s_signalingInterval = value; }
         }
 
-        public static ISignaling Signaling
+        public ISignaling Signaling
         {
             get
             {
@@ -90,19 +90,19 @@ namespace Unity.RenderStreaming.Samples
             }
         }
 
-        public static Vector2Int StreamSize
+        public Vector2Int StreamSize
         {
             get { return s_streamSize; }
             set { s_streamSize = value; }
         }
 
-        public static VideoCodecInfo ReceiverVideoCodec
+        public VideoCodecInfo ReceiverVideoCodec
         {
             get { return s_receiverVideoCodec; }
             set { s_receiverVideoCodec = value; }
         }
 
-        public static VideoCodecInfo SenderVideoCodec
+        public VideoCodecInfo SenderVideoCodec
         {
             get { return s_senderVideoCodec; }
             set { s_senderVideoCodec = value; }
@@ -145,6 +145,8 @@ namespace Unity.RenderStreaming.Samples
             new Vector2Int(2160, 3840),
         };
 
+        private RenderStreamingSettings settings;
+
         static string CodecTitle(VideoCodecInfo codec)
         {
             switch (codec)
@@ -161,11 +163,14 @@ namespace Unity.RenderStreaming.Samples
 
         void Start()
         {
-            dropdownSignalingType.value = (int)RenderStreamingSettings.SignalingType;
-            inputFieldSignalingAddress.text = RenderStreamingSettings.SignalingAddress;
-            toggleSignalingSecured.isOn = RenderStreamingSettings.SignalingSecured;
+            SampleManager.Instance.Initialize();
+            settings  = SampleManager.Instance.Settings;
+
+            dropdownSignalingType.value = (int)settings.SignalingType;
+            inputFieldSignalingAddress.text = settings.SignalingAddress;
+            toggleSignalingSecured.isOn = settings.SignalingSecured;
             inputFieldSignalingInterval.text =
-                RenderStreamingSettings.SignalingInterval.ToString(CultureInfo.InvariantCulture);
+                settings.SignalingInterval.ToString(CultureInfo.InvariantCulture);
 
             dropdownSignalingType.onValueChanged.AddListener(OnChangeSignalingType);
             inputFieldSignalingAddress.onValueChanged.AddListener(OnChangeSignalingAddress);
@@ -176,16 +181,16 @@ namespace Unity.RenderStreaming.Samples
             optionList.Add(new Dropdown.OptionData(" Custom "));
             streamSizeSelector.options = optionList;
 
-            var existInList = streamSizeList.Contains(RenderStreamingSettings.StreamSize);
+            var existInList = streamSizeList.Contains(settings.StreamSize);
             if (existInList)
             {
-                streamSizeSelector.value = streamSizeList.IndexOf(RenderStreamingSettings.StreamSize);
+                streamSizeSelector.value = streamSizeList.IndexOf(settings.StreamSize);
             }
             else
             {
                 streamSizeSelector.value = optionList.Count - 1;
-                textureWidthInput.text = RenderStreamingSettings.StreamSize.x.ToString();
-                textureHeightInput.text = RenderStreamingSettings.StreamSize.y.ToString();
+                textureWidthInput.text = settings.StreamSize.x.ToString();
+                textureHeightInput.text = settings.StreamSize.y.ToString();
                 textureWidthInput.interactable = true;
                 textureHeightInput.interactable = true;
             }
@@ -202,8 +207,8 @@ namespace Unity.RenderStreaming.Samples
                 .Select(codec => new Dropdown.OptionData(CodecTitle(codec))).ToList();
             senderVideoCodecSelector.options.AddRange(senderVideoCodecList);
 
-            receiverVideoCodecSelector.value = Array.FindIndex(VideoStreamReceiver.GetAvailableCodecs().ToArray(), codec => codec.Equals(RenderStreamingSettings.ReceiverVideoCodec)) + 1;
-            senderVideoCodecSelector.value = Array.FindIndex(VideoStreamSender.GetAvailableCodecs().ToArray(), codec => codec.Equals(RenderStreamingSettings.SenderVideoCodec)) + 1;
+            receiverVideoCodecSelector.value = Array.FindIndex(VideoStreamReceiver.GetAvailableCodecs().ToArray(), codec => codec.Equals(settings.ReceiverVideoCodec)) + 1;
+            senderVideoCodecSelector.value = Array.FindIndex(VideoStreamSender.GetAvailableCodecs().ToArray(), codec => codec.Equals(settings.SenderVideoCodec)) + 1;
 
             receiverVideoCodecSelector.onValueChanged.AddListener(OnChangeReceiverVideoCodecSelect);
             senderVideoCodecSelector.onValueChanged.AddListener(OnChangeSenderVideoCodecSelect);
@@ -254,29 +259,29 @@ namespace Unity.RenderStreaming.Samples
 
         private void OnChangeSignalingType(int value)
         {
-            RenderStreamingSettings.SignalingType =
+            settings.SignalingType =
                 (SignalingType)Enum.GetValues(typeof(SignalingType)).GetValue(value);
         }
 
         private void OnChangeSignalingAddress(string value)
         {
-            RenderStreamingSettings.SignalingAddress = value;
+            settings.SignalingAddress = value;
         }
 
         private void OnChangeSignalingSecured(bool value)
         {
-            RenderStreamingSettings.SignalingSecured = value;
+            settings.SignalingSecured = value;
         }
 
         private void OnChangeSignalingInterval(string value)
         {
             if (float.TryParse(value, out float _value))
             {
-                RenderStreamingSettings.SignalingInterval = _value;
+                settings.SignalingInterval = _value;
             }
             else
             {
-                RenderStreamingSettings.SignalingInterval = 5;
+                settings.SignalingInterval = 5;
             }
         }
 
@@ -291,55 +296,55 @@ namespace Unity.RenderStreaming.Samples
                 return;
             }
 
-            RenderStreamingSettings.StreamSize = streamSizeList[index];
+            settings.StreamSize = streamSizeList[index];
         }
 
         private void OnChangeTextureWidthInput(string input)
         {
-            var height = RenderStreamingSettings.StreamSize.y;
+            var height = settings.StreamSize.y;
 
             if (string.IsNullOrEmpty(input))
             {
-                RenderStreamingSettings.StreamSize = new Vector2Int(RenderStreamingSettings.DefaultStreamWidth, height);
+                settings.StreamSize = new Vector2Int(RenderStreamingSettings.DefaultStreamWidth, height);
                 return;
             }
 
             if (int.TryParse(input, out var width))
             {
-                RenderStreamingSettings.StreamSize = new Vector2Int(width, height);
+                settings.StreamSize = new Vector2Int(width, height);
             }
         }
 
         private void OnChangeTextureHeightInput(string input)
         {
-            var width = RenderStreamingSettings.StreamSize.x;
+            var width = settings.StreamSize.x;
 
             if (string.IsNullOrEmpty(input))
             {
-                RenderStreamingSettings.StreamSize = new Vector2Int(width, RenderStreamingSettings.DefaultStreamHeight);
+                settings.StreamSize = new Vector2Int(width, RenderStreamingSettings.DefaultStreamHeight);
                 return;
             }
 
             if (int.TryParse(input, out var height))
             {
-                RenderStreamingSettings.StreamSize = new Vector2Int(width, height);
+                settings.StreamSize = new Vector2Int(width, height);
             }
         }
 
         private void OnChangeSenderVideoCodecSelect(int index)
         {
             if (index == 0)
-                RenderStreamingSettings.SenderVideoCodec = null;
+                settings.SenderVideoCodec = null;
             else
-                RenderStreamingSettings.SenderVideoCodec = VideoStreamSender.GetAvailableCodecs().ElementAt(index - 1);
+                settings.SenderVideoCodec = VideoStreamSender.GetAvailableCodecs().ElementAt(index - 1);
         }
 
         private void OnChangeReceiverVideoCodecSelect(int index)
         {
             if (index == 0)
-                RenderStreamingSettings.ReceiverVideoCodec = null;
+                settings.ReceiverVideoCodec = null;
             else
-                RenderStreamingSettings.ReceiverVideoCodec = VideoStreamReceiver.GetAvailableCodecs().ElementAt(index - 1);
+                settings.ReceiverVideoCodec = VideoStreamReceiver.GetAvailableCodecs().ElementAt(index - 1);
         }
 
         private void OnPressedBidirectional()

--- a/com.unity.renderstreaming/Samples~/Example/WebBrowserInput/WebBrowserInputSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/WebBrowserInput/WebBrowserInputSample.cs
@@ -10,6 +10,13 @@ namespace Unity.RenderStreaming.Samples
         [SerializeField] Transform[] cameras;
         [SerializeField] CopyTransform copyTransform;
 
+        RenderStreamingSettings settings;
+
+        private void Awake()
+        {
+            settings = SampleManager.Instance.Settings;
+        }
+
         // Start is called before the first frame update
         void Start()
         {
@@ -17,7 +24,7 @@ namespace Unity.RenderStreaming.Samples
 
             if (!renderStreaming.runOnAwake)
             {
-                renderStreaming.Run(signaling: RenderStreamingSettings.Signaling);
+                renderStreaming.Run(signaling: settings?.Signaling);
             }
         }
 


### PR DESCRIPTION
This PR fixes sample scenes works well independently without menu scene.

Before that, sample scenes depended on initializing the menu scene. `SceneManager` class manages global settings for sample scenes and fixes that samples will work even if the manager is not initialized.