### PR TITLE
fix: Fix option title of av1 video codec on inspector window

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoCodecInfo.cs
@@ -128,6 +128,8 @@ namespace Unity.RenderStreaming
                     return new H264CodecInfo(caps);
                 case "video/VP9":
                     return new VP9CodecInfo(caps);
+                case "video/AV1":
+                    return new AV1CodecInfo(caps);
                 default:
                     return new VideoCodecInfo(caps);
             }
@@ -257,4 +259,52 @@ namespace Unity.RenderStreaming
         }
     }
 
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum AV1Profile
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Profile0 = 0,
+        /// <summary>
+        /// 
+        /// </summary>
+        Profile1 = 1,
+        /// <summary>
+        /// 
+        /// </summary>
+        Profile2 = 2,
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class AV1CodecInfo : VideoCodecInfo
+    {
+        const string KeyProfile = "profile";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public AV1Profile profile
+        {
+            get
+            {
+
+                if (parameters.TryGetValue(KeyProfile, out var value))
+                {
+                    return (AV1Profile)Enum.ToObject(typeof(AV1Profile), Convert.ToInt32(value));
+                }
+                // If the parameter is not present, it MUST be inferred to be 0 (“Main” profile).
+                // https://aomediacodec.github.io/av1-rtp-spec/#72-sdp-parameters
+                return AV1Profile.Profile0;
+            }
+        }
+
+        internal AV1CodecInfo(RTCRtpCodecCapability caps) : base(caps)
+        {
+        }
+    }
 }

--- a/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
@@ -155,6 +155,8 @@ namespace Unity.RenderStreaming.Samples
                     return $"{h264Codec.mimeType} {h264Codec.profile} {h264Codec.level.ToString().Insert(1, ".")} {h264Codec.codecImplementation}";
                 case VP9CodecInfo V9Codec:
                     return $"{V9Codec.mimeType} {V9Codec.profile} {V9Codec.codecImplementation}";
+                case AV1CodecInfo av1Codec:
+                    return $"{av1Codec.mimeType} {av1Codec.profile} {av1Codec.codecImplementation}";
                 default:
                     return $"{codec.mimeType} {codec.codecImplementation}";
             }


### PR DESCRIPTION
The internal video codec factory in libwebrtc implements two profiles of AV1 video codec, *Profile 0* and *Profile 1*. Add a note, this option is for only receiver side, not sender.

This pull request provides dropdown UI on Inspector Window to choice these options.
![image](https://user-images.githubusercontent.com/1132081/208875085-f6cd912d-fcf0-4cbd-bca8-8fc54de05751.png)
