### PR TITLE
fix: Fix enum name of H.264 profile

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
@@ -211,23 +211,23 @@ namespace Unity.RenderStreaming
     public enum H264Profile
     {
         /// <summary>
-        /// 
+        /// Constrained Baseline Profile.
         /// </summary>
         ConstrainedBaseline = 0x42e0,
         /// <summary>
-        /// 
+        /// Baseline Profile.
         /// </summary>
         Baseline = 0x4200,
         /// <summary>
-        /// 
+        /// Main Profile.
         /// </summary>
-        ProfileMain = 0x4d00,
+        Main = 0x4d00,
         /// <summary>
-        /// 
+        /// Constrained High Profile.
         /// </summary>
         ConstrainedHigh = 0x640c,
         /// <summary>
-        /// 
+        /// High Profile.
         /// </summary>
         High = 0x6400,
     }


### PR DESCRIPTION
Fix the name of H264Profile enum `ProfileMain` to `Main` . 

<img width="430" alt="image" src="https://user-images.githubusercontent.com/1132081/190330073-52a32457-1ccb-4796-b194-55d8fe9bde44.png">
