### PR TITLE
Fix: fix update input settings by wizard

### DIFF
--- a/com.unity.renderstreaming/Editor/RenderStreamingWizard.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingWizard.cs
@@ -177,14 +177,10 @@ namespace Unity.RenderStreaming.Editor
         private static bool IsInputSystemBackgroundBehaviorCorrect() =>
             UnityEngine.InputSystem.InputSystem.settings.backgroundBehavior == InputSettings.BackgroundBehavior.IgnoreFocus;
 
-
-        // workaround: Update using SerializedProperty because settings are not persisted via InputSystem API.
         private static void FixInputSystemBackgroundBehavior()
         {
-            var settingsObject = new SerializedObject(UnityEngine.InputSystem.InputSystem.settings);
-            var property = settingsObject.FindProperty("m_BackgroundBehavior");
-            property.enumValueIndex = (int)InputSettings.BackgroundBehavior.IgnoreFocus;
-            settingsObject.ApplyModifiedProperties();
+            UnityEngine.InputSystem.InputSystem.settings.backgroundBehavior = InputSettings.BackgroundBehavior.IgnoreFocus;
+            EditorUtility.SetDirty(UnityEngine.InputSystem.InputSystem.settings);
         }
 
         private static bool IsInputSystemPlayModeInputBehaviorCorrect() =>
@@ -193,10 +189,8 @@ namespace Unity.RenderStreaming.Editor
 
         private static void FixInputSystemPlayModeInputBehavior()
         {
-            var settingsObject = new SerializedObject(UnityEngine.InputSystem.InputSystem.settings);
-            var property = settingsObject.FindProperty("m_EditorInputBehaviorInPlayMode");
-            property.enumValueIndex = (int)InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView;
-            settingsObject.ApplyModifiedProperties();
+            UnityEngine.InputSystem.InputSystem.settings.editorInputBehaviorInPlayMode = InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView;
+            EditorUtility.SetDirty(UnityEngine.InputSystem.InputSystem.settings);
         }
 
         private static bool IsSupportedBuildTarget()

--- a/com.unity.renderstreaming/Editor/RenderStreamingWizard.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingWizard.cs
@@ -177,16 +177,27 @@ namespace Unity.RenderStreaming.Editor
         private static bool IsInputSystemBackgroundBehaviorCorrect() =>
             UnityEngine.InputSystem.InputSystem.settings.backgroundBehavior == InputSettings.BackgroundBehavior.IgnoreFocus;
 
-        private static void FixInputSystemBackgroundBehavior() =>
-            UnityEngine.InputSystem.InputSystem.settings.backgroundBehavior = InputSettings.BackgroundBehavior.IgnoreFocus;
+
+        // workaround: Update using SerializedProperty because settings are not persisted via InputSystem API.
+        private static void FixInputSystemBackgroundBehavior()
+        {
+            var settingsObject = new SerializedObject(UnityEngine.InputSystem.InputSystem.settings);
+            var property = settingsObject.FindProperty("m_BackgroundBehavior");
+            property.enumValueIndex = (int)InputSettings.BackgroundBehavior.IgnoreFocus;
+            settingsObject.ApplyModifiedProperties();
+        }
 
         private static bool IsInputSystemPlayModeInputBehaviorCorrect() =>
             UnityEngine.InputSystem.InputSystem.settings.editorInputBehaviorInPlayMode ==
             InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView;
 
-        private static void FixInputSystemPlayModeInputBehavior() =>
-            UnityEngine.InputSystem.InputSystem.settings.editorInputBehaviorInPlayMode =
-                InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView;
+        private static void FixInputSystemPlayModeInputBehavior()
+        {
+            var settingsObject = new SerializedObject(UnityEngine.InputSystem.InputSystem.settings);
+            var property = settingsObject.FindProperty("m_EditorInputBehaviorInPlayMode");
+            property.enumValueIndex = (int)InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView;
+            settingsObject.ApplyModifiedProperties();
+        }
 
         private static bool IsSupportedBuildTarget()
         {

--- a/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/RenderStreaming.cs
@@ -57,6 +57,11 @@ namespace Unity.RenderStreaming
             get => s_settings.automaticStreaming;
             set
             {
+                if (s_settings.automaticStreaming == value)
+                {
+                    return;
+                }
+
                 s_settings.automaticStreaming = value;
                 ApplySettings();
             }
@@ -124,6 +129,10 @@ namespace Unity.RenderStreaming
 
         internal static void ApplySettings()
         {
+#if UNITY_EDITOR
+            EditorUtility.SetDirty(s_settings);
+#endif
+
             if (!m_running)
             {
                 return;


### PR DESCRIPTION
User reported Question1 on https://github.com/Unity-Technologies/UnityRenderStreaming/issues/868
I reproduce on main branch.

Changes from scripts in Scriptable Objects will not be persisted at the end Editor unless `SetDirty`.