### PR TITLE
fix: Fix TypeError when reloading the web page of the Receiver sample 

### DIFF
--- a/WebApp/client/public/receiver/js/main.js
+++ b/WebApp/client/public/receiver/js/main.js
@@ -32,6 +32,8 @@ window.addEventListener('resize', function () {
 }, true);
 
 window.addEventListener('beforeunload', async () => {
+  if(!renderstreaming)
+    return;
   await renderstreaming.stop();
 }, true);
 


### PR DESCRIPTION
Fixed the javascript error below.

```
Uncaught (in promise) TypeError: renderstreaming is undefined <anonymous> http://127.0.0.1/receiver/js/main.js:35 EventListener.handleEvent* http://127.0.0.1/receiver/js/main.js:34
```