### PR TITLE
fix: Signaling Manager test Run again immediately. 

### DIFF
--- a/com.unity.renderstreaming/Tests/Runtime/SignalingManagerTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/SignalingManagerTest.cs
@@ -76,8 +76,8 @@ namespace Unity.RenderStreaming.RuntimeTest
         }
 
 
-        [UnityTest]
-        public IEnumerator RunAgain()
+        [Test]
+        public void RunAgain()
         {
             var handler = component.gameObject.AddComponent<SingleConnection>();
             var handlers = new SignalingHandlerBase[] { handler };
@@ -85,9 +85,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             component.runOnAwake = false;
             component.gameObject.SetActive(true);
             component.Run(signaling:mock, handlers:handlers);
-            yield return 0;
             component.Stop();
-            yield return 0;
             component.Run(signaling:mock, handlers:handlers);
         }
 


### PR DESCRIPTION
https://github.com/Unity-Technologies/UnityRenderStreaming/issues/529

This issue not reproduced on current version.
By changing the test, it does not reproduce.