### PR TITLE
fix: Remove method calling Unity API to avoid UnityException

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/StreamReceiverBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/StreamReceiverBase.cs
@@ -36,8 +36,6 @@ namespace Unity.RenderStreaming
         {
             get
             {
-                if (!Application.isPlaying)
-                    return false;
                 if (string.IsNullOrEmpty(Transceiver.Mid))
                     return false;
                 if (Transceiver.Sender.Track.ReadyState == TrackState.Ended)

--- a/com.unity.renderstreaming/Runtime/Scripts/StreamSenderBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/StreamSenderBase.cs
@@ -113,8 +113,6 @@ namespace Unity.RenderStreaming
         {
             get
             {
-                if (!Application.isPlaying)
-                    return false;
                 foreach (var transceiver in Transceivers.Values)
                 {
                     if (string.IsNullOrEmpty(transceiver.Mid))


### PR DESCRIPTION
Fixed issue that throwing UnityException when calling `AudioStreamSender.SetData` method on worker thread.
The exception is below.

```
UnityException: get_isPlaying can only be called from the main thread.
```