### PR TITLE
ci: Add CI jobs which is package isolation test for detecting issues

### DIFF
--- a/.yamato/compile-package.yml
+++ b/.yamato/compile-package.yml
@@ -1,0 +1,23 @@
+compile_test:
+  name: Compilation Test
+  agent:
+    type: Unity::VM
+    flavor: b1.large
+    image: package-ci/win10:v4
+  commands:
+    # When unity-config will be part of the image, this will turn into a no-op
+    - |
+      where /q unity-config
+      if ERRORLEVEL 1 (
+        %GSUDO% choco install unity-config -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
+      )
+    - unity-downloader-cli -c editor -u 2020.3 --wait
+    - .Editor\Unity.exe -createProject CompilationTestProject -logFile logs\CreateProject.log -batchmode -quit
+    - |
+      unity-config project set registry --project-path CompilationTestProject candidates
+      unity-config project add dependency --project-path CompilationTestProject com.unity.renderstreaming@3.1.0-exp.4
+    - .Editor\Unity.exe -projectPath CompilationTestProject -logFile logs\CompilePackage.log -batchmode -quit
+  artifacts:
+    logs:
+      paths:
+        - logs/*

--- a/.yamato/compile-package.yml
+++ b/.yamato/compile-package.yml
@@ -1,5 +1,31 @@
 compile_test:
-  name: Compilation Test
+  name: Compilation Test for Package Version
+  agent:
+    type: Unity::VM
+    flavor: b1.large
+    image: package-ci/win10:v4
+  variables:
+    VERSION: 3.1.0-exp.4
+  commands:
+    # When unity-config will be part of the image, this will turn into a no-op
+    - |
+      where /q unity-config
+      if ERRORLEVEL 1 (
+        %GSUDO% choco install unity-config -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
+      )
+    - unity-downloader-cli -c editor -u 2020.3 --wait
+    - .Editor\Unity.exe -createProject CompilationTestProject -logFile logs\CreateProject.log -batchmode -quit
+    - |
+      unity-config project set registry --project-path CompilationTestProject candidates
+      unity-config project add dependency --project-path CompilationTestProject com.unity.renderstreaming@%VERSION%
+    - .Editor\Unity.exe -projectPath CompilationTestProject -logFile logs\CompilePackage.log -batchmode -quit
+  artifacts:
+    logs:
+      paths:
+        - logs/*
+
+compile_test:
+  name: Compilation Test for Local Path
   agent:
     type: Unity::VM
     flavor: b1.large
@@ -15,7 +41,7 @@ compile_test:
     - .Editor\Unity.exe -createProject CompilationTestProject -logFile logs\CreateProject.log -batchmode -quit
     - |
       unity-config project set registry --project-path CompilationTestProject candidates
-      unity-config project add dependency --project-path CompilationTestProject com.unity.renderstreaming@3.1.0-exp.4
+      unity-config project add dependency --project-path CompilationTestProject .\com.unity.renderstreaming
     - .Editor\Unity.exe -projectPath CompilationTestProject -logFile logs\CompilePackage.log -batchmode -quit
   artifacts:
     logs:

--- a/.yamato/compile-package.yml
+++ b/.yamato/compile-package.yml
@@ -1,4 +1,4 @@
-compile_test:
+compile_test_for_package_version:
   name: Compilation Test for Package Version
   agent:
     type: Unity::VM
@@ -24,7 +24,7 @@ compile_test:
       paths:
         - logs/*
 
-compile_test:
+compile_test_for_local_path:
   name: Compilation Test for Local Path
   agent:
     type: Unity::VM

--- a/.yamato/package.metafile
+++ b/.yamato/package.metafile
@@ -10,7 +10,7 @@ editors:
   - version: 2022.1
   - version: trunk
 platforms:
-  - name: win
+  - name: win-gpu
     type: Unity::VM::GPU
     image: renderstreaming/win10:v0.3.13-1084240
     flavor: b1.large
@@ -21,6 +21,21 @@ platforms:
 # todo(kazuki) : this comment is workaround for avoiding template test error on Yamato.
 # "PackageTestSuite.PackageValidationTests.PackageHasTests" unittest is failed
 # Error message : A package must have either playmode or editor tests in it. If you are using a different package for your tests, make sure to use the 'relatedPackages' field in your main package's manifest like explained here: https://confluence.hq.unity3d.com/display/PAK/How+to+add+a+test+project+for+your+package
+      - backend: mono
+        platform: editmode
+      - backend: mono
+        platform: playmode
+      - backend: mono
+        platform: standalone
+      - backend: il2cpp
+        platform: standalone
+  - name: win
+    type: Unity::VM
+    image: renderstreaming/win10:v0.3.13-1084239
+    flavor: b1.large
+    packed_webapp_name: webserver.exe
+    packed_webapp_platform: win
+    test_params:
       - backend: mono
         platform: editmode
       - backend: mono
@@ -70,7 +85,7 @@ platforms:
 #      - backend: il2cpp
 #        additional_component_arg: StandaloneSupport-IL2CPP
 #        platform: standalone
-  - name: linux
+  - name: linux-gpu
     type: Unity::VM::GPU
     image: renderstreaming/ubuntu:v0.2.4-1104053
     flavor: b1.large

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -139,11 +139,11 @@ test_{{ packagename }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name
 {% if platform.name == "win" %}
     - |
       set WEBAPP_PATH=%cd%\Webapp\bin~\{{ platform.packed_webapp_name }}
-      upm-ci package test -u {{ editor.version }} --package-path {{ packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
+      upm-ci package test -u {{ editor.version }} --package-path {{ packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --enable-load-and-test-isolation
 {% else %}
     - |
       export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
-      upm-ci package test -u {{ editor.version }} --package-path {{ packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!HttpSignaling"
+      upm-ci package test -u {{ editor.version }} --package-path {{ packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --testfilter=!HttpSignaling" --enable-load-and-test-isolation
 {% endif %}
   artifacts:
     {{ packagename }}_{{ editor.version }}_{{ platform.name }}_test_results:

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -73,9 +73,9 @@ build_{{ editor.version }}_android_{{ target.name }}:
     - |
       find upm-ci~/packages/ -name "*.tgz" | xargs -I file tar xvf file -C upm-ci~
       cp -rf upm-ci~/package/Runtime/Plugins Runtime/
-{% if target.name == "vulkan" -%}
+{% if target.name == "vulkan" %}
       cp -f TestProjects/Empty/ProjectSettings/ProjectSettings-android-vulkan.asset TestProjects/Empty/ProjectSettings/ProjectSettings.asset
-{% endif -%}
+{% endif %}
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --fast -w
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools/utr-standalone/utr --output utr
@@ -136,7 +136,7 @@ test_{{ packagename }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name
     - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
-{% if platform.name == "win" %}
+{% if platform.name == "win" or platform.name == "win-gpu" %}
     - |
       set WEBAPP_PATH=%cd%\Webapp\bin~\{{ platform.packed_webapp_name }}
       upm-ci package test -u {{ editor.version }} --package-path {{ packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --enable-load-and-test-isolation
@@ -167,11 +167,11 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
-{% if platform.name != "win" %}
+{% if platform.name != "win" and platform.name != "win-gpu" %}
     - find ./{{ packagename }} -type l -exec bash -c 'sh BuildScripts~/convert_symlinks.sh "$0"' {} \;
 {% endif %}
     - upm-ci project pack --project-path {{ project.path }}
-{% if platform.name == "win" %}
+{% if platform.name == "win" or platform.name == "win-gpu" %}
     - |
       set WEBAPP_PATH=%cd%\Webapp\bin~\{{ platform.packed_webapp_name }}
       upm-ci project test -u {{ editor.version }} --project-path {{ project.path }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
@@ -310,17 +310,22 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.packed_webapp_platform }}
 {% endfor %}
 {% endfor %}
-{% endif -%}
+{% endif %}
 {% endfor %}
 
 trigger_test_{{ packagename }}_{{ editor.version }}:
   name : Trigger test {{ package_displayname }} {{ editor.version }} all platforms
   dependencies:
+<<<<<<< HEAD
     - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ packagename }}_{{ editor.version }}
 {% if editor.version == "2020.3" -%}
+=======
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ editor.version }}
+{% if editor.version == "2020.3" %}
+>>>>>>> f66599b (﻿add job for testing on Windows without GPU)
   triggers:
     expression: pull_request.target eq "main"
-{% endif -%}
+{% endif %}
 
 test_{{ packagename }}_{{ editor.version }}:
   name : Test {{ package_displayname }} {{ editor.version }} all platforms
@@ -379,10 +384,17 @@ publish_dry_run_{{ packagename }}:
   dependencies:
     - .yamato/upm-ci-renderstreaming-packages.yml#pack
 {% for editor in editors %}
+<<<<<<< HEAD
 {% if editor.version != "trunk" -%} # exclude trunk to test
     - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ packagename }}_editmode_mono_win_{{ editor.version }}
     - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ packagename }}_editmode_mono_macos_{{ editor.version }}
     - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ packagename }}_editmode_mono_linux_{{ editor.version }}
+=======
+{% if editor.version != "trunk" %} # exclude trunk to test
+    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ package.name }}_editmode_mono_win-gpu_{{ editor.version }}
+    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ package.name }}_editmode_mono_macos_{{ editor.version }}
+    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ package.name }}_editmode_mono_linux-gpu_{{ editor.version }}
+>>>>>>> f66599b (﻿add job for testing on Windows without GPU)
 {% endif %}
 {% endfor %}
 
@@ -410,3 +422,41 @@ publish_{{ packagename }}:
     - .yamato/upm-ci-renderstreaming-packages.yml#trigger_test_{{ packagename }}_{{ editor.version }}
 {% endif %}
 {% endfor %}
+<<<<<<< HEAD
+=======
+
+{% for platform in platforms %}
+{% if platform.name != "macos" and platform.name != "macos-m1" %}
+{% for editor in editors %}
+codecoverage_{{ package.packagename }}_{{ platform.name }}_{{ editor.version }}:
+  name: Code coverage {{ package.packagename }} {{ platform.name }} {{ editor.version }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor }}
+  commands:
+    - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+    - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+    - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
+{% if platform.name == "win" or platform.name == "win-gpu" %}
+    - |
+      set WEBAPP_PATH=%cd%\Webapp\bin~\{{ platform.packed_webapp_name }}
+      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-UnityEngine.*,+Unity.RenderStreaming" --extra-utr-arg="--timeout=3000"
+{% else %}
+    - |
+      export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
+      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-UnityEngine.*,+Unity.RenderStreaming" --extra-utr-arg="--timeout=3000"
+{% endif %}
+  artifacts:
+    {{ package.name }}_{{ editor.version }}_{{ platform.name }}_coverage_results:
+      paths:
+        - "upm-ci~/test-results/**"
+  dependencies:
+    - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
+    - .yamato/upm-ci-webapp.yml#pack_{{ platform.packed_webapp_platform }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+
+{% endfor %}
+>>>>>>> f66599b (﻿add job for testing on Windows without GPU)

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -316,13 +316,8 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
 trigger_test_{{ packagename }}_{{ editor.version }}:
   name : Trigger test {{ package_displayname }} {{ editor.version }} all platforms
   dependencies:
-<<<<<<< HEAD
     - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ packagename }}_{{ editor.version }}
 {% if editor.version == "2020.3" -%}
-=======
-    - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ editor.version }}
-{% if editor.version == "2020.3" %}
->>>>>>> f66599b (﻿add job for testing on Windows without GPU)
   triggers:
     expression: pull_request.target eq "main"
 {% endif %}
@@ -384,17 +379,10 @@ publish_dry_run_{{ packagename }}:
   dependencies:
     - .yamato/upm-ci-renderstreaming-packages.yml#pack
 {% for editor in editors %}
-<<<<<<< HEAD
 {% if editor.version != "trunk" -%} # exclude trunk to test
-    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ packagename }}_editmode_mono_win_{{ editor.version }}
+    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ packagename }}_editmode_mono_win-gpu_{{ editor.version }}
     - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ packagename }}_editmode_mono_macos_{{ editor.version }}
-    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ packagename }}_editmode_mono_linux_{{ editor.version }}
-=======
-{% if editor.version != "trunk" %} # exclude trunk to test
-    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ package.name }}_editmode_mono_win-gpu_{{ editor.version }}
-    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ package.name }}_editmode_mono_macos_{{ editor.version }}
-    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ package.name }}_editmode_mono_linux-gpu_{{ editor.version }}
->>>>>>> f66599b (﻿add job for testing on Windows without GPU)
+    - .yamato/upm-ci-renderstreaming-packages.yml#test_{{ packagename }}_editmode_mono_linux-gpu_{{ editor.version }}
 {% endif %}
 {% endfor %}
 
@@ -422,41 +410,3 @@ publish_{{ packagename }}:
     - .yamato/upm-ci-renderstreaming-packages.yml#trigger_test_{{ packagename }}_{{ editor.version }}
 {% endif %}
 {% endfor %}
-<<<<<<< HEAD
-=======
-
-{% for platform in platforms %}
-{% if platform.name != "macos" and platform.name != "macos-m1" %}
-{% for editor in editors %}
-codecoverage_{{ package.packagename }}_{{ platform.name }}_{{ editor.version }}:
-  name: Code coverage {{ package.packagename }} {{ platform.name }} {{ editor.version }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor }}
-  commands:
-    - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-    - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
-    - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
-{% if platform.name == "win" or platform.name == "win-gpu" %}
-    - |
-      set WEBAPP_PATH=%cd%\Webapp\bin~\{{ platform.packed_webapp_name }}
-      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-UnityEngine.*,+Unity.RenderStreaming" --extra-utr-arg="--timeout=3000"
-{% else %}
-    - |
-      export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
-      upm-ci package test -u {{ editor.version }} --package-path {{ package.packagename }} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-UnityEngine.*,+Unity.RenderStreaming" --extra-utr-arg="--timeout=3000"
-{% endif %}
-  artifacts:
-    {{ package.name }}_{{ editor.version }}_{{ platform.name }}_coverage_results:
-      paths:
-        - "upm-ci~/test-results/**"
-  dependencies:
-    - .yamato/upm-ci-renderstreaming-packages.yml#pack_{{ package.name }}
-    - .yamato/upm-ci-webapp.yml#pack_{{ platform.packed_webapp_platform }}
-{% endfor %}
-{% endif %}
-{% endfor %}
-
-{% endfor %}
->>>>>>> f66599b (﻿add job for testing on Windows without GPU)

--- a/.yamato/upm-ci-renderstreaming-packages.yml
+++ b/.yamato/upm-ci-renderstreaming-packages.yml
@@ -143,7 +143,7 @@ test_{{ packagename }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name
 {% else %}
     - |
       export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
-      upm-ci package test -u {{ editor.version }} --package-path {{ packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --testfilter=!HttpSignaling" --enable-load-and-test-isolation
+      upm-ci package test -u {{ editor.version }} --package-path {{ packagename }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--testfilter=!HttpSignaling" --enable-load-and-test-isolation
 {% endif %}
   artifacts:
     {{ packagename }}_{{ editor.version }}_{{ platform.name }}_test_results:
@@ -174,11 +174,11 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
 {% if platform.name == "win" or platform.name == "win-gpu" %}
     - |
       set WEBAPP_PATH=%cd%\Webapp\bin~\{{ platform.packed_webapp_name }}
-      upm-ci project test -u {{ editor.version }} --project-path {{ project.path }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000"
+      upm-ci project test -u {{ editor.version }} --project-path {{ project.path }} --platform {{ param.platform }} --backend {{ param.backend }}
 {% else %}
     - |
       export WEBAPP_PATH=$(pwd)/WebApp/bin~/{{ platform.packed_webapp_name }}
-      upm-ci project test -u {{ editor.version }} --project-path {{ project.path }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--timeout=3000 --testfilter=!HttpSignaling"
+      upm-ci project test -u {{ editor.version }} --project-path {{ project.path }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-utr-arg="--testfilter=!HttpSignaling"
 {% endif %}
   artifacts:
     {{ packagename }}_{{ editor.version }}_{{ platform.name }}_test_results:
@@ -207,7 +207,7 @@ build_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.ver
     - unity-downloader-cli -c Editor -c {{ param.additional_component_arg }} -u {{ editor.version }} --fast -w
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools/utr-standalone/utr --output utr
     - chmod +x ./utr
-    - ./utr --suite=playmode --platform=StandaloneOSX --editor-location=.Editor --testproject=TestProjects/Empty --player-save-path=build/players --architecture=x64 --artifacts_path=build/logs --scripting-backend={{ param.backend }} --build-only --timeout=3000 --testfilter=!HttpSignaling
+    - ./utr --suite=playmode --platform=StandaloneOSX --editor-location=.Editor --testproject=TestProjects/Empty --player-save-path=build/players --architecture=x64 --artifacts_path=build/logs --scripting-backend={{ param.backend }} --build-only --testfilter=!HttpSignaling
   artifacts:
     players:
       paths:
@@ -266,7 +266,7 @@ test_{{ packagename }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name
       TEST_ARCHITECTURE: {{ platform.architecture }}
       SCRIPTING_BACKEND: {{ param.backend }}
       EDITOR_VERSION: {{ editor.version }}
-      EXTRA_UTR_ARG: --timeout=3000 --testfilter=!HttpSignaling
+      EXTRA_UTR_ARG: --testfilter=!HttpSignaling
   commands:
     - find upm-ci~/packages/ -name "*.tgz" | xargs -I file tar xvf file -C upm-ci~
     - BuildScripts~/test_package_mac.sh
@@ -298,7 +298,7 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     TEST_PLATFORM: {{ param.platform }}
     SCRIPTING_BACKEND: {{ param.backend }}
     EDITOR_VERSION: {{ editor.version }}
-    EXTRA_UTR_ARG: --timeout=3000 --testfilter=!HttpSignaling
+    EXTRA_UTR_ARG: --testfilter=!HttpSignaling
   commands:
     - find ./{{ packagename }} -type l -exec bash -c 'sh BuildScripts~/convert_symlinks.sh "$0"' {} \;
     - BuildScripts~/test_package_mac.sh

--- a/.yamato/upm-ci-template.yml
+++ b/.yamato/upm-ci-template.yml
@@ -5,7 +5,7 @@
 {% for project in template_projects %}
 
 {% for editor in editors %}
-{% if editor.version == "2020.3" -%}
+{% if editor.version == "2020.3" %}
 
 prepack_{{ project.name }}_{{ editor.version }}:
   name: Pre-Pack {{ project.packagename }} {{ editor.version }} - Primed Artifacts
@@ -44,7 +44,7 @@ pack_{{ project.name }}_{{ editor.version }}:
         - "upm-ci~/**/*"
 
 {% for platform in platforms %}
-{% if platform.name == "win" -%}
+{% if platform.name == "win" or platform.name == "win-gpu" %}
 {% for param in platform.test_params %}
 test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
   name : Test {{ project.packagename }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}
@@ -66,9 +66,9 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - .yamato/upm-ci-template.yml#pack_{{ project.name }}_{{ editor.version }}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
 {% endfor %}
-{% else -%}
+{% else %}
 {% for param in platform.test_params %}
-{% if project.name != "renderstreaming-rtx" -%}
+{% if project.name != "renderstreaming-rtx" %}
 test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}:
   name : Test {{ project.packagename }} {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ platform.name }}
   agent:
@@ -85,29 +85,29 @@ test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
   dependencies:
     - .yamato/upm-ci-template.yml#pack_{{ project.name }}_{{ editor.version }}
     - .yamato/upm-ci-webapp.yml#pack_{{ platform.name }}
-{% endif -%}
+{% endif %}
 {% endfor %}
-{% endif -%}
+{% endif %}
 {% endfor %}
 
 trigger_template_test_{{ project.name }}_{{ editor.version }}:
   name : Trigger all Template test {{ project.packagename }} {{ editor.version }}
   dependencies:
     {% for platform in platforms %}
-    {% if platform.name == "win" -%}
+    {% if platform.name == "win" or platform.name == "win-gpu" %}
     {% for param in platform.test_params %}
     - .yamato/upm-ci-template.yml#test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}
     {% endfor %}
-    {% else -%}
+    {% else %}
     {% if project.name != "renderstreaming-rtx" %}
     {% for param in platform.test_params %}
     - .yamato/upm-ci-template.yml#test_{{ project.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.name }}_{{ editor.version }}
     {% endfor %}
     {% endif %}
-    {% endif -%}
+    {% endif %}
     {% endfor %}
 
-{% endif -%}
+{% endif %}
 {% endfor %}
 
 publish_{{ project.name }}:

--- a/RenderStreaming~/Packages/packages-lock.json
+++ b/RenderStreaming~/Packages/packages-lock.json
@@ -53,7 +53,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.unity.webrtc": "3.0.0-pre.2",
+        "com.unity.webrtc": "3.0.0-pre.3",
         "com.unity.inputsystem": "1.4.4",
         "com.unity.ugui": "1.0.0",
         "com.unity.modules.screencapture": "1.0.0"
@@ -106,7 +106,7 @@
       }
     },
     "com.unity.webrtc": {
-      "version": "3.0.0-pre.2",
+      "version": "3.0.0-pre.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/RenderStreaming~/Packages/packages-lock.json
+++ b/RenderStreaming~/Packages/packages-lock.json
@@ -53,8 +53,9 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.unity.webrtc": "2.4.0-exp.11",
-        "com.unity.inputsystem": "1.4.4"
+        "com.unity.webrtc": "3.0.0-pre.2",
+        "com.unity.inputsystem": "1.4.4",
+        "com.unity.ugui": "1.0.0"
       }
     },
     "com.unity.settings-manager": {
@@ -104,12 +105,13 @@
       }
     },
     "com.unity.webrtc": {
-      "version": "2.4.0-exp.11",
+      "version": "3.0.0-pre.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.editorcoroutines": "1.0.0"
+        "com.unity.editorcoroutines": "1.0.0",
+        "com.unity.modules.audio": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },

--- a/RenderStreaming~/Packages/packages-lock.json
+++ b/RenderStreaming~/Packages/packages-lock.json
@@ -55,7 +55,8 @@
       "dependencies": {
         "com.unity.webrtc": "3.0.0-pre.2",
         "com.unity.inputsystem": "1.4.4",
-        "com.unity.ugui": "1.0.0"
+        "com.unity.ugui": "1.0.0",
+        "com.unity.modules.screencapture": "1.0.0"
       }
     },
     "com.unity.settings-manager": {

--- a/com.unity.renderstreaming/Runtime/Unity.RenderStreaming.Runtime.asmdef
+++ b/com.unity.renderstreaming/Runtime/Unity.RenderStreaming.Runtime.asmdef
@@ -4,6 +4,7 @@
     "references": [
         "Unity.InputSystem",
         "Unity.WebRTC",
+        "UnityEngine.UI",
         "Unity.XR.ARSubsystems",
         "Unity.TextMeshPro",
         "Unity.RenderPipelines.HighDefinition.Runtime",

--- a/com.unity.renderstreaming/package.json
+++ b/com.unity.renderstreaming/package.json
@@ -5,7 +5,7 @@
   "unity": "2020.3",
   "description": "This is a package for using Unity Render Streaming technology. It contains two samples to use the technology.",
   "dependencies": {
-    "com.unity.webrtc": "3.0.0-pre.2",
+    "com.unity.webrtc": "3.0.0-pre.3",
     "com.unity.inputsystem": "1.4.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.screencapture": "1.0.0"

--- a/com.unity.renderstreaming/package.json
+++ b/com.unity.renderstreaming/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "com.unity.webrtc": "3.0.0-pre.2",
     "com.unity.inputsystem": "1.4.4",
-    "com.unity.ugui": "1.0.0"
+    "com.unity.ugui": "1.0.0",
+    "com.unity.modules.screencapture": "1.0.0"
   },
   "samples": [
     {

--- a/com.unity.renderstreaming/package.json
+++ b/com.unity.renderstreaming/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "com.unity.webrtc": "3.0.0-pre.2",
     "com.unity.inputsystem": "1.4.4",
-    "com.unity.modules.ui": "1.0.0"
+    "com.unity.ugui": "1.0.0"
   },
   "samples": [
     {

--- a/com.unity.renderstreaming/package.json
+++ b/com.unity.renderstreaming/package.json
@@ -6,7 +6,8 @@
   "description": "This is a package for using Unity Render Streaming technology. It contains two samples to use the technology.",
   "dependencies": {
     "com.unity.webrtc": "3.0.0-pre.2",
-    "com.unity.inputsystem": "1.4.4"
+    "com.unity.inputsystem": "1.4.4",
+    "com.unity.modules.ui": "1.0.0"
   },
   "samples": [
     {


### PR DESCRIPTION
Original PR is here. Thanks for @mihai-unity
https://github.com/Unity-Technologies/UnityRenderStreaming/pull/796

The Unity Render Streaming package may contains the bug which makes the timeout when quitting the Unity Editor. We add the CI job to detect the issue more easily.