### PR TITLE
fix: Avoid assertion `Could not find active control after ing resolution.` in InputActionState class

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/InputReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputReceiver.cs
@@ -320,6 +320,7 @@ namespace Unity.RenderStreaming
                 m_InputUser = new InputUser();
                 return;
             }
+            m_InputUser = InputUser.CreateUserWithoutPairedDevices();
 
             // If we don't have a valid user at this point, we don't have any paired devices.
             if (m_InputUser.valid)

--- a/com.unity.renderstreaming/Runtime/Scripts/InputReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputReceiver.cs
@@ -8,11 +8,10 @@ using UnityEngine.InputSystem.Users;
 using Unity.RenderStreaming.InputSystem;
 
 using Inputs = UnityEngine.InputSystem.InputSystem;
+using InputRemoting = Unity.RenderStreaming.InputSystem.InputRemoting;
 
 namespace Unity.RenderStreaming
 {
-    using InputRemoting = Unity.RenderStreaming.InputSystem.InputRemoting;
-
     /// <summary>
     /// Represents a separate player in the game complete with a set of actions exclusive
     /// to the player and a set of paired device.
@@ -308,11 +307,23 @@ namespace Unity.RenderStreaming
 
         private void AssignUserAndDevices()
         {
-            if (actions == null)
-                throw new InvalidOperationException("actions field is needed to assign.");
+            // If we already have a user at this point, clear out all its paired devices
+            // to start the pairing process from scratch.
+            if (m_InputUser.valid)
+                m_InputUser.UnpairDevices();
 
-            m_InputUser = InputUser.CreateUserWithoutPairedDevices();
-            m_InputUser.AssociateActionsWithUser(actions);
+            // All our input goes through actions so there's no point setting
+            // anything up if we have none.
+            if (m_Actions == null)
+            {
+                // Make sure user is invalid.
+                m_InputUser = new InputUser();
+                return;
+            }
+
+            // If we don't have a valid user at this point, we don't have any paired devices.
+            if (m_InputUser.valid)
+                m_InputUser.AssociateActionsWithUser(actions);
         }
 
         private void UnassignUserAndDevices()

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
@@ -123,12 +123,25 @@ namespace Unity.RenderStreaming.InputSystem
 
         public virtual InputDevice AddDevice(string layout, string name = null, string variants = null)
         {
-            return InputSystem.AddDevice(layout, name, variants);
+            // workaround(kazuki):
+            // Avoid assertion `Could not find active control after binding resolution.` in InputActionState class.
+            // Occrring this assertion if active InputActionMap is existed when calling InputSystem.AddDevice.
+            var actions = InputSystem.ListEnabledActions();
+            actions.ForEach(action => action.Disable());
+            var device = InputSystem.AddDevice(layout, name, variants);
+            actions.ForEach(action => action.Enable());
+            return device;
         }
 
         public virtual void RemoveDevice(InputDevice device)
         {
+            // workaround(kazuki):
+            // Avoid assertion `Could not find active control after binding resolution.` in InputActionState class.
+            // Occrring this assertion if active InputActionMap is existed when calling InputSystem.RemoveDevice.
+            var actions = InputSystem.ListEnabledActions();
+            actions.ForEach(action => action.Disable());
             InputSystem.RemoveDevice(device);
+            actions.ForEach(action => action.Enable());
         }
 
         public virtual void SetDeviceUsage(InputDevice device, string usage)

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -557,5 +557,28 @@ namespace Unity.RenderStreaming.RuntimeTest
             UnityEngine.Object.DestroyImmediate(asset);
             UnityEngine.Object.DestroyImmediate(go);
         }
+
+        [Test]
+        public void InputUserId()
+        {
+            var go = new GameObject();
+            go.SetActive(false);
+            var receiver = go.AddComponent<InputReceiver>();
+
+            // user.id is InputUser.InvalidId in default.
+            Assert.That(receiver.actions, Is.Null);
+            Assert.That(receiver.user.id, Is.EqualTo(InputUser.InvalidId));
+
+            var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+            var mapName = "test";
+            asset.AddActionMap(mapName);
+            receiver.actions = asset;
+
+            // user.id is not InputUser.InvalidId after set actions parameter.
+            Assert.That(receiver.actions, Is.Not.Null);
+            Assert.That(receiver.user.id, Is.EqualTo(InputUser.InvalidId));
+
+            UnityEngine.Object.DestroyImmediate(go);
+        }
     }
 }


### PR DESCRIPTION
When using InputSystem 1.4.4, we have an assertion error in Unity Render Streaming. 

## How to reproduce

- Build and play sample scenes for Android platform.
- Open "Broadcast" scene on Windows Editor.
- Open "Receiver" scene on Android device and connect to Windows Editor.
- Press "Back" button on Android device, and you can see the error log on Unity Editor.

## Fix
When calling `InputSystem.AddDevice` or `InputSystem.RemoveDevice`, it runs rebinding input control process immediatelly. Occurring the asserion error is in the process. To avoid this assertion, need to set disable all InputActions for the timing which running the process.