### PR TITLE
fix: Fix issue when using AudioSourceType.Microphone

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -377,6 +377,7 @@ namespace Unity.RenderStreaming
             int m_frequency;
             string m_deviceName;
             AudioSource m_audioSource;
+            GameObject m_audioSourceObj;
             AudioStreamSender m_parent;
 
             public AudioStreamSourceMicrophone(AudioStreamSender parent) : base(parent)
@@ -414,7 +415,10 @@ namespace Unity.RenderStreaming
                 // set the latency to “0” samples before the audio starts to play.
                 yield return new WaitUntil(() => Microphone.GetPosition(m_deviceName) > 0);
 
-                m_audioSource = m_parent.gameObject.AddComponent<AudioSource>();
+                m_audioSourceObj = new GameObject("Audio");
+                m_audioSourceObj.hideFlags = HideFlags.HideInHierarchy;
+                DontDestroyOnLoad(m_audioSourceObj);
+                m_audioSource = m_audioSourceObj.AddComponent<AudioSource>();
                 m_audioSource.clip = micClip;
                 m_audioSource.loop = true;
                 m_audioSource.Play();
@@ -424,7 +428,7 @@ namespace Unity.RenderStreaming
 
             public override void Dispose()
             {
-                if (m_audioSource != null)
+                if (m_audioSourceObj != null)
                 {
                     m_audioSource.Stop();
                     var clip = m_audioSource.clip;
@@ -434,7 +438,8 @@ namespace Unity.RenderStreaming
                     }
                     m_audioSource.clip = null;
 
-                    Destroy(m_audioSource);
+                    Destroy(m_audioSourceObj);
+                    m_audioSourceObj = null;
                     m_audioSource = null;
                 }
                 if (Microphone.IsRecording(m_deviceName))


### PR DESCRIPTION
We got an error when using `AudioSourceType.Microphone` in Broadcast sample. The cause of this error is attaching multiple AudioSource components to the single gameObject. To fix this issue, this pull request fixes that instantiate new GameObject for attaching AudioSource component to play Microphone.

```
GameObject has multiple AudioSources and/or AudioListeners attached. While built-in filters like lowpass are instantiated separately, components implementing OnAudioFilterRead may only be used by either one AudioSource or AudioListener at a time.
The reason for this is that any state information used by the callback exists only once in the component, and the source or listener calling it cannot be inferred from the callback.
In this case the OnAudioFilterRead callback of script AudioCustomFilter was first attached to a component of type AudioSource on the game object MainCamera after which a component of type AudioListener tried to attach it.
UnityEngine.GameObject:AddComponent<Unity.WebRTC.AudioCustomFilter> ()
Unity.WebRTC.AudioStreamTrack:.ctor (UnityEngine.AudioSource) (at Library/PackageCache/com.unity.webrtc@3.0.0-pre.4/Runtime/Scripts/AudioStreamTrack.cs:193)
Unity.RenderStreaming.AudioStreamSender/AudioStreamSourceMicrophone/<CreateTrackCoroutine>d__8:MoveNext () (at Packages/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs:422)
UnityEngine.SetupCoroutine:InvokeMoveNext (System.Collections.IEnumerator,intptr)
```