### PR TITLE
fix: Add autocomplete attribute into input elements to avoid issue of "disabled" attribute on Firefox

### DIFF
--- a/WebApp/client/public/bidirectional/index.html
+++ b/WebApp/client/public/bidirectional/index.html
@@ -16,23 +16,24 @@
     <div id="warning" hidden=true></div>
 
     <div id="select">
-      <label for="videoSource">Video source: </label><select id="videoSource"></select>
-      <label for="audioSource">Audio source: </label><select id="audioSource"></select>
+      <label for="videoSource">Video source: </label>
+      <select id="videoSource" autocomplete="off"></select>
+      <label for="audioSource">Audio source: </label>
+      <select id="audioSource" autocomplete="off"></select>
     </div>
 
     <div id="resolutionSelect">
-      <label for="videoResolution">Video resolution: </label><select id="videoResolution"></select>
+      <label for="videoResolution">Video resolution: </label><select id="videoResolution" autocomplete="off"></select>
     </div>
     <div id="resolutionInput">
-      <label for="cameraWidth">Camera width:</label><input id="cameraWidth" type="number" min="0" max="4096" disabled>
-      <label for="cameraHeight">Camera height:</label><input id="cameraHeight" type="number" min="0" max="4096"
-        disabled>
+      <label for="cameraWidth">Camera width:</label><input id="cameraWidth" type="number" min="0" max="4096" autocomplete="off" disabled>
+      <label for="cameraHeight">Camera height:</label><input id="cameraHeight" type="number" min="0" max="4096" autocomplete="off" disabled>
     </div>
 
     <div id="buttons">
-      <button type="button" id="startVideoButton">Start Video</button>
-      <button type="button" id="setUpButton" disabled>Set Up</button>
-      <button type="button" id="hangUpButton" disabled>Hang Up</button>
+      <button type="button" id="startVideoButton" autocomplete="off">Start Video</button>
+      <button type="button" id="setUpButton" autocomplete="off" disabled>Set Up</button>
+      <button type="button" id="hangUpButton"  autocomplete="off" disabled>Hang Up</button>
     </div>
 
     <div id="preview">
@@ -54,7 +55,7 @@
     </div>
     <div class="box">
       <span>Codec preferences:</span>
-      <select id="codecPreferences" disabled>
+      <select id="codecPreferences" autocomplete="off" disabled>
         <option selected value="">Default</option>
       </select>
     </div>

--- a/WebApp/client/public/bidirectional/js/main.js
+++ b/WebApp/client/public/bidirectional/js/main.js
@@ -110,7 +110,7 @@ async function setUp() {
   renderstreaming.onConnect = () => {
     const tracks = sendVideo.getLocalTracks();
     for (const track of tracks) {
-      renderstreaming.addTrack(track);
+      renderstreaming.addTransceiver(track, { direction: 'sendonly' });
     }
     setCodecPreferences();
     showStatsMessage();

--- a/WebApp/client/public/bidirectional/js/main.js
+++ b/WebApp/client/public/bidirectional/js/main.js
@@ -57,6 +57,12 @@ setupButton.addEventListener('click', setUp);
 const hangUpButton = document.getElementById('hangUpButton');
 hangUpButton.addEventListener('click', hangUp);
 
+window.addEventListener('beforeunload', async () => {
+  if(!renderstreaming)
+    return;
+  await renderstreaming.stop();
+}, true);
+
 setupConfig();
 
 async function setupConfig() {
@@ -124,10 +130,6 @@ async function setUp() {
       sendVideo.addRemoteTrack(data.track);
     }
   };
-
-  window.addEventListener('beforeunload', async () => {
-    await renderstreaming.stop();
-  }, true);
 
   await renderstreaming.start();
   await renderstreaming.createConnection(connectionId);

--- a/WebApp/client/public/multiplay/index.html
+++ b/WebApp/client/public/multiplay/index.html
@@ -20,14 +20,14 @@
 
     <div class="box">
       <span>Codec preferences:</span>
-      <select id="codecPreferences" disabled>
+      <select id="codecPreferences" autocomplete="off" disabled>
         <option selected value="">Default</option>
       </select>
     </div>
 
     <div class="box">
       <span>Lock Cursor to Player:</span>
-      <input type="checkbox" id="lockMouseCheck">
+      <input type="checkbox" id="lockMouseCheck" autocomplete="off" />
     </div>
 
     <p>

--- a/WebApp/client/public/multiplay/js/main.js
+++ b/WebApp/client/public/multiplay/js/main.js
@@ -39,6 +39,8 @@ window.addEventListener('resize', function () {
 }, true);
 
 window.addEventListener('beforeunload', async () => {
+  if(!renderstreaming)
+    return;
   await renderstreaming.stop();
 }, true);
 

--- a/WebApp/client/public/receiver/index.html
+++ b/WebApp/client/public/receiver/index.html
@@ -20,18 +20,18 @@
 
     <div class="box">
       <span>Codec preferences:</span>
-      <select id="codecPreferences" disabled>
+      <select id="codecPreferences" autocomplete="off" disabled>
         <option selected value="">Default</option>
       </select>
     </div>
 
     <div class="box">
       <span>Lock Cursor to Player:</span>
-      <input type="checkbox" id="lockMouseCheck">
+      <input type="checkbox" id="lockMouseCheck" autocomplete="off" />
     </div>
 
     <p>
-      For more information about sample, see 
+      For more information about sample, see
         <a href="https://docs.unity3d.com/Packages/com.unity.renderstreaming@3.1/manual/sample-broadcast.html">Broadcast sample</a> document page.
     </p>
 

--- a/WebApp/client/src/peer.js
+++ b/WebApp/client/src/peer.js
@@ -180,7 +180,7 @@ export default class Peer extends EventTarget {
     try {
       await this.pc.addIceCandidate(candidate);
     } catch (e) {
-      if (this.pc && !this.ignoreOffer) 
+      if (this.pc && !this.ignoreOffer)
         this.warn(`${this.pc} this candidate can't accept current signaling state ${this.pc.signalingState}.`);
     }
   }

--- a/WebApp/client/src/renderstreaming.js
+++ b/WebApp/client/src/renderstreaming.js
@@ -165,6 +165,11 @@ export class RenderStreaming {
     return this._peer.addTrack(this._connectionId, track);
   }
 
+  addTransceiver(track, init) {
+    return this._peer.addTransceiver(this._connectionId, track, init);
+  }
+
+
   /**
    * @returns {RTCRtpTransceiver[] | null}
    */

--- a/WebApp/client/src/renderstreaming.js
+++ b/WebApp/client/src/renderstreaming.js
@@ -165,8 +165,13 @@ export class RenderStreaming {
     return this._peer.addTrack(this._connectionId, track);
   }
 
-  addTransceiver(track, init) {
-    return this._peer.addTransceiver(this._connectionId, track, init);
+  /**
+   * @param {MediaStreamTrack | string} trackOrKind
+   * @param {RTCRtpTransceiverInit | null} init
+   * @returns {RTCRtpTransceiver | null}
+   */
+  addTransceiver(trackOrKind, init) {
+    return this._peer.addTransceiver(this._connectionId, trackOrKind, init);
   }
 
 


### PR DESCRIPTION
HTML attribute `disabled` behaves differently on firefox and others.

## How to reproduce

1. Open "Bidirectional" page.
2. You can see the "Set Up" button is disabled at first.
3. Push "Start Video" button, and "Set Up" button is changed to enabled.
4. Refreah the web page, the "Set Up" buton should be returned to disabled.

## Google Chrome 108
https://user-images.githubusercontent.com/1132081/211533091-35cedcd5-1cb8-40d5-a5b8-05df8527a291.mp4

## Firefox 108
https://user-images.githubusercontent.com/1132081/211533061-792fba05-d75d-4a3a-bee4-173dbf40e105.mp4

Surprisingly, this issue has been reported since 12 years ago.
https://bugzilla.mozilla.org/show_bug.cgi?id=654072

We can avoid this issue with `autocomplete="off"`. That's insane.