### PR TITLE
[Bugfix] fix AFoundationSample when script is disabled.

### DIFF
--- a/com.unity.renderstreaming/Samples~/Example/ARFoundation/ARFoundationSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/ARFoundation/ARFoundationSample.cs
@@ -90,7 +90,7 @@ namespace Unity.RenderStreaming.Samples
             positionAction.started -= UpdatePosition;
             positionAction.canceled -= UpdatePosition;
 
-            quaternionAction.Enable();
+            quaternionAction.Disable();
             quaternionAction.performed -= UpdateQuaternion;
             quaternionAction.started -= UpdateQuaternion;
             quaternionAction.canceled -= UpdateQuaternion;


### PR DESCRIPTION
In latest example code, there is a bug on ARFoundationSample.cs.
it is not a critical bug, however I think it should be fixed.

BRs.