### PR TITLE
feat: Define IceServer class to control signaling settings with APIs

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
@@ -36,14 +36,13 @@ namespace Unity.RenderStreaming
             // todo: load from assets
             var settings = ScriptableObject.CreateInstance<RenderStreamingSettings>();
             settings.automaticStreaming = false;
-            var signalingSettings = new WebSocketSignalingSettings
-            {
-                urlSignaling = "ws://127.0.0.1:80",
-                iceServers = new RTCIceServer[]
+            var signalingSettings = new WebSocketSignalingSettings(
+                url: "ws://127.0.0.1:80",
+                iceServers: new[]
                 {
-                    new RTCIceServer() {urls = new string[] {"stun:stun.l.google.com:19302"}}
+                    new IceServer(urls: new[] {"stun:stun.l.google.com:19302"})
                 }
-            };
+            );
             settings.signalingSettings = signalingSettings;
             s_settings = settings;
         }

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingHandler.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingHandler.cs
@@ -17,14 +17,14 @@ namespace Unity.RenderStreaming
     {
 #pragma warning disable 0649
         // ToDo: Create component UI on URS-553
-        [SerializeReference] private SignalingSettings signalingSettings = new WebSocketSignalingSettings
-        {
-            urlSignaling = "ws://127.0.0.1:80",
-            iceServers = new RTCIceServer[]
+        [SerializeReference]
+        private SignalingSettings signalingSettings = new WebSocketSignalingSettings(
+            url: "ws://127.0.0.1:80",
+            iceServers: new IceServer[]
             {
-                new RTCIceServer() {urls = new string[] {"stun:stun.l.google.com:19302"}}
+                new IceServer(urls: new[] {"stun:stun.l.google.com:19302"})
             }
-        };
+         );
 
         [SerializeField, Tooltip("List of handlers of signaling process.")]
         private List<SignalingHandlerBase> handlers = new List<SignalingHandlerBase>();
@@ -143,13 +143,9 @@ namespace Unity.RenderStreaming
             SignalingHandlerBase[] handlers = null
             )
         {
+            RTCIceServer[] iceServers = signalingSettings.iceServers.Cast<RTCIceServer>().ToArray();
             RTCConfiguration _conf =
-                conf.GetValueOrDefault(new RTCConfiguration { iceServers = signalingSettings.iceServers });
-
-            if (signaling != null)
-            {
-                signalingSettings.urlSignaling = signaling.Url;
-            }
+                conf.GetValueOrDefault(new RTCConfiguration { iceServers = iceServers });
 
             ISignaling _signaling = signaling ?? CreateSignaling(signalingSettings, SynchronizationContext.Current);
             RenderStreamingDependencies dependencies = new RenderStreamingDependencies
@@ -187,10 +183,11 @@ namespace Unity.RenderStreaming
 
         void Awake()
         {
-            if (!runOnAwake || m_running　|| handlers.Count == 0)
+            if (!runOnAwake || m_running || handlers.Count == 0)
                 return;
 
-            RTCConfiguration conf = new RTCConfiguration { iceServers = signalingSettings.iceServers };
+            RTCIceServer[] iceServers = signalingSettings.iceServers.Cast<RTCIceServer>().ToArray();
+            RTCConfiguration conf = new RTCConfiguration { iceServers = iceServers };
             ISignaling signaling = CreateSignaling(signalingSettings, SynchronizationContext.Current);
             _Run(conf, signaling, handlers.ToArray());
         }

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingHandler.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingHandler.cs
@@ -143,7 +143,7 @@ namespace Unity.RenderStreaming
             SignalingHandlerBase[] handlers = null
             )
         {
-            RTCIceServer[] iceServers = signalingSettings.iceServers.Cast<RTCIceServer>().ToArray();
+            RTCIceServer[] iceServers = signalingSettings.iceServers.OfType<RTCIceServer>().ToArray();
             RTCConfiguration _conf =
                 conf.GetValueOrDefault(new RTCConfiguration { iceServers = iceServers });
 

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
@@ -24,7 +24,7 @@ namespace Unity.RenderStreaming.Signaling
 
         public HttpSignaling(SignalingSettings signalingSettings, SynchronizationContext mainThreadContext)
         {
-            m_url = signalingSettings.urlSignaling;
+            m_url = signalingSettings.url;
             m_timeout = ((HttpSignalingSettings) signalingSettings).interval;
             m_mainThreadContext = mainThreadContext;
 

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignaling.cs
@@ -22,7 +22,7 @@ namespace Unity.RenderStreaming.Signaling
 
         public WebSocketSignaling(SignalingSettings signalingSettings, SynchronizationContext mainThreadContext)
         {
-            m_url = signalingSettings.urlSignaling;
+            m_url = signalingSettings.url;
             m_timeout = 5.0f;
             m_mainThreadContext = mainThreadContext;
             m_wsCloseEvent = new AutoResetEvent(false);

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingSettings.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingSettings.cs
@@ -134,7 +134,7 @@ namespace Unity.RenderStreaming
         public HttpSignalingSettings(string url, IceServer[] iceServers = null, float interval = 5.0f)
         {
             m_url = url;
-            m_iceServers = iceServers.Select(server => server.Clone()).ToArray();
+            m_iceServers = iceServers?.Select(server => server.Clone()).ToArray();
             m_interval = interval;
         }
     }
@@ -159,7 +159,7 @@ namespace Unity.RenderStreaming
         public FurioosSignalingSettings(string url, IceServer[] iceServers = null)
         {
             m_url = url;
-            m_iceServers = iceServers.Select(server => server.Clone()).ToArray();
+            m_iceServers = iceServers?.Select(server => server.Clone()).ToArray();
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingSettings.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingSettings.cs
@@ -1,28 +1,171 @@
 using System;
+using System.Linq;
 using Unity.RenderStreaming.Signaling;
+using Unity.WebRTC;
+using UnityEngine;
+using UnityEngine.InputSystem.Utilities;
 
 namespace Unity.RenderStreaming
 {
-    public abstract class SignalingSettings
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum IceCredentialType
     {
-        public string urlSignaling = "http://127.0.0.1:80";
-        public WebRTC.RTCIceServer[] iceServers;
-        public abstract Type signalingClass { get; }
+        /// <summary>
+        /// 
+        /// </summary>
+        Password = 0,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        OAuth = 1
     }
 
+    /// <summary>
+    /// 
+    /// </summary>
+    [Serializable]
+    public class IceServer
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public ReadOnlyArray<string> urls => m_urls;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string username => m_username;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IceCredentialType credentialType => m_credentialType;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public string credential => m_credential;
+
+        [SerializeField]
+        private string[] m_urls;
+        [SerializeField]
+        private string m_username;
+        [SerializeField]
+        private IceCredentialType m_credentialType;
+        [SerializeField]
+        private string m_credential;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="server"></param>
+        public static implicit operator RTCIceServer(IceServer server)
+        {
+            var iceServer = new RTCIceServer
+            {
+                urls = server.urls.ToArray(),
+                username = server.username,
+                credential = server.credential,
+                credentialType = (RTCIceCredentialType)server.credentialType
+            };
+            return iceServer;
+        }
+
+        public IceServer Clone()
+        {
+            return new IceServer()
+            {
+                m_urls = this.urls.ToArray(),
+                m_username = this.username,
+                m_credentialType = this.credentialType,
+                m_credential = this.credential
+            };
+        }
+
+        internal IceServer(string[] urls = null, string username = null, string credential = null, IceCredentialType credentialType = IceCredentialType.Password)
+        {
+            m_urls = urls?.ToArray();
+            m_username = username;
+            m_credential = credential;
+            m_credentialType = credentialType;
+        }
+
+        internal IceServer(RTCIceServer server)
+        {
+            m_urls = server.urls;
+            m_username = server.username;
+            m_credential = server.credential;
+            m_credentialType = (IceCredentialType)server.credentialType;
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public abstract class SignalingSettings
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string url => m_url;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ReadOnlyArray<IceServer> iceServers => m_iceServers;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public abstract Type signalingClass { get; }
+
+        [SerializeField]
+        protected string m_url = "http://127.0.0.1:80";
+        [SerializeField]
+        protected IceServer[] m_iceServers;
+    }
+
+    [Serializable]
     public class HttpSignalingSettings : SignalingSettings
     {
         public override Type signalingClass => typeof(HttpSignaling);
-        public float interval = 5.0f;
+        public float interval => m_interval;
+
+        [SerializeField]
+        private float m_interval;
+
+        public HttpSignalingSettings(string url, IceServer[] iceServers = null, float interval = 5.0f)
+        {
+            m_url = url;
+            m_iceServers = iceServers.Select(server => server.Clone()).ToArray();
+            m_interval = interval;
+        }
     }
 
+    [Serializable]
     public class WebSocketSignalingSettings : SignalingSettings
     {
         public override Type signalingClass => typeof(WebSocketSignaling);
+
+        public WebSocketSignalingSettings(string url, IceServer[] iceServers = null)
+        {
+            m_url = url;
+            m_iceServers = iceServers.Select(server => server.Clone()).ToArray();
+        }
     }
 
+    [Serializable]
     public class FurioosSignalingSettings : SignalingSettings
     {
         public override Type signalingClass => typeof(FurioosSignaling);
+
+        public FurioosSignalingSettings(string url, IceServer[] iceServers = null)
+        {
+            m_url = url;
+            m_iceServers = iceServers.Select(server => server.Clone()).ToArray();
+        }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingSettings.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingSettings.cs
@@ -76,16 +76,10 @@ namespace Unity.RenderStreaming
 
         public IceServer Clone()
         {
-            return new IceServer()
-            {
-                m_urls = this.urls.ToArray(),
-                m_username = this.username,
-                m_credentialType = this.credentialType,
-                m_credential = this.credential
-            };
+            return new IceServer(this.urls.ToArray(), this.username, this.credentialType, this.credential);
         }
 
-        internal IceServer(string[] urls = null, string username = null, string credential = null, IceCredentialType credentialType = IceCredentialType.Password)
+        public IceServer(string[] urls = null, string username = null, IceCredentialType credentialType = IceCredentialType.Password, string credential = null)
         {
             m_urls = urls?.ToArray();
             m_username = username;
@@ -95,7 +89,7 @@ namespace Unity.RenderStreaming
 
         internal IceServer(RTCIceServer server)
         {
-            m_urls = server.urls;
+            m_urls = server.urls.ToArray();
             m_username = server.username;
             m_credential = server.credential;
             m_credentialType = (IceCredentialType)server.credentialType;

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingSettings.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingSettings.cs
@@ -147,7 +147,7 @@ namespace Unity.RenderStreaming
         public WebSocketSignalingSettings(string url, IceServer[] iceServers = null)
         {
             m_url = url;
-            m_iceServers = iceServers.Select(server => server.Clone()).ToArray();
+            m_iceServers = iceServers?.Select(server => server.Clone()).ToArray();
         }
     }
 

--- a/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
@@ -70,28 +70,28 @@ namespace Unity.RenderStreaming.Samples
                     {
                         var schema = signalingSecured ? "https" : "http";
                         var settings = new FurioosSignalingSettings
-                        {
-                            urlSignaling = $"{schema}://{signalingAddress}"
-                        };
+                        (
+                            url: $"{schema}://{signalingAddress}"
+                        );
                         return new FurioosSignaling(settings, SynchronizationContext.Current);
                     }
                     case SignalingType.WebSocket:
                     {
                         var schema = signalingSecured ? "wss" : "ws";
                         var settings = new WebSocketSignalingSettings
-                        {
-                            urlSignaling = $"{schema}://{signalingAddress}"
-                        };
+                        (
+                            url: $"{schema}://{signalingAddress}"
+                        );
                         return new WebSocketSignaling(settings, SynchronizationContext.Current);
                     }
                     case SignalingType.Http:
                     {
                         var schema = signalingSecured ? "https" : "http";
                         var settings = new HttpSignalingSettings
-                        {
-                            urlSignaling = $"{schema}://{signalingAddress}",
-                            interval = signalingInterval
-                        };
+                        (
+                            url: $"{schema}://{signalingAddress}",
+                            interval: signalingInterval
+                        );
                         return new FurioosSignaling(settings, SynchronizationContext.Current);
                     }
                 }

--- a/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PrivateSignalingTest.cs
@@ -133,19 +133,19 @@ namespace Unity.RenderStreaming.RuntimeTest
             if (type == typeof(WebSocketSignaling))
             {
                 var settings = new WebSocketSignalingSettings
-                {
-                    urlSignaling = $"ws://localhost:{TestUtility.PortNumber}"
-                };
+                (
+                    url: $"ws://localhost:{TestUtility.PortNumber}"
+                );
                 return new WebSocketSignaling(settings, mainThread);
             }
 
             if (type == typeof(HttpSignaling))
             {
                 var settings = new HttpSignalingSettings
-                {
-                    urlSignaling = $"http://localhost:{TestUtility.PortNumber}",
-                    interval = 0.1f
-                };
+                (
+                    url: $"http://localhost:{TestUtility.PortNumber}",
+                    interval: 0.1f
+                );
                 return new HttpSignaling(settings, mainThread);
             }
 

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingTest.cs
@@ -119,19 +119,19 @@ namespace Unity.RenderStreaming.RuntimeTest
             if (type == typeof(WebSocketSignaling))
             {
                 var settings = new WebSocketSignalingSettings
-                {
-                    urlSignaling = $"ws://localhost:{TestUtility.PortNumber}"
-                };
+                (
+                    url: $"ws://localhost:{TestUtility.PortNumber}"
+                );
                 return new WebSocketSignaling(settings, mainThread);
             }
 
             if (type == typeof(HttpSignaling))
             {
                 var settings = new HttpSignalingSettings
-                {
-                    urlSignaling = $"http://localhost:{TestUtility.PortNumber}",
-                    interval = 0.1f
-                };
+                (
+                    url:  $"http://localhost:{TestUtility.PortNumber}",
+                    interval: 0.1f
+                );
                 return new HttpSignaling(settings, mainThread);
             }
 

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -369,7 +369,7 @@ namespace Unity.RenderStreaming.RuntimeTest
 
         // workaround(kazuki): Fix NullReferenceException in AudioStreamTrack.ProcessAudio.
         [UnityTest]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer})]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxEditor})]
         public IEnumerator ReplaceTrack()
         {
             var go = new GameObject();

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -367,7 +367,9 @@ namespace Unity.RenderStreaming.RuntimeTest
             UnityEngine.Object.DestroyImmediate(go3);
         }
 
+        // workaround(kazuki): Fix NullReferenceException in AudioStreamTrack.ProcessAudio.
         [UnityTest]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer})]
         public IEnumerator ReplaceTrack()
         {
             var go = new GameObject();

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -369,7 +369,7 @@ namespace Unity.RenderStreaming.RuntimeTest
 
         // workaround(kazuki): Fix NullReferenceException in AudioStreamTrack.ProcessAudio.
         [UnityTest]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxEditor})]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxEditor, RuntimePlatform.LinuxPlayer })]
         public IEnumerator ReplaceTrack()
         {
             var go = new GameObject();


### PR DESCRIPTION
This PR defines `IceServer` class which manages STUN/TURN configuraiton. Before that, Inspector window is a only place to change configuration of ICE server. We can make new APIs for managing ICE server with this class.