### PR TITLE
fix: Avoid assertion from Input System package when using Android device

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/InputReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputReceiver.cs
@@ -320,6 +320,7 @@ namespace Unity.RenderStreaming
                 m_InputUser = new InputUser();
                 return;
             }
+            m_InputUser = InputUser.CreateUserWithoutPairedDevices();
 
             // If we don't have a valid user at this point, we don't have any paired devices.
             if (m_InputUser.valid)

--- a/com.unity.renderstreaming/Runtime/Scripts/InputReceiver.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputReceiver.cs
@@ -8,11 +8,10 @@ using UnityEngine.InputSystem.Users;
 using Unity.RenderStreaming.InputSystem;
 
 using Inputs = UnityEngine.InputSystem.InputSystem;
+using InputRemoting = Unity.RenderStreaming.InputSystem.InputRemoting;
 
 namespace Unity.RenderStreaming
 {
-    using InputRemoting = Unity.RenderStreaming.InputSystem.InputRemoting;
-
     /// <summary>
     /// Represents a separate player in the game complete with a set of actions exclusive
     /// to the player and a set of paired device.
@@ -308,11 +307,23 @@ namespace Unity.RenderStreaming
 
         private void AssignUserAndDevices()
         {
-            if (actions == null)
-                throw new InvalidOperationException("actions field is needed to assign.");
+            // If we already have a user at this point, clear out all its paired devices
+            // to start the pairing process from scratch.
+            if (m_InputUser.valid)
+                m_InputUser.UnpairDevices();
 
-            m_InputUser = InputUser.CreateUserWithoutPairedDevices();
-            m_InputUser.AssociateActionsWithUser(actions);
+            // All our input goes through actions so there's no point setting
+            // anything up if we have none.
+            if (m_Actions == null)
+            {
+                // Make sure user is invalid.
+                m_InputUser = new InputUser();
+                return;
+            }
+
+            // If we don't have a valid user at this point, we don't have any paired devices.
+            if (m_InputUser.valid)
+                m_InputUser.AssociateActionsWithUser(actions);
         }
 
         private void UnassignUserAndDevices()

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
@@ -129,11 +130,15 @@ namespace Unity.RenderStreaming.InputSystem
 
         public virtual InputDevice AddDevice(string layout, string name = null, string variants = null)
         {
+            foreach (var device_ in InputSystem.devices.Where(device => device.enabled))
+                InputSystem.ResetDevice(device_);
             return InputSystem.AddDevice(layout, name, variants);
         }
 
         public virtual void RemoveDevice(InputDevice device)
         {
+            foreach (var device_ in InputSystem.devices.Where(device => device.enabled))
+                InputSystem.ResetDevice(device_);
             InputSystem.RemoveDevice(device);
         }
 

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
@@ -53,7 +53,7 @@ namespace Unity.RenderStreaming.InputSystem
         /// <param name="name"></param>
         /// <param name="variants"></param>
         /// <returns></returns>
-        InputDevice AddDevice(string layout, string name = null, string variants = null);
+        InputDevice AddDevice(string layout, string name = null);
         /// <summary>
         ///
         /// </summary>
@@ -64,7 +64,13 @@ namespace Unity.RenderStreaming.InputSystem
         /// </summary>
         /// <param name="device"></param>
         /// <param name="usage"></param>
-        void SetDeviceUsage(InputDevice device, string usage);
+        void AddDeviceUsage(InputDevice device, string usage);
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="device"></param>
+        /// <param name="usage"></param>
+        void RemoveDeviceUsage(InputDevice device, string usage);
         /// <summary>
         ///
         /// </summary>
@@ -121,9 +127,9 @@ namespace Unity.RenderStreaming.InputSystem
             return InputSystem.GetDeviceById(deviceId);
         }
 
-        public virtual InputDevice AddDevice(string layout, string name = null, string variants = null)
+        public virtual InputDevice AddDevice(string layout, string name = null)
         {
-            return InputSystem.AddDevice(layout, name, variants);
+            return InputSystem.AddDevice(layout, name);
         }
 
         public virtual void RemoveDevice(InputDevice device)
@@ -131,9 +137,13 @@ namespace Unity.RenderStreaming.InputSystem
             InputSystem.RemoveDevice(device);
         }
 
-        public virtual void SetDeviceUsage(InputDevice device, string usage)
+        public virtual void AddDeviceUsage(InputDevice device, string usage)
         {
-            InputSystem.SetDeviceUsage(device, usage);
+            InputSystem.AddDeviceUsage(device, usage);
+        }
+        public virtual void RemoveDeviceUsage(InputDevice device, string usage)
+        {
+            InputSystem.RemoveDeviceUsage(device, usage);
         }
 
         public virtual InputControlLayout LoadLayout(string name)

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
@@ -53,7 +53,7 @@ namespace Unity.RenderStreaming.InputSystem
         /// <param name="name"></param>
         /// <param name="variants"></param>
         /// <returns></returns>
-        InputDevice AddDevice(string layout, string name = null);
+        InputDevice AddDevice(string layout, string name = null, string variants = null);
         /// <summary>
         ///
         /// </summary>
@@ -127,9 +127,9 @@ namespace Unity.RenderStreaming.InputSystem
             return InputSystem.GetDeviceById(deviceId);
         }
 
-        public virtual InputDevice AddDevice(string layout, string name = null)
+        public virtual InputDevice AddDevice(string layout, string name = null, string variants = null)
         {
-            return InputSystem.AddDevice(layout, name);
+            return InputSystem.AddDevice(layout, name, variants);
         }
 
         public virtual void RemoveDevice(InputDevice device)

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
@@ -123,25 +123,12 @@ namespace Unity.RenderStreaming.InputSystem
 
         public virtual InputDevice AddDevice(string layout, string name = null, string variants = null)
         {
-            // workaround(kazuki):
-            // Avoid assertion `Could not find active control after binding resolution.` in InputActionState class.
-            // Occrring this assertion if active InputActionMap is existed when calling InputSystem.AddDevice.
-            var actions = InputSystem.ListEnabledActions();
-            actions.ForEach(action => action.Disable());
-            var device = InputSystem.AddDevice(layout, name, variants);
-            actions.ForEach(action => action.Enable());
-            return device;
+            return InputSystem.AddDevice(layout, name, variants);
         }
 
         public virtual void RemoveDevice(InputDevice device)
         {
-            // workaround(kazuki):
-            // Avoid assertion `Could not find active control after binding resolution.` in InputActionState class.
-            // Occrring this assertion if active InputActionMap is existed when calling InputSystem.RemoveDevice.
-            var actions = InputSystem.ListEnabledActions();
-            actions.ForEach(action => action.Disable());
             InputSystem.RemoveDevice(device);
-            actions.ForEach(action => action.Enable());
         }
 
         public virtual void SetDeviceUsage(InputDevice device, string usage)

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputManager.cs
@@ -123,12 +123,25 @@ namespace Unity.RenderStreaming.InputSystem
 
         public virtual InputDevice AddDevice(string layout, string name = null, string variants = null)
         {
-            return InputSystem.AddDevice(layout, name, variants);
+            // workaround(kazuki):
+            // Avoid assertion `Could not find active control after binding resolution.` in InputActionState class.
+            // Occrring this assertion if active InputActionMap is existed when calling InputSystem.AddDevice.
+            var actions = InputSystem.ListEnabledActions();
+            actions.ForEach(action => action.Disable());
+            var device = InputSystem.AddDevice(layout, name, variants);
+            actions.ForEach(action => action.Enable());
+            return device;
         }
 
         public virtual void RemoveDevice(InputDevice device)
         {
+            // workaround(kazuki):
+            // Avoid assertion `Could not find active control after binding resolution.` in InputActionState class.
+            // Occrring this assertion if active InputActionMap is existed when calling InputSystem.RemoveDevice.
+            var actions = InputSystem.ListEnabledActions();
+            actions.ForEach(action => action.Disable());
             InputSystem.RemoveDevice(device);
+            actions.ForEach(action => action.Enable());
         }
 
         public virtual void SetDeviceUsage(InputDevice device, string usage)

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputRemoting.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputRemoting.cs
@@ -582,7 +582,7 @@ namespace Unity.RenderStreaming.InputSystem
                 public string name;
                 public string layout;
                 public int deviceId;
-                public string variants;
+                public string[] usages;
                 public InputDeviceDescription description;
             }
 
@@ -595,8 +595,8 @@ namespace Unity.RenderStreaming.InputSystem
                     name = device.name,
                     layout = device.layout,
                     deviceId = device.deviceId,
-                    variants = device.variants,
-                    description = device.description
+                    description = device.description,
+                    usages = device.usages.Select(x => x.ToString()).ToArray()
                 };
 
                 var json = JsonUtility.ToJson(data);
@@ -634,11 +634,7 @@ namespace Unity.RenderStreaming.InputSystem
                 try
                 {
                     ////REVIEW: this gives remote devices names the same way that local devices receive them; should we make remote status visible in the name?
-                    device = Receiver.m_LocalManager.AddDevice(data.layout, data.name, data.variants);
-
-                    // todo(kazuki)::Avoid to use reflection
-                    // device.m_ParticipantId = msg.participantId;
-                    device.SetParticipantId(msg.participantId);
+                    device = Receiver.m_LocalManager.AddDevice(data.layout, data.name);
                 }
                 catch (Exception exception)
                 {
@@ -647,11 +643,19 @@ namespace Unity.RenderStreaming.InputSystem
                     return;
                 }
                 // todo(kazuki)::Avoid to use reflection
+                // device.m_ParticipantId = msg.participantId;
+                device.SetParticipantId(msg.participantId);
+
+                // todo(kazuki)::Avoid to use reflection
                 // device.m_Description = data.description;
                 // device.m_DeviceFlags |= InputDevice.DeviceFlags.Remote;
                 device.SetDescription(data.description);
+
                 var deviceFlagsRemote = 1 << 3;
                 device.SetDeviceFlags(device.GetDeviceFlags() | deviceFlagsRemote);
+
+                //foreach (var usage in data.usages)
+                //    Receiver.m_LocalManager.AddDeviceUsage(device, new InternedString(usage));
 
                 // Remember it.
                 var record = new RemoteInputDevice
@@ -771,10 +775,20 @@ namespace Unity.RenderStreaming.InputSystem
                 var device = Receiver.TryGetDeviceByRemoteId(data.deviceId, senderIndex);
                 if (device != null)
                 {
-                    ////TODO: clearing usages and setting multiple usages
+                    foreach (var deviceUsage in device.usages)
+                    {
+                        if (!data.usages.Contains(deviceUsage))
+                            Receiver.m_LocalManager.RemoveDeviceUsage(device, new InternedString(deviceUsage));
+                    }
 
                     if (data.usages.Length == 1)
-                        Receiver.m_LocalManager.SetDeviceUsage(device, new InternedString(data.usages[0]));
+                        Receiver.m_LocalManager.AddDeviceUsage(device, new InternedString(data.usages[0]));
+                    foreach (var dataUsage in data.usages)
+                    {
+                        var internedDataUsage = new InternedString(dataUsage);
+                        if (!device.usages.Contains(internedDataUsage))
+                            Receiver.m_LocalManager.AddDeviceUsage(device, new InternedString(dataUsage));
+                    }
                 }
             }
         }

--- a/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputRemoting.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/InputSystem/InputRemoting.cs
@@ -420,7 +420,6 @@ namespace Unity.RenderStreaming.InputSystem
         {
             public int remoteId; // Device ID used by sender.
             public int localId; // Device ID used by us in local system.
-            public string layoutName;
 
             public InputDeviceDescription description;
         }
@@ -654,16 +653,15 @@ namespace Unity.RenderStreaming.InputSystem
                 var deviceFlagsRemote = 1 << 3;
                 device.SetDeviceFlags(device.GetDeviceFlags() | deviceFlagsRemote);
 
-                //foreach (var usage in data.usages)
-                //    Receiver.m_LocalManager.AddDeviceUsage(device, new InternedString(usage));
+                foreach (var usage in data.usages)
+                    Receiver.m_LocalManager.AddDeviceUsage(device, usage);
 
                 // Remember it.
                 var record = new RemoteInputDevice
                 {
                     remoteId = data.deviceId,
                     localId = device.deviceId,
-                    description = data.description,
-                    layoutName = data.layout
+                    description = data.description
                 };
                 ArrayHelpers.Append(ref Receiver.m_Senders[senderIndex].devices, record);
             }

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -557,5 +557,28 @@ namespace Unity.RenderStreaming.RuntimeTest
             UnityEngine.Object.DestroyImmediate(asset);
             UnityEngine.Object.DestroyImmediate(go);
         }
+
+        [Test]
+        public void InputUserId()
+        {
+            var go = new GameObject();
+            go.SetActive(false);
+            var receiver = go.AddComponent<InputReceiver>();
+
+            // user.id is InputUser.InvalidId in default.
+            Assert.That(receiver.actions, Is.Null);
+            Assert.That(receiver.user.id, Is.EqualTo(InputUser.InvalidId));
+
+            var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+            var mapName = "test";
+            asset.AddActionMap(mapName);
+            receiver.actions = asset;
+
+            // user.id is not InputUser.InvalidId after set actions parameter.
+            Assert.That(receiver.actions, Is.Not.Null);
+            Assert.That(receiver.user.id, Is.EqualTo(InputUser.InvalidId));
+
+            UnityEngine.Object.DestroyImmediate(go);
+        }
     }
 }


### PR DESCRIPTION
When using Android device, we got assersion from Input System package below.
```
Could not find active control after binding resolution
    UnityEngine.DebugLogHandler:LogFormat(LogType, Object, String, Object[])
    UnityEngine.Logger:Log(LogType, Object)
    UnityEngine.Debug:Assert(Boolean, String)
    UnityEngine.InputSystem.InputActionState:RestoreActionStatesAfterReResolvingBindings(UnmanagedMemory, InputControlList`1, Boolean)
    UnityEngine.InputSystem.InputActionState:FinishBindingResolution(Boolean, UnmanagedMemory, InputControlList`1, Boolean)
    UnityEngine.InputSystem.InputActionMap:ResolveBindings()
    UnityEngine.InputSystem.InputActionMap:LazyResolveBindings(Boolean)
    UnityEngine.InputSystem.InputActionState:OnDeviceChange(InputDevice, InputDeviceChange)
    UnityEngine.InputSystem.InputManager:AddDevice(InputDevice)
    UnityEngine.InputSystem.InputManager:AddDevice(String, String, InternedString)
    UnityEngine.InputSystem.InputSystem:AddDevice(String, String, String)
    Unity.RenderStreaming.InputSystem.InputManager:AddDevice(String, String, String)
    Unity.RenderStreaming.InputSystem.Receiver:AddDevice(String
```

The line of the assersion is [here](https://github.com/Unity-Technologies/InputSystem/blob/f3b9bc9f4866b7361bb85664846438af7d00ae67/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs#L631). 
It assume that the cause of this error is some processing input controls are remained when adding/removing input devices.

To avoid this assertion, this PR calls `InputSystem.ResetDevice` before callaing `InputSystem.AddDevice` or `InputSystem.RemoveDevice`.