### PR TITLE
fix: websocket is in default as a signaling protocol

### DIFF
--- a/WebApp/client/test/signaling.test.js
+++ b/WebApp/client/test/signaling.test.js
@@ -28,8 +28,8 @@ describe.each([
     } else {
       const path = Path.resolve(`../bin~/${serverExeName()}`);
       let cmd = `${path} -p ${portNumber}`;
-      if (mode == "websocket") {
-        cmd += " -w";
+      if (mode == "http") {
+        cmd += " -t http";
       }
 
       await setup({ command: cmd, port: portNumber, usedPortAction: 'error' });
@@ -228,8 +228,8 @@ describe.each([
 
     const path = Path.resolve(`../bin~/${serverExeName()}`);
     let cmd = `${path} -p ${portNumber} -m private`;
-    if (mode == "websocket") {
-      cmd += " -w";
+    if (mode == "http") {
+      cmd += " -t http";
     }
 
     await setup({ command: cmd, port: portNumber, usedPortAction: 'error' });

--- a/WebApp/src/class/options.ts
+++ b/WebApp/src/class/options.ts
@@ -3,7 +3,7 @@ export default interface Options {
   port?: number;
   keyfile?: string;
   certfile?: string;
-  websocket?: boolean;
+  type?: string;
   mode?: string;
   logging?: string;
 }

--- a/WebApp/src/index.ts
+++ b/WebApp/src/index.ts
@@ -20,7 +20,7 @@ export class RenderStreaming {
           .option('-s, --secure', 'Enable HTTPS (you need server.key and server.cert)', process.env.SECURE || false)
           .option('-k, --keyfile <path>', 'https key file (default server.key)', process.env.KEYFILE || 'server.key')
           .option('-c, --certfile <path>', 'https cert file (default server.cert)', process.env.CERTFILE || 'server.cert')
-          .option('-w, --websocket', 'Enable Websocket Signaling', process.env.WEBSOCKET || false)
+          .option('-t, --type <type>', 'Type of signaling protocol, Choose websocket or http (default websocket)', process.env.TYPE || 'websocket')
           .option('-m, --mode <type>', 'Choose Communication mode public or private (default public)', process.env.MODE || 'public')
           .option('-l, --logging <type>', 'Choose http logging type combined, dev, short, tiny or none.(default dev)', process.env.LOGGING || 'dev')
           .parse(argv);
@@ -30,7 +30,7 @@ export class RenderStreaming {
           secure: option.secure == undefined ? false : option.secure,
           keyfile: option.keyfile,
           certfile: option.certfile,
-          websocket: option.websocket == undefined ? false : option.websocket,
+          type: option.type == undefined ? 'websocket' : option.type,
           mode: option.mode,
           logging: option.logging,
         };
@@ -69,9 +69,17 @@ export class RenderStreaming {
         }
       });
     }
+    if (this.options.type == 'http') {
+      console.log(`Use http polling for signaling server.`);
+    }
+    else if(this.options.type != 'websocket') {
+      console.log(`signaling type should be set "websocket" or "http". ${this.options.type} is not supported.`);
+      console.log(`Changing signaling type to websocket.`);
+      this.options.type = 'websocket';
+    }
+    if (this.options.type == 'websocket') {
+      console.log(`Use websocket for signaling server ws://${this.getIPAddress()[0]}`);
 
-    if (this.options.websocket) {
-      console.log(`start websocket signaling server ws://${this.getIPAddress()[0]}`);
       //Start Websocket Signaling server
       new WSSignaling(this.server, this.options.mode);
     }

--- a/WebApp/src/server.ts
+++ b/WebApp/src/server.ts
@@ -17,7 +17,7 @@ export const createServer = (config: Options): express.Application => {
   // const signal = require('./signaling');
   app.use(express.urlencoded({ extended: true }));
   app.use(express.json());
-  app.get('/config', (req, res) => res.json({ useWebSocket: config.websocket, startupMode: config.mode, logging: config.logging }));
+  app.get('/config', (req, res) => res.json({ useWebSocket: config.type == 'websocket', startupMode: config.mode, logging: config.logging }));
   app.use('/signaling', signaling);
   app.use(express.static(path.join(__dirname, '../client/public')));
   app.use('/module', express.static(path.join(__dirname, '../client/src')));

--- a/com.unity.renderstreaming/CHANGELOG.md
+++ b/com.unity.renderstreaming/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to com.unity.renderstreaming package will be documented in t
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.0-exp.6] - Unreleased
+
+### Changed
+
+- Websocket is in default for signaling protocol instead of HTTP polling.
+
 ## [3.1.0-exp.5] - 2022-12-22
 
 ### Changed

--- a/com.unity.renderstreaming/CHANGELOG.md
+++ b/com.unity.renderstreaming/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to com.unity.renderstreaming package will be documented in t
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.1.0-exp.6] - Unreleased
+## [3.1.0-exp.6] - [Unreleased]
 
 ### Changed
 

--- a/com.unity.renderstreaming/CHANGELOG.md
+++ b/com.unity.renderstreaming/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to com.unity.renderstreaming package will be documented in t
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.1.0-exp.6] - [Unreleased]
+## [Unreleased]
 
 ### Changed
 

--- a/com.unity.renderstreaming/Documentation~/launch-webapp.md
+++ b/com.unity.renderstreaming/Documentation~/launch-webapp.md
@@ -1,6 +1,6 @@
 # Launching The Web Application
 
-After installing the package, you will need to install and run the signaling server. If you want to learn about signaling, you can see [this page](overview.md). 
+After installing the package, you will need to install and run the signaling server. If you want to learn about signaling, you can see [this page](overview.md).
 
 ## Download web application
 
@@ -18,7 +18,7 @@ When the select download folder window appears, click on `Select Folder` to down
 After the download is finished and a `powershell` or `cmd` window is opened, and run `webserver.exe` with `-w` option. Please refer to [this page](webapp.md) for commandline options.
 
 ```
-.\webserver.exe -w
+.\webserver.exe
 ```
 
 You can see logs on the commandline like below.

--- a/com.unity.renderstreaming/Documentation~/signaling-type.md
+++ b/com.unity.renderstreaming/Documentation~/signaling-type.md
@@ -13,11 +13,11 @@ In the example, the schema given to `URL Signaling` is used to determine which t
 If it starts with `http`, `Http Signaling` is used. If it starts with `ws`, `WebSocket Signaling` is used.
 
 ```
-# launch server for HTTP
-webserver.exe 
-
 # launch server for WebSocket
-webserver.exe -w
+webserver.exe
+
+# launch server for HTTP
+webserver.exe -t http
 ```
 
 ## `Http Signaling`

--- a/com.unity.renderstreaming/Documentation~/webapp.md
+++ b/com.unity.renderstreaming/Documentation~/webapp.md
@@ -1,9 +1,9 @@
 # Web Application
 
-The **Web application** 
+The **Web application**
 
 - handles signaling between Unity and the Web browser
-- is the location of the Web page 
+- is the location of the Web page
 
 ## The Web Client
 
@@ -25,16 +25,16 @@ After downloading, run it from the command line.
 
 ### Command Options
 
-| Option                    | Details                                            | Default       |
-| ------------------------- | -------------------------------------------------- | ------------- |
-| `-h` `--help`             | Show the help menu                                 |               |
-| `-p` `—port \<number\>`   | Set the port number                                | `80`          |
-| `-s` `--secure`           | Use https                                          |               |
-| `-k` `—keyfile \<path\>`  | Designate the private key file to use with https   | `server.key`  |
+| Option | Details | Default |
+| ------ | ------- | ------- |
+| `-h` `--help` | Show the help menu | |
+| `-p` `—port \<number\>` | Set the port number | `80` |
+| `-s` `--secure` | Use https | |
+| `-k` `—keyfile \<path\>`  | Designate the private key file to use with https | `server.key` |
 | `-c` `—certfile \<path\>` | Designate the certification file to use with https | `server.cert` |
-| `-w` `--websocket`        | Use Websocket as signaling protocol                |               |
-| `-m` `—-mode \<type\>`    | Choose Communication mode public or private        | `public`      |
-| `-l` `—logging \<type\>`  | Choose http logging type (use [morgan](https://www.npmjs.com/package/morgan) library)      | `dev`         |
+| `-t` `--type \<type\>` | Type of signaling protocol, Choose websocket or http | `websocket` |
+| `-m` `—-mode \<type\>` | Choose Communication mode public or private | `public` |
+| `-l` `—logging \<type\>` | Choose http logging type (use [morgan](https://www.npmjs.com/package/morgan) library) | `dev` |
 
 ### Command Examples
 
@@ -50,13 +50,13 @@ This command will run the server as https. Port 443 will be used. A certificate 
 .\webserver -s -p 443
 ```
 
-The command will run in the mode that uses WebSocket as the signaling protocol.
+The command will run in the mode that uses **HTTP polling** as the signaling protocol.
 
 ```shell
-.\webserver -w
+.\webserver -t http
 ```
 
-The command will run in private mode. 
+The command will run in private mode.
 
 ```shell
 .\webserver -m private
@@ -66,7 +66,7 @@ The command will run in private mode.
 
 
 When running a https server, keep in mind to set the `URL signaling` property of the Renderstreaming component in Unity to https as well.
-Use this command to display the help guide. 
+Use this command to display the help guide.
 
 ```shell
 .\webserver -h

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -91,9 +91,9 @@ namespace Unity.RenderStreaming.RuntimeTest
 
             string arguments = $"-m private -p {TestUtility.PortNumber}";
 
-            if (m_SignalingType == typeof(WebSocketSignaling))
+            if (m_SignalingType == typeof(HttpSignaling))
             {
-                arguments += " -w";
+                arguments += " -t http";
             }
 
             startInfo.Arguments = arguments;

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
@@ -88,9 +88,9 @@ namespace Unity.RenderStreaming.RuntimeTest
 
             string arguments = $"-p {TestUtility.PortNumber}";
 
-            if (m_SignalingType == typeof(WebSocketSignaling))
+            if (m_SignalingType == typeof(HttpSignaling))
             {
-                arguments += " -w";
+                arguments += " -t http";
             }
 
             startInfo.Arguments = arguments;


### PR DESCRIPTION
We provided the signaling server which use HTTP polling as a signaling messaging protocol in default. This PR changes websocket the default messaging protocol. Comparing the response of messaging, websocket is faster than HTTP polling.

And the command line option is changed. `-type` or `-type` option is added in this PR. You can make command below If you want to change the type of signaling protocol to HTTP polling, 

```
webserver.exe -t http
```

```
webserver.exe -type http
```