### PR TITLE
fix: Fix timed out sessions collecting in signaling server

### DIFF
--- a/WebApp/src/class/httphandler.ts
+++ b/WebApp/src/class/httphandler.ts
@@ -67,7 +67,7 @@ function checkSessionId(req: Request, res: Response, next): void {
   if (!clients.has(id)) {
     res.sendStatus(404);
     return;
-  } 
+  }
   lastRequestedTime.set(id, Date.now());
   next();
 }
@@ -119,11 +119,11 @@ function _deleteSession(sessionId: string) {
 
 function _checkForTimedOutSessions(): void {
   for (const sessionId of Array.from(clients.keys()))
-  {
-	if(!lastRequestedTime.has(sessionId))
+  {
+    if(!lastRequestedTime.has(sessionId))
       continue;
     if(lastRequestedTime.get(sessionId) > Date.now() - TimeoutRequestedTime)
-      continue;  
+      continue;
     _deleteSession(sessionId);
     console.log("deleted");
   }
@@ -341,7 +341,7 @@ function postOffer(req: Request, res: Response): void {
   {
     connectionPair.set(connectionId, [sessionId, null]);
   }
-  
+
   keySessionId = sessionId;
   const map = offers.get(keySessionId);
   map.set(connectionId, new Offer(req.body.sdp, Date.now(), polite));

--- a/WebApp/src/class/httphandler.ts
+++ b/WebApp/src/class/httphandler.ts
@@ -117,30 +117,25 @@ function _deleteSession(sessionId: string) {
   disconnections.delete(sessionId);
 }
 
-function _checkDeletedSession(sessionId: string): void {
-  const connectionIds = Array.from(clients.get(sessionId));
-  for (const connectionId of connectionIds) {
-    const pair = connectionPair.get(connectionId);
-    if (pair == null) {
+function _checkForTimedOutSessions(): void {
+  for (const sessionId of Array.from(clients.keys()))
+  {
+	if(!lastRequestedTime.has(sessionId))
       continue;
-    }
-	const otherSessionId = sessionId === pair[0] ? pair[1] : pair[0];
-	if(!lastRequestedTime.has(otherSessionId))
-      continue;
-    if(lastRequestedTime.get(otherSessionId) > Date.now() - TimeoutRequestedTime)
+    if(lastRequestedTime.get(sessionId) > Date.now() - TimeoutRequestedTime)
       continue;  
-    _deleteSession(otherSessionId);
+    _deleteSession(sessionId);
     console.log("deleted");
   }
 }
 
 function _getConnection(sessionId: string): string[] {
-  _checkDeletedSession(sessionId);
+  _checkForTimedOutSessions();
   return Array.from(clients.get(sessionId));
 }
 
 function _getDisconnection(sessionId: string, fromTime: number): Disconnection[] {
-  _checkDeletedSession(sessionId);
+  _checkForTimedOutSessions();
   let arrayDisconnections: Disconnection[] = [];
   if (disconnections.size != 0 && disconnections.has(sessionId)) {
     arrayDisconnections = disconnections.get(sessionId);

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
@@ -92,7 +92,7 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
                 await Task.Delay(MillisecondsDelay);
                 foreach (var signaling in signalingToConnectionLookup.Keys.Where(e => e != owner))
                 {
-                    addToLookups(signaling, data.connectionId);
+                    addToLookups(owner, data.connectionId);
                     signaling.OnAnswer?.Invoke(signaling, data);
                 }
             }

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
@@ -24,8 +24,8 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
 
         class MockPublicSignalingManager : IMockSignalingManager
         {
-            private Dictionary<MockSignaling, HashSet<string>> signalingToConnectionLookup = new ();
-            private Dictionary<string, HashSet<MockSignaling>> connectionToSignalingLookup = new();
+            private Dictionary<MockSignaling, HashSet<string>> signalingToConnectionLookup = new Dictionary<MockSignaling, HashSet<string>>();
+            private Dictionary<string, HashSet<MockSignaling>> connectionToSignalingLookup = new Dictionary<string, HashSet<MockSignaling>>();
             private const int MillisecondsDelay = 10;
 
             public async Task Add(MockSignaling signaling)

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
@@ -31,6 +31,8 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
             public async Task Add(MockSignaling signaling)
             {
                 await Task.Delay(MillisecondsDelay);
+                signalingToConnectionLookup[signaling] = new HashSet<string>();
+
                 signaling.OnStart?.Invoke(signaling);
             }
 
@@ -90,8 +92,8 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
                 await Task.Delay(MillisecondsDelay);
                 foreach (var signaling in signalingToConnectionLookup.Keys.Where(e => e != owner))
                 {
+                    addToLookups(signaling, data.connectionId);
                     signaling.OnAnswer?.Invoke(signaling, data);
-                    addToLookups(owner, data.connectionId);
                 }
             }
 

--- a/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/Signaling/MockSignaling.cs
@@ -24,34 +24,54 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
 
         class MockPublicSignalingManager : IMockSignalingManager
         {
-            private List<MockSignaling> list = new List<MockSignaling>();
+            private Dictionary<MockSignaling, HashSet<string>> signalingToConnectionLookup = new ();
+            private Dictionary<string, HashSet<MockSignaling>> connectionToSignalingLookup = new();
             private const int MillisecondsDelay = 10;
 
             public async Task Add(MockSignaling signaling)
             {
                 await Task.Delay(MillisecondsDelay);
-                list.Add(signaling);
                 signaling.OnStart?.Invoke(signaling);
             }
 
             public async Task Remove(MockSignaling signaling)
             {
                 await Task.Delay(MillisecondsDelay);
-                list.Remove(signaling);
+
+                if (signalingToConnectionLookup.ContainsKey(signaling))
+                {
+                    foreach (var connectionId in signalingToConnectionLookup[signaling])
+                    {
+                        foreach (var signalingToDisconnect in connectionToSignalingLookup[connectionId])
+                        {
+                            signalingToDisconnect.OnDestroyConnection?.Invoke(signaling, connectionId);
+                        }
+
+                        connectionToSignalingLookup.Remove(connectionId);
+                    }
+
+                    signalingToConnectionLookup.Remove(signaling);
+                }
             }
 
             public async Task OpenConnection(MockSignaling signaling, string connectionId)
             {
                 await Task.Delay(MillisecondsDelay);
+                addToLookups(signaling, connectionId);
+
                 signaling.OnCreateConnection?.Invoke(signaling, connectionId, true);
             }
 
             public async Task CloseConnection(MockSignaling signaling, string connectionId)
             {
                 await Task.Delay(MillisecondsDelay);
-                foreach (var element in list)
+
+                if (connectionToSignalingLookup.ContainsKey(connectionId))
                 {
-                    element.OnDestroyConnection?.Invoke(element, connectionId);
+                    foreach (var signalingToDisconnect in connectionToSignalingLookup[connectionId])
+                    {
+                        signalingToDisconnect.OnDestroyConnection?.Invoke(signalingToDisconnect, connectionId);
+                    }
                 }
             }
 
@@ -59,7 +79,7 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
             {
                 await Task.Delay(MillisecondsDelay);
                 data.polite = false;
-                foreach (var signaling in list.Where(e => e != owner))
+                foreach (var signaling in signalingToConnectionLookup.Keys.Where(e => e != owner))
                 {
                     signaling.OnOffer?.Invoke(signaling, data);
                 }
@@ -68,19 +88,37 @@ namespace Unity.RenderStreaming.RuntimeTest.Signaling
             public async Task Answer(MockSignaling owner, DescData data)
             {
                 await Task.Delay(MillisecondsDelay);
-                foreach (var signaling in list.Where(e => e != owner))
+                foreach (var signaling in signalingToConnectionLookup.Keys.Where(e => e != owner))
                 {
                     signaling.OnAnswer?.Invoke(signaling, data);
+                    addToLookups(owner, data.connectionId);
                 }
             }
 
             public async Task Candidate(MockSignaling owner, CandidateData data)
             {
                 await Task.Delay(MillisecondsDelay);
-                foreach (var signaling in list.Where(e => e != owner))
+                foreach (var signaling in signalingToConnectionLookup.Keys.Where(e => e != owner))
                 {
                     signaling.OnIceCandidate?.Invoke(signaling, data);
                 }
+            }
+
+            private void addToLookups(MockSignaling signaling, string connectionId)
+            {
+                if (!connectionToSignalingLookup.TryGetValue(connectionId, out var signalingSet))
+                {
+                    signalingSet = new HashSet<MockSignaling>();
+                    connectionToSignalingLookup[connectionId] = signalingSet;
+                }
+                signalingSet.Add(signaling);
+
+                if (!signalingToConnectionLookup.TryGetValue(signaling, out var connectionSet))
+                {
+                    connectionSet = new HashSet<string>();
+                    signalingToConnectionLookup[signaling] = connectionSet;
+                }
+                connectionSet.Add(connectionId);
             }
         }
 


### PR DESCRIPTION
How to reproduce:

- Set up test project with RenderStreaming samples
- Run webapp sample
- Run broadcast sample
- Connect to receiver example in chrome browser
- Once connection is established hit back in Unity application
- Log will not print out polling thread ended, and the webapp logs won't indicate a disconnect has occured.
- Doing this over and over will result in the signaling server having a large collection of timed out sessions, and can interfer with client connections.

Description of the changes:

- Allow HttpSignaling thread to exit gracefully on Stop(), by joining with a time out of interval * 2 to account for the polling interval & time to send a disconnect message. 
- Swap HttpSignaling thread to a [background thread](https://learn.microsoft.com/en-us/dotnet/standard/threading/foreground-and-background-threads) since we don't want the thread to block exiting the application on close if an error occurs.
- Update HttpHandler.ts to check all sessions for time outs when handling requests. This change will purge sessions that timed out, but don't have a client pair still polling.

How this was tested:

- Tested by running RS unit tests & WebApp unit tests.
- Ran through package samples, and the above reproduction steps.
- Added a test to SignalingTest.cs to verify stop is working corretly for the different signaling modes.
- Added a test to httphandler.test.ts to verify that any GetAll request will clear out all timed out sessions. 