### PR TITLE
fix: fix sessions lingering after they were timed out

### DIFF
--- a/WebApp/src/class/httphandler.ts
+++ b/WebApp/src/class/httphandler.ts
@@ -67,8 +67,8 @@ function checkSessionId(req: Request, res: Response, next): void {
   if (!clients.has(id)) {
     res.sendStatus(404);
     return;
-  }
-  lastRequestedTime[id] = Date.now();
+  } 
+  lastRequestedTime.set(id, Date.now());
   next();
 }
 
@@ -124,11 +124,11 @@ function _checkDeletedSession(sessionId: string): void {
     if (pair == null) {
       continue;
     }
-    const otherSessionId = sessionId === pair[0] ? pair[1] : pair[0];
-    if(!lastRequestedTime.has(otherSessionId))
+	const otherSessionId = sessionId === pair[0] ? pair[1] : pair[0];
+	if(!lastRequestedTime.has(otherSessionId))
       continue;
-    if(lastRequestedTime[otherSessionId] > Date.now() - TimeoutRequestedTime)
-      continue;
+    if(lastRequestedTime.get(otherSessionId) > Date.now() - TimeoutRequestedTime)
+      continue;  
     _deleteSession(otherSessionId);
     console.log("deleted");
   }
@@ -342,7 +342,11 @@ function postOffer(req: Request, res: Response): void {
     return;
   }
 
-  connectionPair.set(connectionId, [sessionId, null]);
+  if(!connectionPair.has(connectionId))
+  {
+    connectionPair.set(connectionId, [sessionId, null]);
+  }
+  
   keySessionId = sessionId;
   const map = offers.get(keySessionId);
   map.set(connectionId, new Offer(req.body.sdp, Date.now(), polite));


### PR DESCRIPTION
How to reproduce:
- Set up test project with RenderStreaming samples
- Run broadcast sample
- Connect to receiver example in chrome browser
- Once connection is established hit F5 to refresh the page, (or can force quit chrome app)
- If you check the webserver app, you will see that no "deleted" message is logged even after the 10 second timeout

Expected behavior:
- Timed out sessions will be deleted after the 10 second time out

How this was tested:
- Added a new test that failed to replicate the issue
- Ran tests after fix was implemented to confirm it fixed issue
- Tested the above steps with the package samples to confirm orphaned connections are cleaned up

Log from webserver demonstrating timeout clean-up of improperly disconnected session:

![image](https://user-images.githubusercontent.com/92394761/208715651-fb412986-8e3a-4074-afa8-d22f70bff653.png)
