### PR TITLE
feat: Define SignalingSettings asset to make portable signaling configurations

### DIFF
--- a/com.unity.renderstreaming/Editor/PropertyDrawers/SignalingSettingsDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/SignalingSettingsDrawer.cs
@@ -94,12 +94,13 @@ namespace Unity.RenderStreaming.Editor
             editor = Activator.CreateInstance(inspectorType) as ISignalingSettingEditor;
             var newValue = editor.CreateInspectorGUI(property);
 
+            // Unbind old element to serializedObject.
             editorGUI.Unbind();
 
             ReplaceVisualElement(editorGUI, newValue);
             editorGUI = newValue;
 
-            // bind new serializedObject.
+            // bind new element to serializedObject.
             editorGUI.Bind(property.serializedObject);
         }
     }

--- a/com.unity.renderstreaming/Editor/PropertyDrawers/SignalingSettingsDrawer.cs
+++ b/com.unity.renderstreaming/Editor/PropertyDrawers/SignalingSettingsDrawer.cs
@@ -31,14 +31,14 @@ namespace Unity.RenderStreaming.Editor
             return root;
         }
 
-        static ISignalingSettingEditor CreateEditor(SerializedProperty property)
+        ISignalingSettingEditor CreateEditor(SerializedProperty property)
         {
             var settings = fieldInfo.GetValue(property.serializedObject.targetObject) as SignalingSettings;
             var type = CustomSignalingSettingsEditor.FindInspectorTypeByInspectedType(settings.GetType());
             return Activator.CreateInstance(type) as ISignalingSettingEditor;
         }
 
-        static PopupField<string> CreatePopUpSignalingType(SerializedProperty property, string label)
+        PopupField<string> CreatePopUpSignalingType(SerializedProperty property, string label)
         {
             var settings = fieldInfo.GetValue(property.serializedObject.targetObject) as SignalingSettings;
             var defaultValue = CustomSignalingSettingsEditor.FindLabelByInspectedType(settings.GetType());
@@ -56,16 +56,13 @@ namespace Unity.RenderStreaming.Editor
 
         void OnSignalingSettingsObjectChange(SerializedPropertyChangeEvent e, SerializedProperty property)
         {
-            var handler = property.serializedObject.targetObject as SignalingManager;
-            var settings = handler.GetSignalingSettings();
+            var settings = fieldInfo.GetValue(property.serializedObject.targetObject) as SignalingSettings;
             var label = CustomSignalingSettingsEditor.FindLabelByInspectedType(settings.GetType());
 
             if (popupFieldSignalingType.value == label)
                 return;
             popupFieldSignalingType.value = label;
             RecreateEditorGUI(label, property);
-
-            //editorGUI.MarkDirtyRepaint();
         }
 
         void OnPopupFieldValueChange(ChangeEvent<string> e, SerializedProperty property)
@@ -79,8 +76,6 @@ namespace Unity.RenderStreaming.Editor
 
             var label = e.newValue;
             RecreateEditorGUI(label, property);
-
-            //editorGUI.MarkDirtyRepaint();
         }
 
         void RecreateEditorGUI(string label, SerializedProperty property)

--- a/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
@@ -92,6 +92,11 @@ namespace Unity.RenderStreaming
             selectorContainer.Add(createAssetHelpBox);
 
             ShowRenderStreamingSettingsProperty();
+
+            // Disable UI when running in Playmode
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+            if(EditorApplication.isPlaying)
+                rootVisualElement.SetEnabled(false);
         }
 
         public override void OnInspectorUpdate()
@@ -146,6 +151,19 @@ namespace Unity.RenderStreaming
             AssetDatabase.CreateAsset(settings, relativePath);
             EditorGUIUtility.PingObject(settings);
             RenderStreaming.Settings = settings;
+        }
+
+        private void OnPlayModeStateChanged(PlayModeStateChange e)
+        {
+            switch (e)
+            {
+                case PlayModeStateChange.EnteredPlayMode:
+                    rootVisualElement.SetEnabled(false);
+                    break;
+                case PlayModeStateChange.ExitingPlayMode:
+                    rootVisualElement.SetEnabled(true);
+                    break;
+            }
         }
 
         private void ShowRenderStreamingSettingsProperty()

--- a/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingProjectSettingsProvider.cs
@@ -58,7 +58,7 @@ namespace Unity.RenderStreaming
             var selectorContainer = rootVisualElement.Q<VisualElement>("renderStreamingSettingsSelector");
 
             var defaultIndex = ArrayHelpers.IndexOf(availableRenderStreamingSettingsAssets, AssetDatabase.GetAssetPath(settings));
-            var choices = availableRenderStreamingSettingsAssets.Select(x => x.Replace("/", " \u2215 ")).ToList();
+            var choices = availableRenderStreamingSettingsAssets.ToList();
             var selectPopup = new PopupField<string>(label: label, choices: choices, defaultIndex: defaultIndex)
             {
                 name = "renderStreamingSettingsSelectPopup"

--- a/com.unity.renderstreaming/Editor/SignalingManagerEditor.cs
+++ b/com.unity.renderstreaming/Editor/SignalingManagerEditor.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Linq;
 using UnityEditor;
 using UnityEditor.UIElements;
+using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Unity.RenderStreaming.Editor
@@ -10,13 +13,140 @@ namespace Unity.RenderStreaming.Editor
     [CustomEditor(typeof(SignalingManager))]
     internal class SignalingManagerEditor : UnityEditor.Editor
     {
+        const string DefaultSignalingSettingsSavePath =
+            "Assets/SignalingSettings.asset";
+
+        const string DefaultSignalingSettingsLoadPath =
+            "Packages/com.unity.renderstreaming/Runtime/SignalingSettings.asset";
+
+        VisualElement root;
+        Button openProjectSettingsButton;
+        //PropertyField signalingSettingsObjectField;
+        PopupField<string> signalingSettingsPopupField;
+        PropertyField signalingSettingsField;
+
         public override VisualElement CreateInspectorGUI()
         {
-            var root = new VisualElement();
-            root.Add(new PropertyField(serializedObject.FindProperty("signalingSettings"), "Signaling Settings"));
+            root = new VisualElement();
+            bool useDefault = serializedObject.FindProperty("m_useDefault").boolValue;
+
+            var useDefaultField = new PropertyField(serializedObject.FindProperty("m_useDefault"), "Use Default Settings in Project Settings");
+            useDefaultField.RegisterValueChangeCallback(OnChangeUseDefault);
+            openProjectSettingsButton = new Button { text = "Open Project Setings" };
+            openProjectSettingsButton.clicked += OnClickedOpenProjectSettingsButton;
+            signalingSettingsPopupField = CreatePopUpSignalingType(serializedObject.FindProperty("signalingSettingsObject"), "Signaling Settings Asset");
+            signalingSettingsField = new PropertyField(serializedObject.FindProperty("signalingSettings"), "Signaling Settings");
+            signalingSettingsField.RegisterValueChangeCallback(OnValueChangeSignalingSettings);
+
+            root.Add(useDefaultField);
+            root.Add(openProjectSettingsButton);
+            root.Add(signalingSettingsPopupField);
+            root.Add(signalingSettingsField);
+            if (useDefault)
+            {
+                signalingSettingsPopupField.style.display = DisplayStyle.None;
+                signalingSettingsField.style.display = DisplayStyle.None;
+            }
             root.Add(new ReorderableListField(serializedObject.FindProperty("handlers"), "Signaling Handler List"));
             root.Add(new PropertyField(serializedObject.FindProperty("runOnAwake"), "Run On Awake"));
             return root;
+        }
+
+        static PopupField<string> CreatePopUpSignalingType(SerializedProperty property, string label)
+        {
+            var asset = property.objectReferenceValue as SignalingSettingsObject;
+            var path = AssetDatabase.GetAssetPath(asset);
+
+            var guids = AssetDatabase.FindAssets("t:SignalingSettingsObject");
+            var choices = guids.Select(AssetDatabase.GUIDToAssetPath).Where(_ => _.StartsWith("Assets"));
+            return new PopupField<string>(label: label, choices: choices.Select(x => x.Replace('/', '\\')).ToList(),
+                defaultValue: path.Replace('/', '\\'));
+        }
+
+        static bool IsValidSignalingSettingsObject(SignalingSettingsObject asset)
+        {
+            if (asset == null)
+                return false;
+            if (AssetDatabase.GetAssetPath(asset).IndexOf("Assets", StringComparison.Ordinal) != 0)
+                return false;
+            return true;
+        }
+
+        static void CreateDefaultSignalingSettings(SignalingManager handler)
+        {
+            // Create Default SignalingSettings in Assets folder when the useDefault flag is turned off first time.
+            SignalingSettingsObject obj = AssetDatabase.LoadAssetAtPath<SignalingSettingsObject>(DefaultSignalingSettingsSavePath);
+            if (obj == null)
+            {
+                if (!AssetDatabase.CopyAsset(DefaultSignalingSettingsLoadPath, DefaultSignalingSettingsSavePath))
+                {
+                    Debug.LogError("CopyAssets is failed.");
+                    return;
+                }
+                obj = AssetDatabase.LoadAssetAtPath<SignalingSettingsObject>(DefaultSignalingSettingsSavePath);
+            }
+            handler.signalingSettingsObject = obj;
+            handler.SetSignalingSettings(handler.signalingSettingsObject.settings);
+        }
+
+        private void OnClickedOpenProjectSettingsButton()
+        {
+            SettingsService.OpenProjectSettings("Project/Render Streaming");
+        }
+
+        private void OnChangeUseDefault(SerializedPropertyChangeEvent e)
+        {
+            bool useDefault = e.changedProperty.boolValue;
+            if (useDefault)
+            {
+                signalingSettingsPopupField.style.display = DisplayStyle.None;
+                signalingSettingsField.style.display = DisplayStyle.None;
+                openProjectSettingsButton.style.display = DisplayStyle.Flex;
+            }
+            else
+            {
+                signalingSettingsPopupField.style.display = DisplayStyle.Flex;
+                signalingSettingsField.style.display = DisplayStyle.Flex;
+                openProjectSettingsButton.style.display = DisplayStyle.None;
+
+                var handler = e.changedProperty.serializedObject.targetObject as SignalingManager;
+                if (!IsValidSignalingSettingsObject(handler.signalingSettingsObject))
+                {
+                    CreateDefaultSignalingSettings(handler);
+                }
+            }
+        }
+
+        private void OnValueChangeSignalingSettingsObject(SerializedPropertyChangeEvent e)
+        {
+            SignalingSettingsObject asset = e.changedProperty.objectReferenceValue as SignalingSettingsObject;
+            if (asset == null)
+            {
+                Debug.LogError("Setting None is not allowed for this parameter. Reverted.");
+                return;
+            }
+            if (AssetDatabase.GetAssetPath(asset).IndexOf("Assets", StringComparison.Ordinal) != 0)
+            {
+                Debug.LogError("Setting an asset not placed under Assets folder is not allowed for this parameter. Reverted.");
+                return;
+            }
+
+            var handler = e.changedProperty.serializedObject.targetObject as SignalingManager;
+            handler.SetSignalingSettings(asset.settings);
+
+            // Send event to repaint SignalingSettingsDrawer.
+            using SerializedPropertyChangeEvent changeEvent = SerializedPropertyChangeEvent.GetPooled();
+            changeEvent.changedProperty = e.changedProperty;
+            changeEvent.target = signalingSettingsField.Children().First();
+            root.SendEvent(changeEvent);
+        }
+
+        private void OnValueChangeSignalingSettings(SerializedPropertyChangeEvent e)
+        {
+            // Update SignalingSettings in ScriptableObject.
+            var handler = e.changedProperty.serializedObject.targetObject as SignalingManager;
+            if (handler.signalingSettingsObject != null)
+                handler.signalingSettingsObject.settings = handler.GetSignalingSettings();
         }
     }
 }

--- a/com.unity.renderstreaming/Editor/SignalingManagerEditor.cs
+++ b/com.unity.renderstreaming/Editor/SignalingManagerEditor.cs
@@ -55,6 +55,11 @@ namespace Unity.RenderStreaming.Editor
             root.Add(new PropertyField(serializedObject.FindProperty("runOnAwake"), "Run On Awake"));
 
             EditorApplication.projectChanged += OnProjectChanged;
+
+            // Disable UI when running in Playmode
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+            if (EditorApplication.isPlaying)
+                root.SetEnabled(false);
             return root;
         }
 
@@ -106,6 +111,19 @@ namespace Unity.RenderStreaming.Editor
             var handler = serializedObject.targetObject as SignalingManager;
             handler.signalingSettingsObject = asset;
             handler.SetSignalingSettings(handler.signalingSettingsObject.settings);
+        }
+
+        private void OnPlayModeStateChanged(PlayModeStateChange e)
+        {
+            switch (e)
+            {
+                case PlayModeStateChange.EnteredPlayMode:
+                    root.SetEnabled(false);
+                    break;
+                case PlayModeStateChange.ExitingPlayMode:
+                    root.SetEnabled(true);
+                    break;
+            }
         }
 
         private void OnProjectChanged()

--- a/com.unity.renderstreaming/Runtime/Scripts/AutomaticStreaming.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AutomaticStreaming.cs
@@ -38,8 +38,6 @@ namespace Unity.RenderStreaming
 
             renderstreaming = gameObject.AddComponent<SignalingManager>();
             renderstreaming.AddSignalingHandler(broadcast);
-            var signalingSettings = RenderStreaming.GetSignalingSettings<WebSocketSignalingSettings>();
-            renderstreaming.SetSignalingSettings(signalingSettings);
             renderstreaming.Run();
 
             SceneManager.activeSceneChanged += (scene1, scene2) =>

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingSettings.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreamingSettings.cs
@@ -2,8 +2,14 @@ using UnityEngine;
 
 namespace Unity.RenderStreaming
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class RenderStreamingSettings : ScriptableObject
     {
+        /// <summary>
+        /// 
+        /// </summary>
         [SerializeField] public bool automaticStreaming;
 
         [SerializeReference, SignalingSettings]

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/SignalingSettingsObject.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/SignalingSettingsObject.cs
@@ -7,7 +7,7 @@ namespace Unity.RenderStreaming
         [SerializeReference]
         public SignalingSettings settings;
 
-        public static ScriptableObject Create()
+        public static SignalingSettingsObject Create()
         {
             var instance = CreateInstance<SignalingSettingsObject>();
             instance.settings = new WebSocketSignalingSettings();

--- a/com.unity.renderstreaming/Runtime/SignalingSettings.asset
+++ b/com.unity.renderstreaming/Runtime/SignalingSettings.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22c294fb286b37446a86664f4fb41023, type: 3}
+  m_Name: SignalingSettings
+  m_EditorClassIdentifier: 
+  settings:
+    id: 0
+  references:
+    version: 1
+    00000000:
+      type: {class: WebSocketSignalingSettings, ns: Unity.RenderStreaming, asm: Unity.RenderStreaming}
+      data:
+        m_url: ws://127.0.0.1
+        m_iceServers:
+        - m_urls:
+          - stun:stun.l.google.com:19302
+          m_username: 
+          m_credentialType: 0
+          m_credential: 

--- a/com.unity.renderstreaming/Runtime/SignalingSettings.asset.meta
+++ b/com.unity.renderstreaming/Runtime/SignalingSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 65662d71af45cc24fa4da622b2a770f9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.renderstreaming/Samples~/Example/ARFoundation/ARFoundationSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/ARFoundation/ARFoundationSample.cs
@@ -48,8 +48,9 @@ namespace Unity.RenderStreaming.Samples
         {
             if (!renderStreaming.runOnAwake)
             {
-                renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
-                if(settings?.SignalingSettings != null)
+                if (settings != null)
+                    renderStreaming.useDefaultSettings = settings.UseDefaultSettings;
+                if (settings?.SignalingSettings != null)
                     renderStreaming.SetSignalingSettings(settings.SignalingSettings);
                 renderStreaming.Run();
             }

--- a/com.unity.renderstreaming/Samples~/Example/ARFoundation/ARFoundationSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/ARFoundation/ARFoundationSample.cs
@@ -48,7 +48,10 @@ namespace Unity.RenderStreaming.Samples
         {
             if (!renderStreaming.runOnAwake)
             {
-                renderStreaming.Run(signaling: settings?.Signaling);
+                renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+                if(settings?.SignalingSettings != null)
+                    renderStreaming.SetSignalingSettings(settings.SignalingSettings);
+                renderStreaming.Run();
             }
 
             if ((ARSession.state == ARSessionState.None ) ||

--- a/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
@@ -76,7 +76,11 @@ namespace Unity.RenderStreaming.Samples
         {
             if (renderStreaming.runOnAwake)
                 return;
-            renderStreaming.Run(signaling: settings?.Signaling);
+
+            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings?.SignalingSettings != null)
+                renderStreaming.SetSignalingSettings(settings.SignalingSettings);
+            renderStreaming.Run();
         }
 
         private void SetUp()

--- a/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Bidirectional/BidirectionalSample.cs
@@ -76,8 +76,8 @@ namespace Unity.RenderStreaming.Samples
         {
             if (renderStreaming.runOnAwake)
                 return;
-
-            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings != null)
+                renderStreaming.useDefaultSettings = settings.UseDefaultSettings;
             if (settings?.SignalingSettings != null)
                 renderStreaming.SetSignalingSettings(settings.SignalingSettings);
             renderStreaming.Run();

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
@@ -186,7 +186,10 @@ namespace Unity.RenderStreaming.Samples
 
             if (renderStreaming.runOnAwake)
                 return;
-            renderStreaming.Run(signaling: settings?.Signaling);
+            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings?.SignalingSettings != null)
+                renderStreaming.SetSignalingSettings(settings.SignalingSettings);
+            renderStreaming.Run();
 
             inputReceiver.OnStartedChannel += OnStartedChannel;
             var map = inputReceiver.currentActionMap;

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
@@ -186,7 +186,8 @@ namespace Unity.RenderStreaming.Samples
 
             if (renderStreaming.runOnAwake)
                 return;
-            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if(settings != null)
+                renderStreaming.useDefaultSettings = settings.UseDefaultSettings;
             if (settings?.SignalingSettings != null)
                 renderStreaming.SetSignalingSettings(settings.SignalingSettings);
             renderStreaming.Run();

--- a/com.unity.renderstreaming/Samples~/Example/Gyro/GyroSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Gyro/GyroSample.cs
@@ -46,7 +46,10 @@ namespace Unity.RenderStreaming.Samples
         {
             if (renderStreaming.runOnAwake)
                 return;
-            renderStreaming.Run(signaling: settings?.Signaling);
+            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings?.SignalingSettings != null)
+                renderStreaming.SetSignalingSettings(settings.SignalingSettings);
+            renderStreaming.Run();
         }
 
         void OnEnable()

--- a/com.unity.renderstreaming/Samples~/Example/Gyro/GyroSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Gyro/GyroSample.cs
@@ -46,7 +46,8 @@ namespace Unity.RenderStreaming.Samples
         {
             if (renderStreaming.runOnAwake)
                 return;
-            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings != null)
+                renderStreaming.useDefaultSettings = settings.UseDefaultSettings;
             if (settings?.SignalingSettings != null)
                 renderStreaming.SetSignalingSettings(settings.SignalingSettings);
             renderStreaming.Run();

--- a/com.unity.renderstreaming/Samples~/Example/Menu/Menu.unity
+++ b/com.unity.renderstreaming/Samples~/Example/Menu/Menu.unity
@@ -1299,6 +1299,7 @@ MonoBehaviour:
     type: 3}
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
 --- !u!114 &264030626
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1446,6 +1447,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1632855334}
+  - {fileID: 1341972279}
   - {fileID: 1241864396}
   - {fileID: 1305239481}
   - {fileID: 789249148}
@@ -1456,7 +1458,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 400}
+  m_SizeDelta: {x: 600, y: 471.9563}
   m_Pivot: {x: 1, y: 0}
 --- !u!1 &403658633
 GameObject:
@@ -2970,6 +2972,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 661700338}
   m_CullTransparentMesh: 1
+--- !u!1 &690401032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 690401033}
+  - component: {fileID: 690401035}
+  - component: {fileID: 690401034}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &690401033
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 690401032}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1922333361}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &690401034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 690401032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &690401035
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 690401032}
+  m_CullTransparentMesh: 1
 --- !u!1 &721044881
 GameObject:
   m_ObjectHideFlags: 0
@@ -3280,11 +3357,11 @@ RectTransform:
   - {fileID: 1225082140}
   - {fileID: 2087068098}
   m_Father: {fileID: 397743427}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 295, y: -238}
+  m_AnchoredPosition: {x: 294, y: -303.257}
   m_SizeDelta: {x: 584, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &964629093
@@ -4809,6 +4886,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8d6df25b96db2814daa5608049a81529, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  toggleUseDefaultSettings: {fileID: 1341972280}
   dropdownSignalingType: {fileID: 404516253}
   inputFieldSignalingAddress: {fileID: 2087068099}
   toggleSignalingSecured: {fileID: 1305239482}
@@ -4867,12 +4945,12 @@ RectTransform:
   - {fileID: 595137781}
   - {fileID: 404516252}
   m_Father: {fileID: 397743427}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 129.78998}
-  m_SizeDelta: {x: 541.684, y: 80.9345}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 299, y: -135.46701}
+  m_SizeDelta: {x: 541.684, y: 80.93451}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1305239480
 GameObject:
@@ -4905,11 +4983,11 @@ RectTransform:
   - {fileID: 1850475806}
   - {fileID: 134408846}
   m_Father: {fileID: 397743427}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 153, y: -148}
+  m_AnchoredPosition: {x: 152, y: -213.25699}
   m_SizeDelta: {x: 300, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1305239482
@@ -5068,6 +5146,92 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1326775951}
   m_CullTransparentMesh: 1
+--- !u!1 &1341972278
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1341972279}
+  - component: {fileID: 1341972280}
+  m_Layer: 5
+  m_Name: UseDefaultSettings
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1341972279
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1341972278}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1568416102}
+  - {fileID: 1922333361}
+  m_Father: {fileID: 397743427}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 152, y: -55}
+  m_SizeDelta: {x: 300, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1341972280
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1341972278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1922333362}
+  toggleTransition: 1
+  graphic: {fileID: 690401034}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_IsOn: 0
 --- !u!1 &1350795546
 GameObject:
   m_ObjectHideFlags: 0
@@ -5885,6 +6049,85 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1543731663}
+  m_CullTransparentMesh: 1
+--- !u!1 &1568416101
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1568416102}
+  - component: {fileID: 1568416104}
+  - component: {fileID: 1568416103}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1568416102
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1568416101}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1341972279}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -68.93698, y: -0.5}
+  m_SizeDelta: {x: -137.876, y: -3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1568416103
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1568416101}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 28
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 5
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Use Default Settings
+--- !u!222 &1568416104
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1568416101}
   m_CullTransparentMesh: 1
 --- !u!1 &1571725899
 GameObject:
@@ -7673,6 +7916,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1892752226}
   m_CullTransparentMesh: 1
+--- !u!1 &1922333360
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1922333361}
+  - component: {fileID: 1922333363}
+  - component: {fileID: 1922333362}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1922333361
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922333360}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 690401033}
+  m_Father: {fileID: 1341972279}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 197, y: 0}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1922333362
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922333360}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1922333363
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922333360}
+  m_CullTransparentMesh: 1
 --- !u!1 &1925992335
 GameObject:
   m_ObjectHideFlags: 0
@@ -7786,11 +8105,11 @@ RectTransform:
   - {fileID: 43381537}
   - {fileID: 1584422740}
   m_Father: {fileID: 397743427}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 295, y: -338}
+  m_AnchoredPosition: {x: 294, y: -403.257}
   m_SizeDelta: {x: 584, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1979558881

--- a/com.unity.renderstreaming/Samples~/Example/Multiplay/MultiplaySample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Multiplay/MultiplaySample.cs
@@ -87,7 +87,8 @@ namespace Unity.RenderStreaming.Samples
             playerController.CheckPairedDevices();
 
             statsUI.AddSignalingHandler(handler);
-            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings != null)
+                renderStreaming.useDefaultSettings = settings.UseDefaultSettings;
             if (settings?.SignalingSettings != null)
                 renderStreaming.SetSignalingSettings(settings.SignalingSettings);
             renderStreaming.Run(handlers: new SignalingHandlerBase[] {handler});
@@ -99,7 +100,8 @@ namespace Unity.RenderStreaming.Samples
             var handler = guestPlayer.GetComponent<SingleConnection>();
 
             statsUI.AddSignalingHandler(handler);
-            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings != null)
+                renderStreaming.useDefaultSettings = settings.UseDefaultSettings;
             if (settings?.SignalingSettings != null)
                 renderStreaming.SetSignalingSettings(settings.SignalingSettings);
             renderStreaming.Run(handlers: new SignalingHandlerBase[] {handler});

--- a/com.unity.renderstreaming/Samples~/Example/Multiplay/MultiplaySample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Multiplay/MultiplaySample.cs
@@ -87,9 +87,10 @@ namespace Unity.RenderStreaming.Samples
             playerController.CheckPairedDevices();
 
             statsUI.AddSignalingHandler(handler);
-            renderStreaming.Run(signaling: settings?.Signaling,
-                handlers: new SignalingHandlerBase[] {handler}
-            );
+            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings?.SignalingSettings != null)
+                renderStreaming.SetSignalingSettings(settings.SignalingSettings);
+            renderStreaming.Run(handlers: new SignalingHandlerBase[] {handler});
         }
 
         IEnumerator SetUpGuest(string username, string connectionId)
@@ -98,9 +99,10 @@ namespace Unity.RenderStreaming.Samples
             var handler = guestPlayer.GetComponent<SingleConnection>();
 
             statsUI.AddSignalingHandler(handler);
-            renderStreaming.Run(signaling: settings?.Signaling,
-                handlers: new SignalingHandlerBase[] {handler}
-            );
+            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings?.SignalingSettings != null)
+                renderStreaming.SetSignalingSettings(settings.SignalingSettings);
+            renderStreaming.Run(handlers: new SignalingHandlerBase[] {handler});
 
             videoImage.gameObject.SetActive(true);
             var receiveVideoViewer = guestPlayer.GetComponent<VideoStreamReceiver>();

--- a/com.unity.renderstreaming/Samples~/Example/Receiver/ReceiverSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Receiver/ReceiverSample.cs
@@ -70,7 +70,11 @@ namespace Unity.RenderStreaming.Samples
         {
             if (renderStreaming.runOnAwake)
                 return;
-            renderStreaming.Run(signaling: settings?.Signaling);
+
+            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings?.SignalingSettings != null)
+                renderStreaming.SetSignalingSettings(settings.SignalingSettings);
+            renderStreaming.Run();
         }
 
         private void Update()

--- a/com.unity.renderstreaming/Samples~/Example/Receiver/ReceiverSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Receiver/ReceiverSample.cs
@@ -71,7 +71,8 @@ namespace Unity.RenderStreaming.Samples
             if (renderStreaming.runOnAwake)
                 return;
 
-            renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+            if (settings != null)
+                renderStreaming.useDefaultSettings = settings.UseDefaultSettings;
             if (settings?.SignalingSettings != null)
                 renderStreaming.SetSignalingSettings(settings.SignalingSettings);
             renderStreaming.Run();

--- a/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Scripts/SceneSelectUI.cs
@@ -28,6 +28,7 @@ namespace Unity.RenderStreaming.Samples
         public const int DefaultStreamWidth = 1280;
         public const int DefaultStreamHeight = 720;
 
+        private bool useDefaultSettings = false;
         private SignalingType signalingType = SignalingType.WebSocket;
         private string signalingAddress = "localhost";
         private float signalingInterval = 5;
@@ -35,6 +36,12 @@ namespace Unity.RenderStreaming.Samples
         private Vector2Int streamSize = new Vector2Int(DefaultStreamWidth, DefaultStreamHeight);
         private VideoCodecInfo receiverVideoCodec = null;
         private VideoCodecInfo senderVideoCodec = null;
+
+        public bool UseDefaultSettings
+        {
+            get { return useDefaultSettings; }
+            set { useDefaultSettings = value; }
+        }
 
         public SignalingType SignalingType
         {
@@ -60,7 +67,7 @@ namespace Unity.RenderStreaming.Samples
             set { signalingInterval = value; }
         }
 
-        public ISignaling Signaling
+        public SignalingSettings SignalingSettings
         {
             get
             {
@@ -69,33 +76,29 @@ namespace Unity.RenderStreaming.Samples
                     case SignalingType.Furioos:
                     {
                         var schema = signalingSecured ? "https" : "http";
-                        var settings = new FurioosSignalingSettings
+                        return new FurioosSignalingSettings
                         (
                             url: $"{schema}://{signalingAddress}"
                         );
-                        return new FurioosSignaling(settings, SynchronizationContext.Current);
                     }
                     case SignalingType.WebSocket:
                     {
                         var schema = signalingSecured ? "wss" : "ws";
-                        var settings = new WebSocketSignalingSettings
+                        return new WebSocketSignalingSettings
                         (
                             url: $"{schema}://{signalingAddress}"
                         );
-                        return new WebSocketSignaling(settings, SynchronizationContext.Current);
                     }
                     case SignalingType.Http:
                     {
                         var schema = signalingSecured ? "https" : "http";
-                        var settings = new HttpSignalingSettings
+                        return new HttpSignalingSettings
                         (
                             url: $"{schema}://{signalingAddress}",
                             interval: signalingInterval
                         );
-                        return new FurioosSignaling(settings, SynchronizationContext.Current);
                     }
                 }
-
                 throw new InvalidOperationException();
             }
         }
@@ -121,6 +124,7 @@ namespace Unity.RenderStreaming.Samples
 
     internal class SceneSelectUI : MonoBehaviour
     {
+        [SerializeField] private Toggle toggleUseDefaultSettings;
         [SerializeField] private Dropdown dropdownSignalingType;
         [SerializeField] private InputField inputFieldSignalingAddress;
         [SerializeField] private Toggle toggleSignalingSecured;
@@ -178,16 +182,20 @@ namespace Unity.RenderStreaming.Samples
             SampleManager.Instance.Initialize();
             settings  = SampleManager.Instance.Settings;
 
+            toggleUseDefaultSettings.isOn = settings.UseDefaultSettings;
             dropdownSignalingType.value = (int)settings.SignalingType;
             inputFieldSignalingAddress.text = settings.SignalingAddress;
             toggleSignalingSecured.isOn = settings.SignalingSecured;
             inputFieldSignalingInterval.text =
                 settings.SignalingInterval.ToString(CultureInfo.InvariantCulture);
 
+            toggleUseDefaultSettings.onValueChanged.AddListener(OnChangeUseDefaultSettings);
             dropdownSignalingType.onValueChanged.AddListener(OnChangeSignalingType);
             inputFieldSignalingAddress.onValueChanged.AddListener(OnChangeSignalingAddress);
             toggleSignalingSecured.onValueChanged.AddListener(OnChangeSignalingSecured);
             inputFieldSignalingInterval.onValueChanged.AddListener(OnChangeSignalingInterval);
+
+            SetInteractableSignalingUI(!settings.UseDefaultSettings);
 
             var optionList = streamSizeList.Select(size => new Dropdown.OptionData($" {size.x} x {size.y} ")).ToList();
             optionList.Add(new Dropdown.OptionData(" Custom "));
@@ -283,6 +291,20 @@ namespace Unity.RenderStreaming.Samples
         private void OnChangeSignalingSecured(bool value)
         {
             settings.SignalingSecured = value;
+        }
+
+        private void OnChangeUseDefaultSettings(bool value)
+        {
+            settings.UseDefaultSettings = value;
+            SetInteractableSignalingUI(!value);
+        }
+
+        private void SetInteractableSignalingUI(bool interactable)
+        {
+            dropdownSignalingType.interactable = interactable;
+            inputFieldSignalingAddress.interactable = interactable;
+            toggleSignalingSecured.interactable = interactable;
+            inputFieldSignalingInterval.interactable = interactable;
         }
 
         private void OnChangeSignalingInterval(string value)

--- a/com.unity.renderstreaming/Samples~/Example/WebBrowserInput/WebBrowserInputSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/WebBrowserInput/WebBrowserInputSample.cs
@@ -22,13 +22,14 @@ namespace Unity.RenderStreaming.Samples
         {
             dropdownCamera.onValueChanged.AddListener(OnChangeCamera);
 
-            if (!renderStreaming.runOnAwake)
-            {
-                renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
-                if (settings?.SignalingSettings != null)
-                    renderStreaming.SetSignalingSettings(settings.SignalingSettings);
-                renderStreaming.Run();
-            }
+            if (renderStreaming.runOnAwake)
+                return;
+
+            if (settings != null)
+                renderStreaming.useDefaultSettings = settings.UseDefaultSettings;
+            if (settings?.SignalingSettings != null)
+                renderStreaming.SetSignalingSettings(settings.SignalingSettings);
+            renderStreaming.Run();
         }
 
         void OnChangeCamera(int value)

--- a/com.unity.renderstreaming/Samples~/Example/WebBrowserInput/WebBrowserInputSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/WebBrowserInput/WebBrowserInputSample.cs
@@ -24,7 +24,10 @@ namespace Unity.RenderStreaming.Samples
 
             if (!renderStreaming.runOnAwake)
             {
-                renderStreaming.Run(signaling: settings?.Signaling);
+                renderStreaming.useDefaultSettings = settings?.UseDefaultSettings ?? true;
+                if (settings?.SignalingSettings != null)
+                    renderStreaming.SetSignalingSettings(settings.SignalingSettings);
+                renderStreaming.Run();
             }
         }
 

--- a/com.unity.renderstreaming/Tests/Editor/EditorTest.cs
+++ b/com.unity.renderstreaming/Tests/Editor/EditorTest.cs
@@ -163,5 +163,14 @@ namespace Unity.RenderStreaming.EditorTest
             Assert.That(asset.info.Equals(otherAsset.info), Is.True);
             AssetDatabase.DeleteAsset(exportPath);
         }
+
+        [Test]
+        public void CreateSignalingSettingsObject()
+        {
+            var asset = SignalingSettingsObject.Create();
+            Assert.That(asset, Is.Not.Null);
+            Assert.That(asset.settings, Is.Not.Null);
+            Assert.That(asset.settings, Is.TypeOf<WebSocketSignalingSettings>());
+        }
     }
 }

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingTest.cs
@@ -73,7 +73,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             var defaultSignalingSettings = defaultSettings.signalingSettings as WebSocketSignalingSettings;
             Assert.That(defaultSignalingSettings, Is.Not.Null);
             Assert.That(defaultSignalingSettings.signalingClass, Is.EqualTo(typeof(WebSocketSignaling)));
-            Assert.That(defaultSignalingSettings.url, Is.EqualTo("ws://127.0.0.1"));
+            Assert.That(defaultSignalingSettings.url, Is.EqualTo("ws://127.0.0.1:80"));
             Assert.That(defaultSignalingSettings.iceServers.ElementAt(0).urls, Is.EquivalentTo(new string[] {"stun:stun.l.google.com:19302"}));
         }
 

--- a/com.unity.renderstreaming/Tests/Runtime/RenderStreamingTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/RenderStreamingTest.cs
@@ -73,7 +73,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             var defaultSignalingSettings = defaultSettings.signalingSettings as WebSocketSignalingSettings;
             Assert.That(defaultSignalingSettings, Is.Not.Null);
             Assert.That(defaultSignalingSettings.signalingClass, Is.EqualTo(typeof(WebSocketSignaling)));
-            Assert.That(defaultSignalingSettings.url, Is.EqualTo("ws://127.0.0.1:80"));
+            Assert.That(defaultSignalingSettings.url, Is.EqualTo("ws://127.0.0.1"));
             Assert.That(defaultSignalingSettings.iceServers.ElementAt(0).urls, Is.EquivalentTo(new string[] {"stun:stun.l.google.com:19302"}));
         }
 

--- a/com.unity.renderstreaming/Tests/Runtime/SignalingManagerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingManagerTest.cs
@@ -32,6 +32,14 @@ namespace Unity.RenderStreaming.RuntimeTest
         }
 
         [Test]
+        public void UseDefaultSettings()
+        {
+            Assert.That(component.useDefaultSettings, Is.True);
+            component.useDefaultSettings = false;
+            Assert.That(component.useDefaultSettings, Is.False);
+        }
+
+        [Test]
         public void Run()
         {
             var handler = component.gameObject.AddComponent<SingleConnection>();
@@ -91,8 +99,6 @@ namespace Unity.RenderStreaming.RuntimeTest
 
             var settings = component.GetSignalingSettings() as WebSocketSignalingSettings;
             Assert.That(settings, Is.Not.Null);
-            Assert.That(settings.url, Is.Not.Null);
-            Assert.That(settings.iceServers, Is.Not.Null);
         }
 
         [Test]


### PR DESCRIPTION
This pull request makes ScriptableObject for SignalingSettings class and can set settings into SignalingManager inspector. Signaling settings is also configured in Project Settings window, developers select the reference of settings from two ways, from Project Settings or SignalingManager inspector.

https://user-images.githubusercontent.com/1132081/216274700-7803e551-3fb4-490c-9857-ffb6642fa334.mov

