### PR TITLE
fix: Fix audio codec selector in Unity Editor

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioCodecInfo.cs
@@ -44,6 +44,11 @@ namespace Unity.RenderStreaming
         /// </summary>
         public string sdpFmtpLine { get { return m_SdpFmtpLine; } }
 
+        static internal AudioCodecInfo Create(RTCRtpCodecCapability caps)
+        {
+            return new AudioCodecInfo(caps);
+        }
+
         /// <summary>
         /// 
         /// </summary>
@@ -107,7 +112,7 @@ namespace Unity.RenderStreaming
             return !(left == right);
         }
 
-        internal AudioCodecInfo(RTCRtpCodecCapability cap)
+        protected AudioCodecInfo(RTCRtpCodecCapability cap)
         {
             m_MimeType = cap.mimeType;
             m_SdpFmtpLine = cap.sdpFmtpLine;

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamReceiver.cs
@@ -54,7 +54,7 @@ namespace Unity.RenderStreaming
         {
             var excludeCodecMimeType = new[] { "audio/CN", "audio/telephone-event" };
             var capabilities = RTCRtpReceiver.GetCapabilities(TrackKind.Audio);
-            return capabilities.codecs.Where(codec => !excludeCodecMimeType.Contains(codec.mimeType)).Select(codec => new AudioCodecInfo(codec));
+            return capabilities.codecs.Where(codec => !excludeCodecMimeType.Contains(codec.mimeType)).Select(codec => AudioCodecInfo.Create(codec));
         }
 
         /// <summary>

--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -154,7 +154,7 @@ namespace Unity.RenderStreaming
         {
             var excludeCodecMimeType = new[] { "audio/CN", "audio/telephone-event" };
             var capabilities = RTCRtpSender.GetCapabilities(TrackKind.Audio);
-            return capabilities.codecs.Where(codec => !excludeCodecMimeType.Contains(codec.mimeType)).Select(codec => new AudioCodecInfo(codec));
+            return capabilities.codecs.Where(codec => !excludeCodecMimeType.Contains(codec.mimeType)).Select(codec => AudioCodecInfo.Create(codec));
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes the issue that the audio codec option doesn't effect the actual codec in play mode.

The audio codec option in *AudioStreamSender* component and *AudioStreamReceiver* component.
Audio codec options have properties **channelCount** and **sampleRate** unlike video codec options.

![image](https://user-images.githubusercontent.com/1132081/190352349-629373ad-4e6a-458d-bed4-d388375b16fb.png)