### PR TITLE
Fix: Create input settings from wizard

### DIFF
--- a/com.unity.renderstreaming/Editor/ConfigInfoLine.cs
+++ b/com.unity.renderstreaming/Editor/ConfigInfoLine.cs
@@ -20,7 +20,7 @@ namespace Unity.RenderStreaming.Editor
         private Func<bool> m_dependTester;
         private bool m_haveFixer;
         private bool m_currentStatus;
-        private bool m_dependStats;
+        private bool m_dependStatus;
 
         public ConfigInfoLine(
             string label,
@@ -75,7 +75,7 @@ namespace Unity.RenderStreaming.Editor
 
             Add(new HelpBox(error, kind));
 
-            UpdateDisplay(m_currentStatus, m_haveFixer, m_dependStats);
+            UpdateDisplay(m_currentStatus, m_haveFixer, m_dependStatus);
         }
 
         public void CheckUpdate()
@@ -83,12 +83,12 @@ namespace Unity.RenderStreaming.Editor
             bool wellConfigured = m_tester();
             bool wellDependConfigured = m_dependTester == null || m_dependTester();
             bool changeConfigured = wellConfigured ^ m_currentStatus;
-            bool changeDependConfigured = wellDependConfigured ^ m_dependStats;
+            bool changeDependConfigured = wellDependConfigured ^ m_dependStatus;
             if (changeConfigured || changeDependConfigured)
             {
                 UpdateDisplay(wellConfigured, m_haveFixer, wellDependConfigured);
                 m_currentStatus = wellConfigured;
-                m_dependStats = wellDependConfigured;
+                m_dependStatus = wellDependConfigured;
             }
         }
 

--- a/com.unity.renderstreaming/Editor/RenderStreamingWizard.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingWizard.cs
@@ -48,6 +48,10 @@ namespace Unity.RenderStreaming.Editor
             label: "Run In Background",
             error: "Run In Background must be True for Render Streaming to work in Background.");
 
+        static readonly ConfigStyle inputSystemSettingsAssets = new ConfigStyle(
+            label: "Input System Settings Assets",
+            error: "Input System Settings asset must exist under the Assets folder for changes.");
+
         static readonly ConfigStyle inputSystemBackgroundBehavior = new ConfigStyle(
             label: "InputSystem Background Behavior",
             error: "InputSystem Background Behavior must be Ignore Focus for Input System to work in Background.");
@@ -144,6 +148,7 @@ namespace Unity.RenderStreaming.Editor
                     entries = new[]
                     {
                         new Entry(Scope.PlayMode, runInBackground, IsRunInBackgroundCorrect, FixRunInBackground),
+                        new Entry(Scope.PlayMode, inputSystemSettingsAssets, IsInputSettingsAssetsExists, FixInputSettingsAssets),
                         new Entry(Scope.PlayMode, inputSystemBackgroundBehavior,
                             IsInputSystemBackgroundBehaviorCorrect,
                             FixInputSystemBackgroundBehavior),
@@ -173,6 +178,19 @@ namespace Unity.RenderStreaming.Editor
 
         private static bool IsRunInBackgroundCorrect() => PlayerSettings.runInBackground;
         private static void FixRunInBackground() => PlayerSettings.runInBackground = true;
+
+        private static bool IsInputSettingsAssetsExists()
+        {
+            var path = AssetDatabase.GetAssetPath(UnityEngine.InputSystem.InputSystem.settings);
+            return !string.IsNullOrEmpty(path) && path.StartsWith("Assets/");
+        }
+
+        private static void FixInputSettingsAssets()
+        {
+            var inputSettings = CreateInstance<InputSettings>();
+            AssetDatabase.CreateAsset(inputSettings, $"Assets/{PlayerSettings.productName}.inputsettings.asset");
+            UnityEngine.InputSystem.InputSystem.settings = inputSettings;
+        }
 
         private static bool IsInputSystemBackgroundBehaviorCorrect() =>
             UnityEngine.InputSystem.InputSystem.settings.backgroundBehavior == InputSettings.BackgroundBehavior.IgnoreFocus;

--- a/com.unity.renderstreaming/Editor/RenderStreamingWizard.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingWizard.cs
@@ -109,13 +109,14 @@ namespace Unity.RenderStreaming.Editor
         struct Entry
         {
             public delegate bool Checker();
-
             public delegate void Fixer();
+            public delegate bool DependChecker();
 
             public readonly Scope scope;
             public readonly ConfigStyle configStyle;
             public readonly Checker check;
             public readonly Fixer fix;
+            public readonly DependChecker dependChecker;
             public readonly bool forceDisplayCheck;
             public readonly bool skipErrorIcon;
 
@@ -124,6 +125,7 @@ namespace Unity.RenderStreaming.Editor
                 ConfigStyle configStyle,
                 Checker check,
                 Fixer fix,
+                DependChecker dependChecker = null,
                 bool forceDisplayCheck = false,
                 bool skipErrorIcon = false
             )
@@ -132,6 +134,7 @@ namespace Unity.RenderStreaming.Editor
                 this.configStyle = configStyle;
                 this.check = check;
                 this.fix = fix;
+                this.dependChecker = dependChecker;
                 this.forceDisplayCheck = forceDisplayCheck;
                 this.skipErrorIcon = skipErrorIcon;
             }
@@ -151,10 +154,12 @@ namespace Unity.RenderStreaming.Editor
                         new Entry(Scope.PlayMode, inputSystemSettingsAssets, IsInputSettingsAssetsExists, FixInputSettingsAssets),
                         new Entry(Scope.PlayMode, inputSystemBackgroundBehavior,
                             IsInputSystemBackgroundBehaviorCorrect,
-                            FixInputSystemBackgroundBehavior),
+                            FixInputSystemBackgroundBehavior,
+                            IsInputSettingsAssetsExists),
                         new Entry(Scope.PlayMode, inputSystemPlayModeInputBehavior,
                             IsInputSystemPlayModeInputBehaviorCorrect,
-                            FixInputSystemPlayModeInputBehavior),
+                            FixInputSystemPlayModeInputBehavior,
+                            IsInputSettingsAssetsExists),
                         new Entry(Scope.BuildSettings, currentBuildTarget, IsSupportedBuildTarget, FixSupportedBuildTarget),
                         new Entry(Scope.BuildSettings, currentGraphicsApi, IsSupportedGraphics, FixSupportedGraphics),
                         new Entry(Scope.BuildSettings, macCameraUsageDescription, IsMacCameraUsageCorrect, FixMacCameraUsage),
@@ -528,6 +533,7 @@ namespace Unity.RenderStreaming.Editor
                     entry.configStyle.button,
                     () => entry.check(),
                     entry.fix == null ? (Action)null : () => entry.fix(),
+                    entry.dependChecker == null ? (Func<bool>)null : () => entry.dependChecker(),
                     entry.configStyle.messageType == MessageType.Error || entry.forceDisplayCheck,
                     entry.skipErrorIcon));
             }
@@ -541,6 +547,7 @@ namespace Unity.RenderStreaming.Editor
                     entry.configStyle.button,
                     () => entry.check(),
                     entry.fix == null ? (Action)null : () => entry.fix(),
+                    entry.dependChecker == null ? (Func<bool>)null : () => entry.dependChecker(),
                     entry.configStyle.messageType == MessageType.Error || entry.forceDisplayCheck,
                     entry.skipErrorIcon));
             }


### PR DESCRIPTION
InputSettings that do not exist under Assets can't modify, so added check and fix button that create asset under Assets Folder.

![image](https://user-images.githubusercontent.com/26959415/219523188-c35d0455-9bd3-418a-be51-7aa842ed893b.png)
