### PR TITLE
ci: enable testing in true isolation

### DIFF
--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -142,11 +142,11 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
 {% if platform.name == "win" %}
     - |
       set WEBAPP_PATH=%cd%\Webapp\bin~\{{ platform.packed_webapp_name }}
-      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
+      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000" --enable-load-and-test-isolation
 {% else %}
     - |
       export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
-      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!HttpSignaling"
+      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!HttpSignaling" --enable-load-and-test-isolation
 {% endif %}
   artifacts:
     {{ package.name }}_{{ editor.version }}_{{ platform.name }}_test_results:


### PR DESCRIPTION
We are experiencing a hang in our repo where we are building API Validation assemblies in which we take your latest promoted package `com.unity.renderstreaming@3.1.0-exp.4` (not happening with `3.1.0-exp.3`). The script imports the package with the Windows Unity Editor for the version you have specified in the `unity` field of your package (i.e. `2020.3`).

We think it's because the use of `SynchronizationContext` are not properly cleaned up after and Unity still waits for them. Unfortunately this doesn't reproduce when we run the same commands on the command line but this PR should, in theory, reproduce the same hang on your repo as well.

Enabling testing in true isolation is considered a good practice since this way you should be able to spot also missing dependencies since we are loading the package in a empty project and it should compile without errors.

We were also wondering the reason you added that huge --timeout arg to utr if it's related to this issue but we were unable to find any job that exceeded reasonable timings.