### PR TITLE
Fix: Stream AudioStreamTrack APIOnly

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AudioStreamSender.cs
@@ -466,7 +466,7 @@ namespace Unity.RenderStreaming
             {
                 var instruction = new WaitForCreateTrack();
                 m_audioTrack = new AudioStreamTrack();
-                instruction.Done(new AudioStreamTrack());
+                instruction.Done(m_audioTrack);
                 return instruction;
             }
 

--- a/com.unity.renderstreaming/Runtime/Scripts/AutomaticStreaming.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/AutomaticStreaming.cs
@@ -86,6 +86,7 @@ namespace Unity.RenderStreaming
 
                 var nativeArray = new NativeArray<float>(data, Allocator.Temp);
                 sender.SetData(ref nativeArray, channels);
+                nativeArray.Dispose();
             }
 
             private void OnDestroy()


### PR DESCRIPTION
The Track used for `SetData` and the Track used for stream are different.