### PR TITLE
fix: Fix the process of destroying WebCamTexture in VideoStreamSender

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Collections;
 using System.Collections.Generic;
 using Unity.Collections;
 using Unity.WebRTC;
@@ -64,6 +65,20 @@ namespace Unity.RenderStreaming
         private Action<float[], int, int> m_onAudioFilterRead = null;
 
         private int m_frequency = 48000;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public AudioStreamSource source
+        {
+            get { return m_Source; }
+            set
+            {
+                if (isPlaying)
+                    throw new InvalidOperationException("Can not change this parameter after the streaming is started.");
+                m_Source = value;
+            }
+        }
 
         /// <summary>
         /// 
@@ -216,7 +231,7 @@ namespace Unity.RenderStreaming
             m_sourceImpl = null;
         }
 
-        internal override MediaStreamTrack CreateTrack()
+        internal override WaitForCreateTrack CreateTrack()
         {
             m_sourceImpl?.Dispose();
             m_sourceImpl = CreateAudioStreamSource();
@@ -270,7 +285,7 @@ namespace Unity.RenderStreaming
             {
             }
 
-            public abstract AudioStreamTrack CreateTrack();
+            public abstract WaitForCreateTrack CreateTrack();
             public abstract void Dispose();
         }
 
@@ -285,10 +300,12 @@ namespace Unity.RenderStreaming
                     throw new InvalidOperationException("Audio Listener have to be set the same gameObject.");
             }
 
-            public override AudioStreamTrack CreateTrack()
+            public override WaitForCreateTrack CreateTrack()
             {
+                var instruction = new WaitForCreateTrack();
                 m_audioTrack = new AudioStreamTrack();
-                return m_audioTrack;
+                instruction.Done(m_audioTrack);
+                return instruction;
             }
 
             public override void Dispose()
@@ -328,13 +345,15 @@ namespace Unity.RenderStreaming
             {
                 m_audioSource = parent.m_AudioSource;
                 if (m_audioSource == null)
-                    throw new ArgumentException("parent", "The m_AudioSource is not assigned.");
+                    throw new InvalidOperationException("The audioSource is not assigned.");
 
             }
 
-            public override AudioStreamTrack CreateTrack()
+            public override WaitForCreateTrack CreateTrack()
             {
-                return new AudioStreamTrack(m_audioSource);
+                var instruction = new WaitForCreateTrack();
+                instruction.Done(new AudioStreamTrack(m_audioSource));
+                return instruction;
             }
 
             public override void Dispose()
@@ -353,29 +372,33 @@ namespace Unity.RenderStreaming
             bool m_autoRequestUserAuthorization;
             int m_frequency;
             string m_deviceName;
-            GameObject m_parentObj;
             AudioSource m_audioSource;
+            AudioStreamSender m_parent;
 
             public AudioStreamSourceMicrophone(AudioStreamSender parent) : base(parent)
             {
                 int deviceIndex = parent.m_MicrophoneDeviceIndex;
                 if (deviceIndex < 0 || Microphone.devices.Length <= deviceIndex)
                     throw new ArgumentOutOfRangeException("deviceIndex", deviceIndex, "The deviceIndex is out of range");
-                m_parentObj = parent.gameObject;
+                m_parent = parent;
                 m_deviceIndex = deviceIndex;
                 m_frequency = parent.m_frequency;
                 m_autoRequestUserAuthorization = parent.m_AutoRequestUserAuthorization;
             }
 
-            public override AudioStreamTrack CreateTrack()
+            public override WaitForCreateTrack CreateTrack()
+            {
+                var instruction = new WaitForCreateTrack();
+                m_parent.StartCoroutine(CreateTrackCoroutine(instruction));
+                return instruction;
+            }
+
+            IEnumerator CreateTrackCoroutine(WaitForCreateTrack instruction)
             {
                 if (m_autoRequestUserAuthorization)
                 {
                     AsyncOperation op = Application.RequestUserAuthorization(UserAuthorization.Microphone);
-                    while (!op.isDone)
-                    {
-                        System.Threading.Thread.Sleep(1);
-                    }
+                    yield return op;
                 }
                 if (!Application.HasUserAuthorization(UserAuthorization.Microphone))
                     throw new InvalidOperationException("Call Application.RequestUserAuthorization before creating track with Microphone.");
@@ -385,14 +408,19 @@ namespace Unity.RenderStreaming
                 var micClip = Microphone.Start(m_deviceName, true, 1, m_frequency);
 
                 // set the latency to “0” samples before the audio starts to play.
-                while (!(Microphone.GetPosition(m_deviceName) > 0)) { }
+                yield return new WaitUntil(() => Microphone.GetPosition(m_deviceName) > 0);
 
-                m_audioSource = m_parentObj.AddComponent<AudioSource>();
+                /// todo: Throw exception if gameObject already has the AudioSource.
+                /// To fix this, fix the issue of AudioStreamTrack first.
+                m_audioSource = m_parent.gameObject.GetComponent<AudioSource>();
+                if(m_audioSource == null)
+                    m_audioSource = m_parent.gameObject.AddComponent<AudioSource>();
+
                 m_audioSource.clip = micClip;
                 m_audioSource.loop = true;
                 m_audioSource.Play();
 
-                return new AudioStreamTrack(m_audioSource);
+                instruction.Done(new AudioStreamTrack(m_audioSource));
             }
 
             public override void Dispose()
@@ -407,7 +435,12 @@ namespace Unity.RenderStreaming
                     }
                     m_audioSource.clip = null;
 
-                    Destroy(m_audioSource);
+                    /// todo: AudioCustomFilter should be removed before destroying m_audioSource because
+                    /// AudioSource is the RequiredComponent by AudioCustomFilter. But AudioStreamTrack removes
+                    /// the AudioCustomFilter asyncnouslly. So we got the error log below.
+                    /// "Can't remove AudioSource because AudioCustomFilter (Script) depends on it"
+
+                    // Destroy(m_audioSource);
                     m_audioSource = null;
                 }
                 if (Microphone.IsRecording(m_deviceName))

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Collections;
 using System.Collections.Generic;
 using Unity.WebRTC;
 using UnityEngine;
@@ -154,6 +155,21 @@ namespace Unity.RenderStreaming
         /// <returns></returns>
         public virtual void AddSender(string connectionId, IStreamSender sender)
         {
+            StartCoroutine(AddSenderCoroutine(connectionId, sender));
+        }
+
+        private IEnumerator AddSenderCoroutine(string connectionId, IStreamSender sender)
+        {
+            if(sender.Track == null && sender is StreamSenderBase senderBase)
+            {
+                var op = senderBase.CreateTrack();
+                if(op.Track == null)
+                    yield return op;
+                senderBase.SetTrack(op.Track);
+            }
+            if (sender.Track == null)
+                throw new InvalidOperationException("sender.Track is null");
+
             RTCRtpTransceiverInit init = GetTransceiverInit(sender);
             var transceiver = m_handler.AddTransceiver(connectionId, sender.Track, init);
             if (sender is VideoStreamSender videoStreamSender)

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -176,10 +176,9 @@ namespace Unity.RenderStreaming
         /// <param name="sender"></param>
         public virtual void RemoveSender(string connectionId, IStreamSender sender)
         {
-            sender.Track.Stop();
-            sender.SetTransceiver(connectionId, null);
             if (ExistConnection(connectionId))
                 RemoveTrack(connectionId, sender.Track);
+            sender.SetTransceiver(connectionId, null);
         }
 
         /// <summary>

--- a/com.unity.renderstreaming/Runtime/Scripts/StreamSenderBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/StreamSenderBase.cs
@@ -121,6 +121,11 @@ namespace Unity.RenderStreaming
             {
                 m_transceivers.Remove(connectionId);
                 OnStoppedStream?.Invoke(connectionId);
+                if (!m_transceivers.Any())
+                {
+                    m_track.Dispose();
+                    m_track = null;
+                }
             }
             else
             {

--- a/com.unity.renderstreaming/Runtime/Scripts/StreamSenderBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/StreamSenderBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.WebRTC;
@@ -11,6 +12,25 @@ namespace Unity.RenderStreaming
     /// </summary>
     public abstract class StreamSenderBase : MonoBehaviour, IStreamSender
     {
+        internal class WaitForCreateTrack : CustomYieldInstruction
+        {
+            public MediaStreamTrack Track { get { return m_track; } }
+
+            MediaStreamTrack m_track;
+
+            bool m_keepWaiting = true;
+
+            public override bool keepWaiting { get { return m_keepWaiting; } }
+
+            public WaitForCreateTrack() { }
+
+            public void Done(MediaStreamTrack track)
+            {
+                m_track = track;
+                m_keepWaiting = false;
+            }
+        }
+
         /// <summary>
         ///
         /// </summary>
@@ -26,25 +46,40 @@ namespace Unity.RenderStreaming
         /// </summary>
         public OnStoppedStreamHandler OnStoppedStream { get; set; }
 
-        internal virtual MediaStreamTrack CreateTrack() { return null; }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        internal abstract WaitForCreateTrack CreateTrack();
+
 
         internal virtual void ReplaceTrack(MediaStreamTrack track)
         {
             if (track == null)
                 throw new ArgumentNullException("track", "This argument must be not null.");
 
-            if(m_track == track)
+            if (m_track == Track)
                 throw new ArgumentException("track", "The value of this argument has already been set.");
 
             /// todo:: If not disposing the old track here, the app will crash.
             /// This problem is caused by the MediaStreamTrack when it is destroyed on the thread other than the main thread.
             m_track?.Dispose();
 
-            m_track = track;
+            m_track = Track;
             foreach (var transceiver in Transceivers.Values)
             {
                 transceiver.Sender.ReplaceTrack(m_track);
             }
+        }
+
+        internal void SetTrack(MediaStreamTrack track)
+        {
+            if (track == null)
+                throw new ArgumentNullException("track", "This argument must be not null.");
+
+            if (m_track != null)
+                throw new InvalidOperationException("Track is not null.");
+            m_track = track;
         }
 
         private MediaStreamTrack m_track;
@@ -55,15 +90,7 @@ namespace Unity.RenderStreaming
         /// <summary>
         ///
         /// </summary>
-        public MediaStreamTrack Track
-        {
-            get
-            {
-                if (m_track == null)
-                    m_track = CreateTrack();
-                return m_track;
-            }
-        }
+        public MediaStreamTrack Track => m_track;
 
         /// <summary>
         /// 
@@ -102,7 +129,7 @@ namespace Unity.RenderStreaming
 
         protected virtual void OnDisable()
         {
-            if(m_track?.ReadyState == TrackState.Live)
+            if (m_track?.ReadyState == TrackState.Live)
             {
                 m_track.Enabled = false;
             }

--- a/com.unity.renderstreaming/Samples~/Example/Bidirectional/Bidirectional.unity
+++ b/com.unity.renderstreaming/Samples~/Example/Bidirectional/Bidirectional.unity
@@ -150,6 +150,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1180904220}
   - {fileID: 1423621364}
@@ -215,6 +216,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1013695939}
   m_RootOrder: 0
@@ -295,6 +297,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1046847830}
   m_Father: {fileID: 447881815}
@@ -348,8 +351,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 375413529}
   m_HandleRect: {fileID: 375413528}
   m_Direction: 2
-  m_Value: 1
-  m_Size: 0.99999994
+  m_Value: 0
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -420,6 +423,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2128695119}
   m_RootOrder: 0
@@ -500,6 +504,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2143861285}
   - {fileID: 678698532}
@@ -562,7 +567,10 @@ MonoBehaviour:
   m_HideMobileInput: 0
   m_CharacterValidation: 0
   m_CharacterLimit: 0
-  m_OnEndEdit:
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDidEndEdit:
     m_PersistentCalls:
       m_Calls: []
   m_OnValueChanged:
@@ -640,6 +648,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2063941925}
   m_Father: {fileID: 2101892767}
@@ -953,6 +962,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 474040021}
   m_RootOrder: 2
@@ -1033,6 +1043,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1261207007}
   m_Father: {fileID: 1268027397}
@@ -1159,6 +1170,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1676245737}
   m_Father: {fileID: 932364532}
@@ -1279,6 +1291,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1046847830}
   m_RootOrder: 0
@@ -1355,6 +1368,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1485084886}
   m_Father: {fileID: 1664650282}
@@ -1445,6 +1459,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1031505000}
   - {fileID: 2101892767}
@@ -1552,6 +1567,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1136971054}
   - {fileID: 966029635}
@@ -1827,6 +1843,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 447881815}
   - {fileID: 310412160}
@@ -1867,6 +1884,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 185332755}
   m_RootOrder: 1
@@ -1946,6 +1964,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1446828911}
   m_RootOrder: 2
@@ -2076,6 +2095,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -2107,6 +2127,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 185332755}
   - {fileID: 346362250}
@@ -2173,6 +2194,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 474040021}
   m_RootOrder: 1
@@ -2249,6 +2271,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 172843649}
   m_Father: {fileID: 2134522315}
@@ -2370,6 +2393,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 131784669}
   m_Father: {fileID: 447881815}
@@ -2457,6 +2481,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 375413528}
   m_Father: {fileID: 174861474}
@@ -2496,6 +2521,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1258234880}
   m_Father: {fileID: 1664650282}
@@ -2621,6 +2647,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1446828911}
   m_RootOrder: 0
@@ -2696,6 +2723,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 474040021}
   m_RootOrder: 0
@@ -2771,6 +2799,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2125586391}
   m_RootOrder: 0
@@ -2849,6 +2878,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1363584100}
   - {fileID: 1221238572}
@@ -2915,6 +2945,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1180904220}
   m_RootOrder: 1
@@ -3081,6 +3112,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1563904669}
   m_Father: {fileID: 1054277507}
@@ -3117,6 +3149,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1708597410}
   m_Father: {fileID: 314272781}
@@ -3156,6 +3189,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1846535030}
   - {fileID: 314272781}
@@ -3265,6 +3299,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_MoveRepeatDelay: 0.5
   m_MoveRepeatRate: 0.1
   m_XRTrackingOrigin: {fileID: 0}
@@ -3318,6 +3353,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -3350,6 +3386,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2125586391}
   m_RootOrder: 1
@@ -3408,7 +3445,6 @@ GameObject:
   - component: {fileID: 1363584100}
   - component: {fileID: 1363584102}
   - component: {fileID: 1363584101}
-  - component: {fileID: 1363584103}
   - component: {fileID: 1363584104}
   m_Layer: 5
   m_Name: LocalImage
@@ -3427,6 +3463,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1180904220}
   m_RootOrder: 0
@@ -3471,102 +3508,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1363584099}
   m_CullTransparentMesh: 0
---- !u!82 &1363584103
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1363584099}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 0
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!114 &1363584104
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3619,6 +3560,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2134522315}
   - {fileID: 932364532}
@@ -3683,6 +3625,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1094835990}
   - {fileID: 1811427819}
@@ -3769,6 +3712,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 474040021}
   m_Father: {fileID: 1846535030}
@@ -3805,6 +3749,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1446828911}
   m_Father: {fileID: 441688740}
@@ -3843,6 +3788,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1258234880}
   m_RootOrder: 0
@@ -3919,6 +3865,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 441688740}
   - {fileID: 1054277507}
@@ -4026,6 +3973,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 346362250}
   m_RootOrder: 0
@@ -4105,6 +4053,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1261207007}
   m_RootOrder: 0
@@ -4180,6 +4129,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1859585769}
   m_RootOrder: 0
@@ -4259,6 +4209,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1859585769}
   m_RootOrder: 1
@@ -4334,6 +4285,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1446828911}
   m_RootOrder: 1
@@ -4410,6 +4362,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1464711774}
   m_Father: {fileID: 1268027397}
@@ -4500,6 +4453,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1720753588}
   - {fileID: 1772713976}
@@ -4692,6 +4646,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -4809,6 +4764,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 220075808}
   m_RootOrder: 0
@@ -4885,6 +4841,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 220075808}
   m_Father: {fileID: 447881815}
@@ -5011,6 +4968,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1161220085}
   - {fileID: 1360947117}
@@ -5149,6 +5107,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 174875021}
   m_Father: {fileID: 932364532}
@@ -5268,6 +5227,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1859585769}
   - {fileID: 2125586391}
@@ -5334,6 +5294,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 185332755}
   m_RootOrder: 0

--- a/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
@@ -94,6 +94,7 @@ namespace Unity.RenderStreaming.Samples
             hangUpButton.interactable = false;
             connectionIdInput.interactable = true;
             connectionIdInput.text = $"{Random.Range(0, 99999):D5}";
+            localVideoImage.texture = null;
         }
     }
 }

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
@@ -322,7 +322,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             var container = TestContainer<SingleConnectionBehaviourTest>.Create("test");
             var streamer = container.test.gameObject.AddComponent<VideoStreamSenderTester>();
 
-            Assert.That(streamer.Track, Is.Not.Null);
+            Assert.That(streamer.Track, Is.Null);
             Assert.That(streamer.Transceivers, Is.Empty);
 
             container.test.component.AddComponent(streamer);

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
@@ -147,7 +147,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             var container = TestContainer<BroadcastBehaviourTest>.Create("test");
             var streamer = container.test.gameObject.AddComponent<VideoStreamSenderTester>();
 
-            Assert.That(streamer.Track, Is.Not.Null);
+            Assert.That(streamer.Track, Is.Null);
             Assert.That(streamer.Transceivers, Is.Empty);
 
             container.test.component.AddComponent(streamer);

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingHandlerTest.cs
@@ -30,10 +30,12 @@ namespace Unity.RenderStreaming.RuntimeTest
     {
         private Camera m_camera;
 
-        internal override MediaStreamTrack CreateTrack()
+        internal override WaitForCreateTrack CreateTrack()
         {
             m_camera = gameObject.AddComponent<Camera>();
-            return m_camera.CaptureStreamTrack(256, 256, 0);
+            var instruction = new WaitForCreateTrack();
+            instruction.Done(m_camera.CaptureStreamTrack(256, 256, 0));
+            return instruction;
         }
     }
 
@@ -45,11 +47,13 @@ namespace Unity.RenderStreaming.RuntimeTest
     {
         private AudioSource m_audioSource;
 
-        internal override MediaStreamTrack CreateTrack()
+        internal override WaitForCreateTrack CreateTrack()
         {
             m_audioSource = gameObject.AddComponent<AudioSource>();
             m_audioSource.clip = AudioClip.Create("test", 48000, 2, 48000, false);
-            return new AudioStreamTrack(m_audioSource);
+            var instruction = new WaitForCreateTrack();
+            instruction.Done(new AudioStreamTrack(m_audioSource));
+            return instruction;
         }
     }
 

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -338,7 +338,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             track.Dispose();
             track = null;
 
-            // With WebCam
+            // With Microphone
 #if !(UNITY_IPHONE || UNITY_ANDROID)
             sender.source = AudioStreamSource.Microphone;
             op = sender.CreateTrack();

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -340,13 +340,16 @@ namespace Unity.RenderStreaming.RuntimeTest
 
             // With Microphone
 #if !(UNITY_IPHONE || UNITY_ANDROID)
-            sender.source = AudioStreamSource.Microphone;
-            op = sender.CreateTrack();
-            yield return op;
-            track = op.Track;
-            Assert.That(track, Is.Not.Null);
-            track.Dispose();
-            track = null;
+            if (Microphone.devices.Length > 0 && Application.HasUserAuthorization(UserAuthorization.Microphone))
+            {
+                sender.source = AudioStreamSource.Microphone;
+                op = sender.CreateTrack();
+                yield return op;
+                track = op.Track;
+                Assert.That(track, Is.Not.Null);
+                track.Dispose();
+                track = null;
+            }
 #endif
             UnityEngine.Object.DestroyImmediate(go);
             UnityEngine.Object.DestroyImmediate(go2);

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -356,15 +356,6 @@ namespace Unity.RenderStreaming.RuntimeTest
         }
 
         [Test]
-        public void Hoge()
-        {
-            var go = new GameObject();
-            var audioSource = go.AddComponent<AudioSource>();
-            audioSource.Play();
-            UnityEngine.Object.DestroyImmediate(audioSource);
-        }
-
-        [Test]
         public void SelectCodecCapabilities()
         {
             var codecs = AudioStreamSender.GetAvailableCodecs();

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Linq;
+using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 using Unity.WebRTC;
+using UnityEngine.TestTools;
 
 namespace Unity.RenderStreaming.RuntimeTest
 {
@@ -61,8 +63,8 @@ namespace Unity.RenderStreaming.RuntimeTest
             UnityEngine.Object.DestroyImmediate(go);
         }
 
-        [Test]
-        public void CreateTrack()
+        [UnityTest]
+        public IEnumerator CreateTrack()
         {
             var go = new GameObject();
             var sender = go.AddComponent<VideoStreamSender>();
@@ -70,13 +72,15 @@ namespace Unity.RenderStreaming.RuntimeTest
 
             // With camera
             sender.source = VideoStreamSource.Camera;
-            Assert.Throws<ArgumentNullException>(() => track = sender.CreateTrack());
+            Assert.Throws<ArgumentNullException>(() => sender.CreateTrack());
 
             var camera = go.AddComponent<Camera>();
             sender.sourceCamera = camera;
             sender.width = 640;
             sender.height = 480;
-            track = sender.CreateTrack();
+            var op = sender.CreateTrack();
+            yield return op;
+            track = op.Track;
             Assert.That(track, Is.Not.Null);
             var videoTrack = track as VideoStreamTrack;
             Assert.That(videoTrack.Texture.width, Is.EqualTo(sender.width));
@@ -86,7 +90,9 @@ namespace Unity.RenderStreaming.RuntimeTest
 
             // With screen
             sender.source = VideoStreamSource.Screen;
-            track = sender.CreateTrack();
+            op = sender.CreateTrack();
+            yield return op;
+            track = op.Track;
             Assert.That(track, Is.Not.Null);
             track.Dispose();
             track = null;
@@ -94,7 +100,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             // With Texture
             sender.source = VideoStreamSource.Texture;
             Assert.That(sender.sourceTexture, Is.Null);
-            Assert.Throws<ArgumentNullException>(() => track = sender.CreateTrack());
+            Assert.Throws<ArgumentNullException>(() => sender.CreateTrack());
 
             var width = 256;
             var height = 256;
@@ -106,7 +112,9 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(sender.height, Is.EqualTo(height));
             Assert.Throws<InvalidOperationException>(() => sender.width = 1280);
             Assert.Throws<InvalidOperationException>(() => sender.height = 720);
-            track = sender.CreateTrack();
+            op = sender.CreateTrack();
+            yield return op;
+            track = op.Track;
             Assert.That(track, Is.Not.Null);
             track.Dispose();
 
@@ -117,9 +125,11 @@ namespace Unity.RenderStreaming.RuntimeTest
                 sender.source = VideoStreamSource.WebCamera;
                 Assert.That(sender.sourceDeviceIndex, Is.EqualTo(0));
                 sender.sourceDeviceIndex = -1;
-                Assert.Throws<ArgumentOutOfRangeException>(() => track = sender.CreateTrack());
+                Assert.Throws<ArgumentOutOfRangeException>(() => sender.CreateTrack());
                 sender.sourceDeviceIndex = 0;
-                track = sender.CreateTrack();
+                op = sender.CreateTrack();
+                yield return op;
+                track = op.Track;
                 Assert.That(track, Is.Not.Null);
                 Assert.That(sender.sourceWebCamTexture, Is.Not.Null);
                 track.Dispose();
@@ -293,6 +303,62 @@ namespace Unity.RenderStreaming.RuntimeTest
                 Assert.That(codec.channelCount, Is.GreaterThan(0));
                 Assert.That(codec.sampleRate, Is.GreaterThan(0));
             }
+        }
+
+        [UnityTest]
+        public IEnumerator CreateTrack()
+        {
+            var go = new GameObject();
+            var sender = go.AddComponent<AudioStreamSender>();
+            MediaStreamTrack track = null;
+
+            // With AudioListener
+            sender.source = AudioStreamSource.AudioListener;
+            Assert.Throws<InvalidOperationException>(() => sender.CreateTrack());
+
+            var audioListener = go.AddComponent<AudioListener>();
+            var op = sender.CreateTrack();
+            yield return op;
+            track = op.Track;
+            Assert.That(track, Is.Not.Null);
+            track.Dispose();
+            track = null;
+
+            // With AudioSource
+            var go2 = new GameObject();
+            sender = go2.AddComponent<AudioStreamSender>();
+            sender.source = AudioStreamSource.AudioSource;
+            Assert.Throws<InvalidOperationException>(() => sender.CreateTrack());
+            var audioSource = go2.AddComponent<AudioSource>();
+            sender.audioSource = audioSource;
+            op = sender.CreateTrack();
+            yield return op;
+            track = op.Track;
+            Assert.That(track, Is.Not.Null);
+            track.Dispose();
+            track = null;
+
+            // With WebCam
+#if !(UNITY_IPHONE || UNITY_ANDROID)
+            sender.source = AudioStreamSource.Microphone;
+            op = sender.CreateTrack();
+            yield return op;
+            track = op.Track;
+            Assert.That(track, Is.Not.Null);
+            track.Dispose();
+            track = null;
+#endif
+            UnityEngine.Object.DestroyImmediate(go);
+            UnityEngine.Object.DestroyImmediate(go2);
+        }
+
+        [Test]
+        public void Hoge()
+        {
+            var go = new GameObject();
+            var audioSource = go.AddComponent<AudioSource>();
+            audioSource.Play();
+            UnityEngine.Object.DestroyImmediate(audioSource);
         }
 
         [Test]


### PR DESCRIPTION
Related issue.
https://github.com/Unity-Technologies/UnityRenderStreaming/issues/663

This pull request fixes the issue that not releasing the webcam device handle after destroying the scene. This issue caused by not calling `Dispose` method of `VideoStreamSourceImpl` instance, so this fix added `OnDestroy` method and call `Dispose`.

Additionally, this change fixes another issue. `WebCamTexture` constructor returns texture instance, however, its size is very small sometimes. It fixes by the waiting process of `WebCamTexture.didUpdateThisFrame` to wait timing for the suitable texture.