### PR TITLE
feat: Add command line option for stanadlone app

### DIFF
--- a/com.unity.renderstreaming/Editor/RenderStreamingSettings.asset
+++ b/com.unity.renderstreaming/Editor/RenderStreamingSettings.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc8ba17751ad4107a50fa1415017b6b1, type: 3}
+  m_Name: RenderStreamingSettings
+  m_EditorClassIdentifier: 
+  automaticStreaming: 0
+  signalingSettings:
+    id: 0
+  references:
+    version: 1
+    00000000:
+      type: {class: WebSocketSignalingSettings, ns: Unity.RenderStreaming, asm: Unity.RenderStreaming}
+      data:
+        m_url: ws://127.0.0.1:80
+        m_iceServers:
+        - m_urls:
+          - stun:stun.l.google.com:19302
+          m_username: 
+          m_credentialType: 0
+          m_credential: 

--- a/com.unity.renderstreaming/Editor/RenderStreamingSettings.asset.meta
+++ b/com.unity.renderstreaming/Editor/RenderStreamingSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63a426df4894b1f4b94574475120a261
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Editor/SignalingManagerEditor.cs
+++ b/com.unity.renderstreaming/Editor/SignalingManagerEditor.cs
@@ -53,6 +53,7 @@ namespace Unity.RenderStreaming.Editor
             }
             root.Add(new ReorderableListField(serializedObject.FindProperty("handlers"), "Signaling Handler List"));
             root.Add(new PropertyField(serializedObject.FindProperty("runOnAwake"), "Run On Awake"));
+            root.Add(new PropertyField(serializedObject.FindProperty("evaluateCommandlineArguments"), "Evaluate Commandline Arguments"));
 
             EditorApplication.projectChanged += OnProjectChanged;
 

--- a/com.unity.renderstreaming/Runtime/Scripts/CommandLineParser.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/CommandLineParser.cs
@@ -1,0 +1,280 @@
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Unity.RenderStreaming.Signaling;
+using Unity.WebRTC;
+using UnityEngine;
+
+namespace Unity.RenderStreaming
+{
+    [Serializable]
+    internal struct CommandLineInfo
+    {
+        public string signalingType;
+        public string signalingUrl;
+        public RTCIceServer[] iceServers;
+        public string pollingInterval;
+    }
+
+    static class CommandLineParser
+    {
+        internal static readonly StringArgument SignalingUrl = new StringArgument("-signalingUrl");
+        internal static readonly StringArgument SignalingType = new StringArgument("-signalingType");
+        internal static readonly StringArrayArgument IceServerUrls = new StringArrayArgument("-iceServerUrl");
+        internal static readonly StringArgument IceServerUsername = new StringArgument("-iceServerUsername");
+        internal static readonly StringArgument IceServerCredential = new StringArgument("-iceServerCredential");
+        internal static readonly EnumArgument<IceCredentialType> IceServerCredentialType = new EnumArgument<IceCredentialType>("-iceServerCredentialType");
+        internal static readonly IntArgument PollingInterval = new IntArgument("-pollingInterval");
+        internal static readonly JsonFileArgument<CommandLineInfo> ImportJson = new JsonFileArgument<CommandLineInfo>("-importJson");
+
+        static readonly List<IArgument> options = new List<IArgument>() { SignalingUrl, SignalingType, IceServerUrls, IceServerUsername, IceServerCredential, IceServerCredentialType, PollingInterval, ImportJson };
+
+        internal delegate bool TryParseDelegate<T>(string[] arguments, string argumentName, out T result);
+
+        internal interface IArgument
+        {
+            bool TryParse(string[] arguments);
+        }
+
+        internal abstract class BaseArgument<T> : IArgument
+        {
+            /// <summary>
+            /// A switch that will either retrieve the argument using the resolver, or use the readonly
+            /// argument name string set on construction.
+            /// </summary>
+            public string ArgumentName { get; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public bool Defined => m_defined;
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public readonly bool Required;
+
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public T Value => m_value;
+
+            protected bool m_defined;
+            protected T m_value;
+            readonly TryParseDelegate<T> m_parser;
+
+            protected abstract bool DefaultParser(string[] arguments, string argumentName, out T parsedResult);
+
+            public bool TryParse(string[] arguments)
+            {
+                m_defined =
+                    m_parser != null &&
+                    m_parser(arguments, ArgumentName, out m_value);
+                return m_defined;
+            }
+
+            internal BaseArgument(string argumentName, bool required = false)
+            {
+                Required = required;
+                ArgumentName = argumentName;
+                m_parser = DefaultParser;
+            }
+
+            internal BaseArgument(string argumentName, TryParseDelegate<T> tryParseDelegate, bool required = false)
+            {
+                Required = required;
+                ArgumentName = argumentName;
+                m_parser = tryParseDelegate;
+            }
+        }
+
+        internal class StringArgument : BaseArgument<string>
+        {
+            protected override bool DefaultParser(string[] arguments, string argumentName, out string parsedResult) => TryParseStringArgument(arguments, argumentName, out parsedResult, Required);
+
+            internal StringArgument(string argumentName, bool required = false) : base(argumentName, required) { }
+            internal StringArgument(string argumentName, TryParseDelegate<string> tryParse, bool required = false) : base(argumentName, tryParse, required) { }
+
+            public static implicit operator string(StringArgument argument) => !argument.Defined ? null : argument.Value;
+        }
+
+        internal class EnumArgument<T> : BaseArgument<T?> where T : struct
+        {
+            protected override bool DefaultParser(string[] arguments, string argumentName, out T? parsedResult) => TryParseEnumArgument(arguments, argumentName, out parsedResult, Required);
+
+            internal EnumArgument(string argumentName, bool required = false) : base(argumentName, required) { }
+
+            public static implicit operator T?(EnumArgument<T> argument) => !argument.Defined ? null : argument.Value;
+        }
+
+        internal class StringArrayArgument : BaseArgument<string[]>
+        {
+            protected override bool DefaultParser(string[] arguments, string argumentName, out string[] parsedResult) => TryParseStringArrayArgument(arguments, argumentName, out parsedResult, Required);
+
+            internal StringArrayArgument(string argumentName, bool required = false) : base(argumentName, required) { }
+
+            public static implicit operator string[](StringArrayArgument argument) => !argument.Defined ? null : argument.Value;
+        }
+
+
+        internal class IntArgument : BaseArgument<int?>
+        {
+            protected override bool DefaultParser(string[] arguments, string argumentName, out int? parsedResult) => TryParseIntArgument(arguments, argumentName, out parsedResult, Required);
+
+            internal IntArgument(string argumentName, bool required = false) : base(argumentName, required) { }
+
+            public static implicit operator int?(IntArgument argument) => !argument.Defined ? null : argument.Value;
+        }
+
+        internal class JsonFileArgument<T> : BaseArgument<T?> where T : struct
+        {
+            protected override bool DefaultParser(string[] arguments, string argumentName, out T? parsedResult) => TryParseJsonFileArgument(arguments, argumentName, out parsedResult, Required);
+
+            internal JsonFileArgument(string argumentName, bool required = false) : base(argumentName, required) { }
+
+            public static implicit operator T?(JsonFileArgument<T> argument) => !argument.Defined ? null : argument.Value;
+        }
+
+        static bool TryParseStringArgument(string[] arguments, string argumentName, out string argumentValue, bool required = false)
+        {
+            var startIndex = System.Array.FindIndex(arguments, x => x == argumentName);
+            if (startIndex < 0)
+            {
+                argumentValue = null;
+                return !required;
+            }
+
+            if (startIndex + 1 >= arguments.Length)
+            {
+                argumentValue = null;
+                return false;
+            }
+
+            argumentValue = arguments[startIndex + 1];
+            return !string.IsNullOrEmpty(argumentValue);
+        }
+
+        static bool TryParseEnumArgument<T>(string[] arguments, string argumentName, out T? argumentValue,
+            bool required = false) where T : struct
+        {
+            bool result = TryParseStringArgument(arguments, argumentName, out string value, required);
+            if (result && !string.IsNullOrEmpty(value))
+            {
+                if (Enum.TryParse(value, true, out T enumValue))
+                {
+                    argumentValue = enumValue;
+                    return true;
+                }
+                result = false;
+            }
+            argumentValue = null;
+            return result;
+        }
+
+
+        static bool TryParseIntArgument(string[] arguments, string argumentName, out int? argumentValue, bool required = false)
+        {
+            var startIndex = System.Array.FindIndex(arguments, x => x == argumentName);
+            if (startIndex < 0)
+            {
+                argumentValue = null;
+                return !required;
+            }
+
+            if (startIndex + 1 >= arguments.Length)
+            {
+                argumentValue = null;
+                return false;
+            }
+
+            if (!int.TryParse(arguments[startIndex + 1], out var result))
+            {
+                argumentValue = null;
+                return false;
+            }
+            argumentValue = result;
+            return true;
+        }
+
+        static bool TryParseStringArrayArgument(string[] arguments, string argumentName, out string[] argumentValue, bool required = false)
+        {
+            List<string> list = new List<string>();
+
+            for (int i = 0; i < arguments.Length;)
+            {
+                var startIndex = Array.FindIndex(arguments, i, x => x == argumentName);
+                if (startIndex < 0)
+                    break;
+                if (startIndex + 1 >= arguments.Length)
+                    break;
+                list.Add(arguments[startIndex + 1]);
+                i = startIndex + 2;
+            }
+            if (list.Count == 0 && required)
+            {
+                argumentValue = null;
+                return false;
+            }
+            argumentValue = list.ToArray();
+            return true;
+        }
+
+        static bool TryParseJsonFileArgument<T>(string[] arguments, string argumentName, out T? argumentValue,
+            bool required = false) where T : struct
+        {
+            bool result = TryParseFilePathArgument(arguments, argumentName, out string value);
+            if (result && !string.IsNullOrEmpty(value))
+            {
+                string text = File.ReadAllText(value);
+                try
+                {
+                    argumentValue = JsonUtility.FromJson<T>(text);
+                    return true;
+                }
+                catch (Exception)
+                {
+                    result = false;
+                }
+            }
+            else if (required)
+                result = false;
+            argumentValue = null;
+            return result;
+        }
+
+        static bool TryParseFilePathArgument(string[] arguments, string argumentName, out string argumentValue)
+        {
+            bool ret = TryParseStringArgument(arguments, argumentName, out string value);
+            if (!ret)
+            {
+                argumentValue = null;
+                return false;
+            }
+            if (string.IsNullOrEmpty(value))
+            {
+                argumentValue = null;
+                return true;
+            }
+
+            if (!File.Exists(value))
+            {
+                argumentValue = null;
+                return false;
+            }
+            argumentValue = value;
+            return true;
+        }
+
+        internal static bool TryParse(string[] arguments)
+        {
+            foreach (var option in options)
+            {
+                if (!option.TryParse(arguments))
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/com.unity.renderstreaming/Runtime/Scripts/CommandLineParser.cs.meta
+++ b/com.unity.renderstreaming/Runtime/Scripts/CommandLineParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69acbbff893ba5840937e10e7b325365
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/FurioosSignalingSettings.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/FurioosSignalingSettings.cs
@@ -59,5 +59,15 @@ namespace Unity.RenderStreaming
                 new IceServer (urls: new[] {"stun:stun.l.google.com:19302"})
             };
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        public override bool ParseArguments(string[] arguments)
+        {
+            return true;
+        }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/SignalingSettings.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/SignalingSettings.cs
@@ -6,6 +6,28 @@ using UnityEngine;
 
 namespace Unity.RenderStreaming
 {
+    /// <summary>
+    /// The attribute is used for commandline argument of "-signalingType".
+    /// </summary>
+    public sealed class SignalingTypeAttribute : Attribute
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string typename => m_typename;
+
+        private string m_typename;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="typename"></param>
+        public SignalingTypeAttribute(string name)
+        {
+            m_typename = name;
+        }
+    }
+
     internal sealed class SignalingSettingsAttribute : PropertyAttribute { }
 
     /// <summary>
@@ -84,6 +106,22 @@ namespace Unity.RenderStreaming
             return new IceServer(this.urls.ToArray(), this.username, this.credentialType, this.credential);
         }
 
+        public IceServer Clone(string[] urls = null, string username = null, IceCredentialType? credentialType = null, string credential = null)
+        {
+            var server = new IceServer(this.urls.ToArray(), this.username, this.credentialType, this.credential);
+            if (urls != null)
+                server.m_urls = urls;
+            if (username != null)
+                server.m_username = username;
+            if (credentialType != null)
+                server.m_credentialType = credentialType.Value;
+            if (credential != null)
+                server.m_credential = credential;
+            return server;
+        }
+
+
+
         /// <summary>
         /// 
         /// </summary>
@@ -122,5 +160,28 @@ namespace Unity.RenderStreaming
         ///
         /// </summary>
         public abstract Type signalingClass { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        public abstract bool ParseArguments(string[] arguments);
+    }
+
+    internal static class RuntimeTypeCache<T> where T : class
+    {
+        private static Type[] s_types;
+
+        public static Type[] GetTypesDerivedFrom()
+        {
+            if (s_types != null)
+                return s_types;
+
+            s_types = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(domainAssembly => domainAssembly.GetTypes())
+                .Where(type => typeof(T).IsAssignableFrom(type) && !type.IsAbstract).ToArray();
+            return s_types;
+        }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignalingSettings.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/WebSocketSignalingSettings.cs
@@ -9,7 +9,7 @@ namespace Unity.RenderStreaming
     /// <summary>
     /// 
     /// </summary>
-    [Serializable]
+    [Serializable, SignalingType("websocket")]
     public class WebSocketSignalingSettings : SignalingSettings
     {
         /// <summary>
@@ -58,6 +58,44 @@ namespace Unity.RenderStreaming
             {
                 new IceServer (urls: new[] {"stun:stun.l.google.com:19302"})
             };
+        }
+
+        public override bool ParseArguments(string[] arguments)
+        {
+            if (arguments == null)
+                throw new ArgumentNullException("arguments");
+            if (arguments.Length == 0)
+                throw new ArgumentException("arguments is empty");
+
+            if (!CommandLineParser.TryParse(arguments))
+                return false;
+
+            if (CommandLineParser.ImportJson.Value != null)
+            {
+                CommandLineInfo info = CommandLineParser.ImportJson.Value.Value;
+
+                if(info.signalingUrl != null)
+                    m_url = info.signalingUrl;
+                if(info.iceServers != null && info.iceServers.Length != 0)
+                    m_iceServers = info.iceServers.Select(v => new IceServer(v)).ToArray();
+            }
+            if (CommandLineParser.SignalingUrl.Value != null)
+                m_url = CommandLineParser.SignalingUrl.Value;
+
+            var username = CommandLineParser.IceServerUsername != null
+                ? CommandLineParser.IceServerUsername.Value
+                : null;
+            var credential = CommandLineParser.IceServerCredential != null
+                ? CommandLineParser.IceServerCredential.Value
+                : null;
+            var credentialType = CommandLineParser.IceServerCredentialType != null
+                ? CommandLineParser.IceServerCredentialType.Value
+                : null;
+            var urls = CommandLineParser.IceServerUrls != null
+                ? CommandLineParser.IceServerUrls.Value
+                : null;
+            m_iceServers[0] = m_iceServers[0].Clone(username:username, credential:credential, credentialType: credentialType, urls:urls);
+            return true;
         }
     }
 }

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingManager.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingManager.cs
@@ -209,6 +209,7 @@ namespace Unity.RenderStreaming
             )
         {
             var settings = m_useDefault ? RenderStreaming.GetSignalingSettings<SignalingSettings>() : signalingSettings;
+#if !UNITY_EDITOR
             var arguments = Environment.GetCommandLineArgs();
             if (evaluateCommandlineArguments && arguments.Length > 1)
             {
@@ -217,6 +218,7 @@ namespace Unity.RenderStreaming
                     Debug.LogError("Command line arguments are invalid.");
                 }
             }
+#endif
             RTCIceServer[] iceServers = settings.iceServers.OfType<RTCIceServer>().ToArray();
             RTCConfiguration _conf =
                 conf.GetValueOrDefault(new RTCConfiguration { iceServers = iceServers });

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingManager.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingManager.cs
@@ -157,34 +157,6 @@ namespace Unity.RenderStreaming
             _Run(conf, signaling, handlers);
         }
 
-//        void OnValidate()
-//        {
-//#if UNITY_EDITOR
-//            if (Application.isPlaying)
-//                return;
-
-//            if (!m_useDefault)
-//            {
-//                if (!IsValidSignalingSettingsObject(signalingSettingsObject))
-//                {
-//                    // Create Default SignalingSettings in Assets folder when the useDefault flag is turned off first time.
-//                    SignalingSettingsObject obj = AssetDatabase.LoadAssetAtPath<SignalingSettingsObject>(DefaultSignalingSettingsSavePath);
-//                    if (obj == null)
-//                    {
-//                        if (!AssetDatabase.CopyAsset(DefaultSignalingSettingsLoadPath, DefaultSignalingSettingsSavePath))
-//                        {
-//                            Debug.LogError("CopyAssets is failed.");
-//                            return;
-//                        }
-//                        obj = AssetDatabase.LoadAssetAtPath<SignalingSettingsObject>(DefaultSignalingSettingsSavePath);
-//                    }
-//                    signalingSettingsObject = obj;
-//                    signalingSettings = signalingSettingsObject.settings;
-//                }
-//            }
-//#endif
-//        }
-
 #if UNITY_EDITOR
         bool IsValidSignalingSettingsObject(SignalingSettingsObject asset)
         {

--- a/com.unity.renderstreaming/Tests/Runtime/CommandLineParserTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/CommandLineParserTest.cs
@@ -46,12 +46,12 @@ namespace Unity.RenderStreaming.RuntimeTest
             string signalingType = "websocket";
             string[] arguments = { "-signalingType", signalingType };
             Assert.That(CommandLineParser.TryParse(arguments), Is.True);
-            Assert.That((string)CommandLineParser.SignalingType, Is.EqualTo(typeof(WebSocketSignaling).FullName));
+            Assert.That((string)CommandLineParser.SignalingType, Is.EqualTo(signalingType));
 
             signalingType = "dummy";
             arguments = new[] { "-signalingType", signalingType };
-            Assert.That(CommandLineParser.TryParse(arguments), Is.False);
-            Assert.That((string)CommandLineParser.SignalingType, Is.Null);
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That((string)CommandLineParser.SignalingType, Is.EqualTo(signalingType));
         }
 
         [Test]

--- a/com.unity.renderstreaming/Tests/Runtime/CommandLineParserTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/CommandLineParserTest.cs
@@ -1,0 +1,150 @@
+using System.IO;
+using NUnit.Framework;
+using Unity.RenderStreaming.Signaling;
+using Unity.WebRTC;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.RenderStreaming.RuntimeTest
+{
+    /// <note>
+    /// Commandline parser doesn't support mobile platforms.
+    /// </note>
+    [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer, RuntimePlatform.Android })]
+    class CommandLineParserTest
+    {
+        [Test]
+        public void NothingArgument()
+        {
+            string[] arguments = { };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That((string)CommandLineParser.SignalingUrl, Is.Null);
+            Assert.That((int?)CommandLineParser.PollingInterval, Is.Null);
+        }
+
+        [Test]
+        public void SignalingUrlArgument()
+        {
+            const string signalingUrl = "localhost:8080";
+            string[] arguments = new[] { "-signalingUrl", signalingUrl };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That((string)CommandLineParser.SignalingUrl, Is.EqualTo(signalingUrl));
+        }
+
+        [Test]
+        public void PollingIntervalArgument()
+        {
+            const int pollingInterval = 5000;
+            string[] arguments = { "-pollingInterval", pollingInterval.ToString() };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That((int)CommandLineParser.PollingInterval, Is.EqualTo(pollingInterval));
+        }
+
+        [Test]
+        public void SignalingTypeArgument()
+        {
+            string signalingType = "websocket";
+            string[] arguments = { "-signalingType", signalingType };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That((string)CommandLineParser.SignalingType, Is.EqualTo(typeof(WebSocketSignaling).FullName));
+
+            signalingType = "dummy";
+            arguments = new[] { "-signalingType", signalingType };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.False);
+            Assert.That((string)CommandLineParser.SignalingType, Is.Null);
+        }
+
+        [Test]
+        public void IceServerUrlArgument()
+        {
+            string[] iceServerUrls = { "stun:stun.l.google.com:19302", "stun:stun.l.google.com:19303" };
+            string[] arguments = { "-iceServerUrl", iceServerUrls[0], "-iceServerUrl", iceServerUrls[1] };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That(CommandLineParser.IceServerUrls.Value, Has.Length.EqualTo(2));
+            Assert.That(CommandLineParser.IceServerUrls.Value[0], Is.EqualTo(iceServerUrls[0]));
+            Assert.That(CommandLineParser.IceServerUrls.Value[1], Is.EqualTo(iceServerUrls[1]));
+        }
+
+        [Test]
+        public void IceServerUserNameArgument()
+        {
+            string iceServerUsername = "username";
+            string[] arguments = { "-iceServerUsername", iceServerUsername };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That((string)CommandLineParser.IceServerUsername, Is.EqualTo(iceServerUsername));
+        }
+
+        [Test]
+        public void IceServerCredentialArgument()
+        {
+            string iceServerCredential = "password";
+            string[] arguments = { "-iceServerCredential", iceServerCredential };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That((string)CommandLineParser.IceServerCredential, Is.EqualTo(iceServerCredential));
+        }
+
+        [Test]
+        public void IceServerCredentialTypeArgument()
+        {
+            string iceServerCredentialType = "password";
+            string[] arguments = { "-iceServerCredentialType", iceServerCredentialType };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That((IceCredentialType)CommandLineParser.IceServerCredentialType, Is.EqualTo(IceCredentialType.Password));
+
+            iceServerCredentialType = "oauth";
+            arguments = new[] { "-iceServerCredentialType", iceServerCredentialType };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That((IceCredentialType)CommandLineParser.IceServerCredentialType, Is.EqualTo(IceCredentialType.OAuth));
+
+            iceServerCredentialType = "dummy";
+            arguments = new[] { "-iceServerCredentialType", iceServerCredentialType };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.False);
+            Assert.That(CommandLineParser.IceServerCredentialType.Value, Is.Null);
+        }
+
+        [Test]
+        public void ImportJsonArgument()
+        {
+            string filepath = "dummy.json";
+            var file = File.Create(filepath);
+            file.Close();
+            string[] arguments = { "-importJson", filepath };
+            Assert.That(CommandLineParser.TryParse(arguments), Is.False);
+            Assert.That(CommandLineParser.ImportJson.Value, Is.Null);
+            string json = "{\"signalingType\":\"websocket\",\"signalingUrl\":\"ws://localhost\",\"pollingInterval\":\"1\"}";
+            File.WriteAllText(filepath, json);
+            Assert.That(CommandLineParser.TryParse(arguments), Is.True);
+            Assert.That(CommandLineParser.ImportJson.Value, Is.Not.Null);
+            var info = CommandLineParser.ImportJson.Value.Value;
+            Assert.That(info.signalingUrl, Is.EqualTo("ws://localhost"));
+            Assert.That(info.signalingType, Is.EqualTo("websocket"));
+            Assert.That(info.iceServers, Is.Null);
+            Assert.That(info.pollingInterval, Is.EqualTo("1"));
+            File.Delete(filepath);
+        }
+
+        [Test]
+        public void ParseJson()
+        {
+            string json = "{\"signalingType\":\"websocket\",\"signalingUrl\":\"ws://localhost\",\"pollingInterval\":\"1\"}";
+            var settings = JsonUtility.FromJson<CommandLineInfo>(json);
+            Assert.That(settings.signalingUrl, Is.EqualTo("ws://localhost"));
+            Assert.That(settings.signalingType, Is.EqualTo("websocket"));
+            Assert.That(settings.iceServers, Is.Null);
+            Assert.That(settings.pollingInterval, Is.EqualTo("1"));
+
+            string json2 = "{\"iceServers\":[{\"credential\":\"pass\",\"username\":\"user\",\"credentialType\":\"password\"," +
+                           "\"urls\":[\"turn:192.168.10.10:3478?transport=udp\"]}]}";
+            settings = JsonUtility.FromJson<CommandLineInfo>(json2);
+            Assert.That(settings.signalingUrl, Is.Null);
+            Assert.That(settings.signalingType, Is.Null);
+            Assert.That(settings.iceServers, Has.Length.EqualTo(1));
+            Assert.That(settings.iceServers[0].credential, Is.EqualTo("pass"));
+            Assert.That(settings.iceServers[0].credentialType, Is.EqualTo(RTCIceCredentialType.Password));
+            Assert.That(settings.iceServers[0].username, Is.EqualTo("user"));
+            Assert.That(settings.iceServers[0].urls, Has.Length.EqualTo(1));
+            Assert.That(settings.iceServers[0].urls[0], Is.EqualTo("turn:192.168.10.10:3478?transport=udp"));
+            Assert.That(settings.pollingInterval, Is.Null);
+        }
+    }
+}

--- a/com.unity.renderstreaming/Tests/Runtime/CommandLineParserTest.cs.meta
+++ b/com.unity.renderstreaming/Tests/Runtime/CommandLineParserTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f48ad77b30bc9124aaf2a391f696603b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Tests/Runtime/InputSystem/InputEditorUserSettingsTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/InputSystem/InputEditorUserSettingsTest.cs
@@ -1,7 +1,3 @@
-using NUnit.Framework;
-using Unity.RenderStreaming.InputSystem;
-using Assert = NUnit.Framework.Assert;
-
 namespace Unity.RenderStreaming.RuntimeTest
 {
 #if UNITY_EDITOR && !INPUTSYSTEM_1_1_OR_NEWER

--- a/com.unity.renderstreaming/Tests/Runtime/PeerConnectionTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/PeerConnectionTest.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using NUnit.Framework;
 using Unity.WebRTC;
 using UnityEngine;

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingTest.cs
@@ -59,25 +59,6 @@ namespace Unity.RenderStreaming.RuntimeTest
         }
 
         [Test]
-        public void CheckDefaultSettings()
-        {
-            RenderStreamingSettings defaultSettings = null;
-#if UNITY_EDITOR
-            defaultSettings =
-                AssetDatabase.LoadAssetAtPath<RenderStreamingSettings>(RenderStreaming.DefaultRenderStreamingSettingsPath);
-#else
-            defaultSettings = Resources.FindObjectsOfTypeAll<RenderStreamingSettings>().FirstOrDefault() ??
-                                       ScriptableObject.CreateInstance<RenderStreamingSettings>();
-#endif
-            Assert.That(defaultSettings.automaticStreaming, Is.True);
-            var defaultSignalingSettings = defaultSettings.signalingSettings as WebSocketSignalingSettings;
-            Assert.That(defaultSignalingSettings, Is.Not.Null);
-            Assert.That(defaultSignalingSettings.signalingClass, Is.EqualTo(typeof(WebSocketSignaling)));
-            Assert.That(defaultSignalingSettings.url, Is.EqualTo("ws://127.0.0.1:80"));
-            Assert.That(defaultSignalingSettings.iceServers.ElementAt(0).urls, Is.EquivalentTo(new string[] {"stun:stun.l.google.com:19302"}));
-        }
-
-        [Test]
         public void Settings()
         {
             Assert.That(() => RenderStreaming.Settings = null, Throws.ArgumentNullException);

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignalingSettings.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignalingSettings.cs
@@ -8,5 +8,10 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
         public override Type signalingClass => typeof(MockSignaling);
 
         public override IReadOnlyCollection<IceServer> iceServers => Array.Empty<IceServer>();
+
+        public override bool ParseArguments(string[] arguments)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingManagerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingManagerTest.cs
@@ -131,6 +131,7 @@ namespace Unity.RenderStreaming.RuntimeTest
         }
 
         [Test]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.Android, RuntimePlatform.IPhonePlayer })]
         public void EvaluateCommandlineArguments()
         {
             // Change signaling type.

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingManagerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingManagerTest.cs
@@ -1,4 +1,7 @@
 using System.Collections;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using NUnit.Framework;
 using Unity.RenderStreaming.RuntimeTest.Signaling;
 using Unity.RenderStreaming.Signaling;
@@ -125,6 +128,44 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(component.Running, Is.True);
 
             Assert.That(() => component.SetSignalingSettings(new MockSignalingSettings()), Throws.InvalidOperationException);
+        }
+
+        [Test]
+        public void EvaluateCommandlineArguments()
+        {
+            // Change signaling type.
+            SignalingSettings settings = new WebSocketSignalingSettings();
+            string[] arguments = { "-signalingType", "http" };
+            Assert.That(SignalingManager.EvaluateCommandlineArguments(ref settings, arguments), Is.True);
+            Assert.That(settings, Is.TypeOf<HttpSignalingSettings>());
+
+            // Change signaling url.
+            string url = "http://192.168.10.10";
+            arguments = new[] { "-signalingUrl", url };
+            Assert.That(SignalingManager.EvaluateCommandlineArguments(ref settings, arguments), Is.True);
+            Assert.That(settings, Is.TypeOf<HttpSignalingSettings>());
+            Assert.That((settings as HttpSignalingSettings).url, Is.EqualTo(url));
+
+            // Import json for ice server settings.
+            string json = "{\"iceServers\":[{\"credential\":\"pass\",\"username\":\"user\",\"credentialType\":\"password\"," +
+                          "\"urls\":[\"turn:192.168.10.10:3478?transport=udp\"]}]}";
+            string filepath = "dummy.json";
+            File.WriteAllText(filepath, json);
+            arguments = new[] { "-importJson", filepath };
+            var info = JsonUtility.FromJson<CommandLineInfo>(json);
+            Assert.That(SignalingManager.EvaluateCommandlineArguments(ref settings, arguments), Is.True);
+            Assert.That(settings, Is.TypeOf<HttpSignalingSettings>());
+            Assert.That(settings.iceServers.Count, Is.EqualTo(1));
+            Assert.That(settings.iceServers.ElementAt(0).credential, Is.EqualTo(info.iceServers[0].credential));
+            Assert.That(settings.iceServers.ElementAt(0).credentialType, Is.EqualTo((IceCredentialType)info.iceServers[0].credentialType));
+            File.Delete(filepath);
+
+            // Import json to change signaling type.
+            json = "{\"signalingType\":\"websocket\"}";
+            File.WriteAllText(filepath, json);
+            arguments = new[] { "-importJson", filepath };
+            Assert.That(SignalingManager.EvaluateCommandlineArguments(ref settings, arguments), Is.True);
+            Assert.That(settings, Is.TypeOf<WebSocketSignalingSettings>());
         }
     }
 }

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingSettingsTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingSettingsTest.cs
@@ -1,14 +1,38 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Unity.RenderStreaming.Signaling;
-using Unity.WebRTC;
-using UnityEngine;
 
 namespace Unity.RenderStreaming.RuntimeTest
 {
+    class IceServerTest
+    {
+        [Test]
+        public void Clone()
+        {
+            var iceServer = new IceServer(
+                urls: new[]{"stun:stun.l.google.com:19302"},
+                username:"username",
+                credentialType:IceCredentialType.Password,
+                credential:"password");
+
+            var copied = iceServer.Clone();
+            Assert.That(copied.urls, Is.EqualTo(iceServer.urls));
+            Assert.That(copied.username, Is.EqualTo(iceServer.username));
+            Assert.That(copied.credentialType, Is.EqualTo(iceServer.credentialType));
+            Assert.That(copied.credential, Is.EqualTo(iceServer.credential));
+
+            copied = iceServer.Clone(
+                username: "username2",
+                credential: "password2");
+            Assert.That(copied.urls, Is.EqualTo(iceServer.urls));
+            Assert.That(copied.username, Is.Not.EqualTo(iceServer.username));
+            Assert.That(copied.credentialType, Is.EqualTo(iceServer.credentialType));
+            Assert.That(copied.credential, Is.Not.EqualTo(iceServer.credential));
+        }
+    }
+
+
     class SignalingSettingsTest
     {
         [Test]


### PR DESCRIPTION
This pull request adds commandline arguments support. Please see details below.

| arguments | description |
| --- | --- |
| `signalingType <value>` | Class type of the signaling. `http` or `websocket`. |
|  `signalingUrl  <value>` | Set the signaling server URL. If you use WebSocket as a signaling protocol, you should specify a URL starting with `ws` or `wss`. |
| `iceServerUrl <value>` | Set URLs of STUN/TURN servers.  |
| `iceServerUsername <value>` | The username to use when logging into the TURN server. |
| `iceServerCredential <value>` | The credential to use when logging into the TURN server. |
| `iceServerCredentialType <value>` | This attribute specifies what kind of credential is to be used when connecting to the TURN server. |
| `pollingInterval  <value>` | Http polling interval (milliseconds). This value is evaluated when using the http signaling. |
| `importJson <path>` | Set file path of JSON file. |