### PR TITLE
fix: Fix SetTextureSize when using VideoSourceType.Texture

### DIFF
--- a/com.unity.renderstreaming/Editor/VideoStreamSenderEditor.cs
+++ b/com.unity.renderstreaming/Editor/VideoStreamSenderEditor.cs
@@ -120,8 +120,10 @@ namespace Unity.RenderStreaming.Editor
             EditorGUILayout.EndFadeGroup();
 
             if (EditorGUILayout.BeginFadeGroup(m_sourceFade[(int)VideoStreamSource.Texture].faded))
+            {
                 EditorGUILayout.PropertyField(m_texture);
                 EditorGUILayout.PropertyField(m_textureSize);
+            }
             EditorGUILayout.EndFadeGroup();
 
             if (EditorGUILayout.BeginFadeGroup(m_sourceFade[(int)VideoStreamSource.WebCamera].faded))

--- a/com.unity.renderstreaming/Editor/VideoStreamSenderEditor.cs
+++ b/com.unity.renderstreaming/Editor/VideoStreamSenderEditor.cs
@@ -121,6 +121,7 @@ namespace Unity.RenderStreaming.Editor
 
             if (EditorGUILayout.BeginFadeGroup(m_sourceFade[(int)VideoStreamSource.Texture].faded))
                 EditorGUILayout.PropertyField(m_texture);
+                EditorGUILayout.PropertyField(m_textureSize);
             EditorGUILayout.EndFadeGroup();
 
             if (EditorGUILayout.BeginFadeGroup(m_sourceFade[(int)VideoStreamSource.WebCamera].faded))

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -579,7 +579,7 @@ namespace Unity.RenderStreaming
 
                 GraphicsFormat format =
                     WebRTC.WebRTC.GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);
-                if (m_texture.graphicsFormat == format)
+                if (m_texture.graphicsFormat == format && m_texture.width == width && m_texture.height == height)
                 {
                     instruction.Done(new VideoStreamTrack(m_texture));
                     return instruction;

--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -423,8 +423,6 @@ namespace Unity.RenderStreaming
         /// <param name="size"></param>
         public void SetTextureSize(Vector2Int size)
         {
-            if (m_Source == VideoStreamSource.Texture)
-                throw new InvalidOperationException("Video source is set Texture.");
             m_TextureSize = size;
 
             if (!isPlaying)

--- a/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
+++ b/com.unity.renderstreaming/Samples~/Example/Broadcast/BroadcastSample.cs
@@ -173,11 +173,8 @@ namespace Unity.RenderStreaming.Samples
         {
             var resolution = resolutionOptions.Values.ElementAt(index);
 
-            if (videoStreamSender.source != VideoStreamSource.Texture)
-            {
-                videoStreamSender.SetTextureSize(resolution);
-                CalculateInputRegion();
-            }
+            videoStreamSender.SetTextureSize(resolution);
+            CalculateInputRegion();
         }
 
         private void Start()

--- a/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/StreamingComponentTest.cs
@@ -113,8 +113,8 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(sender.sourceTexture, Is.Not.Null);
             Assert.That(sender.width, Is.EqualTo(width));
             Assert.That(sender.height, Is.EqualTo(height));
-            Assert.That(() => sender.width = 1280, Throws.Exception.TypeOf<InvalidOperationException>());
-            Assert.That(() => sender.height = 720, Throws.Exception.TypeOf<InvalidOperationException>());
+            Assert.That(() => sender.width = 1280, Throws.Nothing);
+            Assert.That(() => sender.height = 720, Throws.Nothing);
             op = sender.CreateTrack();
             yield return op;
             track = op.Track;


### PR DESCRIPTION
This PR fixes this issue. https://github.com/Unity-Technologies/UnityRenderStreaming/issues/859