### PR TITLE
fix: Fix build IL2CPP error Unity2021.3 on all platforms

### DIFF
--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -119,9 +119,9 @@ namespace Unity.RenderStreaming.RuntimeTest
             track.Dispose();
 
             // With WebCam
-            /// todo:: macOS il2cpp standalone build is failed by IL2CPP error in Unity 2021.3.
-#if !(UNITY_IPHONE || UNITY_ANDROID || (UNITY_2021_3 && UNITY_STANDALONE_OSX))
-            if(WebCamTexture.devices.Length > 0 && Application.HasUserAuthorization(UserAuthorization.WebCam))
+            /// todo:: standalone build is failed by IL2CPP error in Unity 2021.3.
+#if !(UNITY_IPHONE || UNITY_ANDROID || (UNITY_2021_3 && ENABLE_IL2CPP))
+            if (WebCamTexture.devices.Length > 0 && Application.HasUserAuthorization(UserAuthorization.WebCam))
             {
                 sender.source = VideoStreamSource.WebCamera;
                 Assert.That(sender.sourceDeviceIndex, Is.EqualTo(0));


### PR DESCRIPTION
This issue #790 occurred all platforms not only macOS.