### PR TITLE
Handle exception if the received message cannot be deserialized

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Receiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/Receiver.cs
@@ -59,8 +59,17 @@ namespace Unity.RenderStreaming.InputSystem
 
         private void OnMessage(byte[] bytes)
         {
-            MessageSerializer.Deserialize(bytes, out var message);
-            onMessage?.Invoke(message);
+			try
+            {
+                MessageSerializer.Deserialize(bytes, out var message);
+
+                onMessage?.Invoke(message);
+            }
+
+            catch (Exception)
+            {
+                Debug.LogError("Found the invalid message body that cannot be deserialized!");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The current problem occurs when I am trying to send custom message from web that I want to handle by myself in Unity.

I can extend InputReceiver class and override the OnMessage method but unfortunately the InputReceiver class also creates Receiver object in SetChannel method that trying to deserialize all received messages. If my packet is too small and undeserializable, the unhandled exception will be throwed and after that the streaming system loses stability and the some errors appear, so I have to restart the application.

This pull request contains changes to ignore problematic message, so users like me can handle their own messages without any problems.
