### PR TITLE
Fix: fix the version of Serialized Reference Object by URP/HDRP scene

### DIFF
--- a/RenderStreaming~/ProjectSettings/EditorBuildSettings.asset
+++ b/RenderStreaming~/ProjectSettings/EditorBuildSettings.asset
@@ -42,7 +42,7 @@ EditorBuildSettings:
       type: 2}
     com.unity.input.settings: {fileID: 11400000, guid: 9d3afefa5e1574ee38fb1d298122dbc7,
       type: 2}
-    com.unity.renderstreaming.settings: {fileID: 11400000, guid: eaaad242393318e4f85c45e69c8837f0,
+    com.unity.renderstreaming.settings: {fileID: 11400000, guid: 039337c008e9a5c44a60f957eae3e450,
       type: 2}
     com.unity.xr.management.loader_settings: {fileID: 11400000, guid: 66105b57eda77e74db55e7eb2b532054,
       type: 2}

--- a/com.unity.renderstreaming/Samples~/Example/RenderPipeline/HDRP.unity
+++ b/com.unity.renderstreaming/Samples~/Example/RenderPipeline/HDRP.unity
@@ -4647,15 +4647,14 @@ MonoBehaviour:
   m_useDefault: 1
   signalingSettingsObject: {fileID: 0}
   signalingSettings:
-    rid: 0
+    id: 0
   handlers:
   - {fileID: 1131364784}
   runOnAwake: 0
   evaluateCommandlineArguments: 1
   references:
-    version: 2
-    RefIds:
-    - rid: 0
+    version: 1
+    00000000:
       type: {class: WebSocketSignalingSettings, ns: Unity.RenderStreaming, asm: Unity.RenderStreaming}
       data:
         m_url: ws://127.0.0.1

--- a/com.unity.renderstreaming/Samples~/Example/RenderPipeline/URP.unity
+++ b/com.unity.renderstreaming/Samples~/Example/RenderPipeline/URP.unity
@@ -6097,15 +6097,14 @@ MonoBehaviour:
   m_useDefault: 1
   signalingSettingsObject: {fileID: 0}
   signalingSettings:
-    rid: 0
+    id: 0
   handlers:
   - {fileID: 1623734776}
   runOnAwake: 0
   evaluateCommandlineArguments: 1
   references:
-    version: 2
-    RefIds:
-    - rid: 0
+    version: 1
+    00000000:
       type: {class: WebSocketSignalingSettings, ns: Unity.RenderStreaming, asm: Unity.RenderStreaming}
       data:
         m_url: ws://127.0.0.1


### PR DESCRIPTION
Build error on Unity 2020.3.
Asset version serialized in HDRP/URP scene is not supported in 2020.3