### PR TITLE
fix: Error on http signaling using short interval 

### DIFF
--- a/WebApp/client/src/signaling.js
+++ b/WebApp/client/src/signaling.js
@@ -2,9 +2,10 @@ import * as Logger from "./logger.js";
 
 export class Signaling extends EventTarget {
 
-  constructor() {
+  constructor(interval = 1000) {
     super();
     this.running = false;
+    this.interval = interval;
     this.sleep = msec => new Promise(resolve => setTimeout(resolve, msec));
   }
 
@@ -15,10 +16,6 @@ export class Signaling extends EventTarget {
     else {
       return { 'Content-Type': 'application/json' };
     }
-  }
-
-  get interval() {
-    return 1000;
   }
 
   url(method, parameter='') {
@@ -136,8 +133,9 @@ export class Signaling extends EventTarget {
 
 export class WebSocketSignaling extends EventTarget {
 
-  constructor() {
+  constructor(interval = 1000) {
     super();
+    this.interval = interval;
     this.sleep = msec => new Promise(resolve => setTimeout(resolve, msec));
 
     let websocketUrl;
@@ -186,10 +184,6 @@ export class WebSocketSignaling extends EventTarget {
           break;
       }
     };
-  }
-
-  get interval() {
-    return 100;
   }
 
   async start() {

--- a/WebApp/client/src/signaling.js
+++ b/WebApp/client/src/signaling.js
@@ -53,9 +53,9 @@ export class Signaling extends EventTarget {
     let lastTimeRequest = Date.now() - 30000;
     while (this.running) {
       const res = await this.getAll(lastTimeRequest);
-      lastTimeRequest = Date.parse(res.headers.get('Date'));
-
       const data = await res.json();
+      lastTimeRequest = data.datetime ? data.datetime : Date.now();
+
       const messages = data.messages;
 
       for(const msg of messages) {

--- a/WebApp/client/test/mocksignaling.js
+++ b/WebApp/client/test/mocksignaling.js
@@ -9,8 +9,9 @@ export function reset(isPrivate) {
 
 export class MockSignaling extends EventTarget {
 
-  get interval() {
-    return 100;
+  constructor(interval = 1000) {
+    super();
+    this.interval = interval;
   }
 
   async start() {
@@ -115,7 +116,7 @@ class MockPrivateSignalingManager {
   constructor() {
     // structure Map<string:connectionId, Set<MockSignaling>> connectionIds
     this.connectionIds = new Map();
-    this.delay = () => new Promise(resolve => setTimeout(resolve, 10));
+    this.delay = async () => await sleep(10);
   }
 
   async add(signaling) {

--- a/WebApp/client/test/signaling.test.js
+++ b/WebApp/client/test/signaling.test.js
@@ -23,8 +23,8 @@ describe.each([
   beforeAll(async () => {
     if (mode == "mock") {
       reset(false);
-      signaling1 = new MockSignaling();
-      signaling2 = new MockSignaling();
+      signaling1 = new MockSignaling(1);
+      signaling2 = new MockSignaling(1);
     } else {
       const path = Path.resolve(`../bin~/${serverExeName()}`);
       let cmd = `${path} -p ${portNumber}`;
@@ -35,13 +35,13 @@ describe.each([
       await setup({ command: cmd, port: portNumber, usedPortAction: 'error' });
 
       if (mode == "http") {
-        signaling1 = new Signaling();
-        signaling2 = new Signaling();
+        signaling1 = new Signaling(1);
+        signaling2 = new Signaling(1);
       }
 
       if (mode == "websocket") {
-        signaling1 = new WebSocketSignaling();
-        signaling2 = new WebSocketSignaling();
+        signaling1 = new WebSocketSignaling(1);
+        signaling2 = new WebSocketSignaling(1);
       }
     }
 
@@ -221,8 +221,8 @@ describe.each([
   beforeAll(async () => {
     if (mode == "mock") {
       reset(true);
-      signaling1 = new MockSignaling();
-      signaling2 = new MockSignaling();
+      signaling1 = new MockSignaling(1);
+      signaling2 = new MockSignaling(1);
       return;
     }
 
@@ -235,13 +235,13 @@ describe.each([
     await setup({ command: cmd, port: portNumber, usedPortAction: 'error' });
 
     if (mode == "http") {
-      signaling1 = new Signaling();
-      signaling2 = new Signaling();
+      signaling1 = new Signaling(1);
+      signaling2 = new Signaling(1);
     }
 
     if (mode == "websocket") {
-      signaling1 = new WebSocketSignaling();
-      signaling2 = new WebSocketSignaling();
+      signaling1 = new WebSocketSignaling(1);
+      signaling2 = new WebSocketSignaling(1);
     }
 
     await signaling1.start();

--- a/WebApp/client/test/signaling.test.js
+++ b/WebApp/client/test/signaling.test.js
@@ -455,6 +455,7 @@ describe.each([
     signaling1.addEventListener('offer', (e) => offerRes1 = e.detail);
     signaling2.addEventListener('offer', (e) => offerRes2 = e.detail);
     await signaling1.sendOffer(connectionId, testsdp);
+    await waitFor(() => offerRes2 != null);
     await sleep(signaling1.interval * 2);
     expect(offerRes1).toBeUndefined();
     expect(offerRes2).not.toBeUndefined();
@@ -464,6 +465,7 @@ describe.each([
     signaling1.addEventListener('answer', (e) => answerRes1 = e.detail);
     signaling2.addEventListener('answer', (e) => answerRes2 = e.detail);
     await signaling2.sendAnswer(connectionId, testsdp);
+    await waitFor(() => answerRes1 != null);
     await sleep(signaling2.interval * 2);
     expect(answerRes1).not.toBeUndefined();
     expect(answerRes1.connectionId).toBe(connectionId);

--- a/WebApp/package-lock.json
+++ b/WebApp/package-lock.json
@@ -11,6 +11,7 @@
         "@types/express": "^4.17.13",
         "@types/node": "^18.7.15",
         "@types/ws": "^8.5.3",
+        "cors": "^2.8.5",
         "debug": "~4.3.4",
         "express": "~4.18.1",
         "morgan": "^1.10.0",
@@ -2979,6 +2980,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -7055,7 +7068,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10794,8 +10806,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -11383,6 +11394,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-require": {
       "version": "1.1.1",
@@ -13306,8 +13326,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-resolve": {
       "version": "29.0.2",
@@ -14529,8 +14548,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-hash": {
       "version": "1.3.1",
@@ -15982,8 +16000,7 @@
     "ws": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-      "requires": {}
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA=="
     },
     "xmlbuilder": {
       "version": "15.1.1",

--- a/WebApp/src/class/httphandler.ts
+++ b/WebApp/src/class/httphandler.ts
@@ -72,8 +72,7 @@ function checkSessionId(req: Request, res: Response, next): void {
   next();
 }
 
-function _deleteConnection(sessionId:string, connectionId:string) {
-  const datetime = lastRequestedTime.get(sessionId);
+function _deleteConnection(sessionId:string, connectionId:string, datetime:number) {
   clients.get(sessionId).delete(connectionId);
 
   if(isPrivate) {
@@ -108,7 +107,7 @@ function _deleteConnection(sessionId:string, connectionId:string) {
 function _deleteSession(sessionId: string) {
   if(clients.has(sessionId)) {
     for(const connectionId of Array.from(clients.get(sessionId))) {
-      _deleteConnection(sessionId, connectionId);
+      _deleteConnection(sessionId, connectionId, Date.now());
     }
   }
   offers.delete(sessionId);
@@ -315,8 +314,9 @@ function createConnection(req: Request, res: Response): void {
 function deleteConnection(req: Request, res: Response): void {
   const sessionId: string = req.header('session-id');
   const { connectionId } = req.body;
+  const datetime = lastRequestedTime.get(sessionId);
 
-  _deleteConnection(sessionId, connectionId);
+  _deleteConnection(sessionId, connectionId, datetime);
 
   res.json({ connectionId: connectionId });
 }

--- a/WebApp/src/class/httphandler.ts
+++ b/WebApp/src/class/httphandler.ts
@@ -73,6 +73,7 @@ function checkSessionId(req: Request, res: Response, next): void {
 }
 
 function _deleteConnection(sessionId:string, connectionId:string) {
+  const datetime = lastRequestedTime.get(sessionId);
   clients.get(sessionId).delete(connectionId);
 
   if(isPrivate) {
@@ -83,7 +84,7 @@ function _deleteConnection(sessionId:string, connectionId:string) {
         if (clients.has(otherSessionId)) {
           clients.get(otherSessionId).delete(connectionId);
           const array1 = disconnections.get(otherSessionId);
-          array1.push(new Disconnection(connectionId, Date.now()));
+          array1.push(new Disconnection(connectionId, datetime));
         }
       }
     }
@@ -91,7 +92,7 @@ function _deleteConnection(sessionId:string, connectionId:string) {
     disconnections.forEach((array, id) => {
       if (id == sessionId)
         return;
-      array.push(new Disconnection(connectionId, Date.now()));
+      array.push(new Disconnection(connectionId, datetime));
     });
   }
 
@@ -101,7 +102,7 @@ function _deleteConnection(sessionId:string, connectionId:string) {
   candidates.get(sessionId).delete(connectionId);
 
   const array2 = disconnections.get(sessionId);
-  array2.push(new Disconnection(connectionId, Date.now()));
+  array2.push(new Disconnection(connectionId, datetime));
 }
 
 function _deleteSession(sessionId: string) {
@@ -125,7 +126,7 @@ function _checkForTimedOutSessions(): void {
     if(lastRequestedTime.get(sessionId) > Date.now() - TimeoutRequestedTime)
       continue;
     _deleteSession(sessionId);
-    console.log("deleted");
+    console.log(`deleted sessionId:${sessionId} by timeout.`);
   }
 }
 
@@ -142,7 +143,7 @@ function _getDisconnection(sessionId: string, fromTime: number): Disconnection[]
   }
 
   if (fromTime > 0) {
-    arrayDisconnections = arrayDisconnections.filter((v) => v.datetime > fromTime);
+    arrayDisconnections = arrayDisconnections.filter((v) => v.datetime >= fromTime);
   }
   return arrayDisconnections;
 }
@@ -162,7 +163,7 @@ function _getOffer(sessionId: string, fromTime: number): [string, Offer][] {
   }
 
   if (fromTime > 0) {
-    arrayOffers = arrayOffers.filter((v) => v[1].datetime > fromTime);
+    arrayOffers = arrayOffers.filter((v) => v[1].datetime >= fromTime);
   }
   return arrayOffers;
 }
@@ -175,7 +176,7 @@ function _getAnswer(sessionId: string, fromTime: number): [string, Answer][] {
   }
 
   if (fromTime > 0) {
-    arrayAnswers = arrayAnswers.filter((v) => v[1].datetime > fromTime);
+    arrayAnswers = arrayAnswers.filter((v) => v[1].datetime >= fromTime);
   }
   return arrayAnswers;
 }
@@ -193,7 +194,7 @@ function _getCandidate(sessionId: string, fromTime: number): [string, Candidate]
       continue;
     }
     const arrayCandidates = candidates.get(otherSessionId).get(connectionId)
-      .filter((v) => v.datetime > fromTime);
+      .filter((v) => v.datetime >= fromTime);
     if (arrayCandidates.length === 0) {
       continue;
     }
@@ -243,17 +244,18 @@ function getAll(req: Request, res: Response): void {
   const answers: [string, Answer][] = _getAnswer(sessionId, fromTime);
   const candidates: [string, Candidate][] = _getCandidate(sessionId, fromTime);
   const disconnections: Disconnection[] = _getDisconnection(sessionId, fromTime);
+  const datetime = lastRequestedTime.get(sessionId);
 
   let array: any[] = [];
 
-  array = array.concat(connections.map((v) => ({ connectionId: v, type: "connect", datetime: Date.now() })));
+  array = array.concat(connections.map((v) => ({ connectionId: v, type: "connect", datetime: datetime })));
   array = array.concat(offers.map((v) => ({ connectionId: v[0], sdp: v[1].sdp, polite: v[1].polite, type: "offer", datetime: v[1].datetime })));
   array = array.concat(answers.map((v) => ({ connectionId: v[0], sdp: v[1].sdp, type: "answer", datetime: v[1].datetime })));
   array = array.concat(candidates.map((v) => ({ connectionId: v[0], candidate: v[1].candidate, sdpMLineIndex: v[1].sdpMLineIndex, sdpMid: v[1].sdpMid, type: "candidate", datetime: v[1].datetime })));
   array = array.concat(disconnections.map((v) => ({ connectionId: v.id, type: "disconnect", datetime: v.datetime })));
 
   array.sort((a, b) => a.datetime - b.datetime);
-  res.json({ messages: array, datetime: Date.now() });
+  res.json({ messages: array, datetime: datetime });
 }
 
 function createSession(sessionId: string, res: Response): void;
@@ -278,6 +280,8 @@ function deleteSession(req: Request, res: Response): void {
 function createConnection(req: Request, res: Response): void {
   const sessionId: string = req.header('session-id');
   const { connectionId } = req.body;
+  const datetime = lastRequestedTime.get(sessionId);
+
   if (connectionId == null) {
     res.status(400).send({ error: new Error(`connectionId is required`) });
     return;
@@ -305,7 +309,7 @@ function createConnection(req: Request, res: Response): void {
 
   const connectionIds = getOrCreateConnectionIds(sessionId);
   connectionIds.add(connectionId);
-  res.json({ connectionId: connectionId, polite: polite, type: "connect", datetime: Date.now() });
+  res.json({ connectionId: connectionId, polite: polite, type: "connect", datetime: datetime });
 }
 
 function deleteConnection(req: Request, res: Response): void {
@@ -320,6 +324,7 @@ function deleteConnection(req: Request, res: Response): void {
 function postOffer(req: Request, res: Response): void {
   const sessionId: string = req.header('session-id');
   const { connectionId } = req.body;
+  const datetime = lastRequestedTime.get(sessionId);
   let keySessionId = null;
   let polite = false;
 
@@ -330,7 +335,7 @@ function postOffer(req: Request, res: Response): void {
       if (keySessionId != null) {
         polite = true;
         const map = offers.get(keySessionId);
-        map.set(connectionId, new Offer(req.body.sdp, Date.now(), polite));
+        map.set(connectionId, new Offer(req.body.sdp, datetime, polite));
       }
     }
     res.sendStatus(200);
@@ -344,7 +349,7 @@ function postOffer(req: Request, res: Response): void {
 
   keySessionId = sessionId;
   const map = offers.get(keySessionId);
-  map.set(connectionId, new Offer(req.body.sdp, Date.now(), polite));
+  map.set(connectionId, new Offer(req.body.sdp, datetime, polite));
 
   res.sendStatus(200);
 }
@@ -352,6 +357,7 @@ function postOffer(req: Request, res: Response): void {
 function postAnswer(req: Request, res: Response): void {
   const sessionId: string = req.header('session-id');
   const { connectionId } = req.body;
+  const datetime = lastRequestedTime.get(sessionId);
   const connectionIds = getOrCreateConnectionIds(sessionId);
   connectionIds.add(connectionId);
 
@@ -374,7 +380,7 @@ function postAnswer(req: Request, res: Response): void {
   }
 
   const map = answers.get(otherSessionId);
-  map.set(connectionId, new Answer(req.body.sdp, Date.now()));
+  map.set(connectionId, new Answer(req.body.sdp, datetime));
 
   // update datetime for candidates
   const mapCandidates = candidates.get(otherSessionId);
@@ -382,7 +388,7 @@ function postAnswer(req: Request, res: Response): void {
     const arrayCandidates = mapCandidates.get(connectionId);
     if (arrayCandidates) {
       for (const candidate of arrayCandidates) {
-        candidate.datetime = Date.now();
+        candidate.datetime = datetime;
       }
     }
   }
@@ -392,13 +398,14 @@ function postAnswer(req: Request, res: Response): void {
 function postCandidate(req: Request, res: Response): void {
   const sessionId: string = req.header('session-id');
   const { connectionId } = req.body;
+  const datetime = lastRequestedTime.get(sessionId);
 
   const map = candidates.get(sessionId);
   if (!map.has(connectionId)) {
     map.set(connectionId, []);
   }
   const arr = map.get(connectionId);
-  const candidate = new Candidate(req.body.candidate, req.body.sdpMLineIndex, req.body.sdpMid, Date.now());
+  const candidate = new Candidate(req.body.candidate, req.body.sdpMLineIndex, req.body.sdpMid, datetime);
   arr.push(candidate);
   res.sendStatus(200);
 }

--- a/WebApp/src/class/httphandler.ts
+++ b/WebApp/src/class/httphandler.ts
@@ -253,7 +253,7 @@ function getAll(req: Request, res: Response): void {
   array = array.concat(disconnections.map((v) => ({ connectionId: v.id, type: "disconnect", datetime: v.datetime })));
 
   array.sort((a, b) => a.datetime - b.datetime);
-  res.json({ messages: array });
+  res.json({ messages: array, datetime: Date.now() });
 }
 
 function createSession(sessionId: string, res: Response): void;

--- a/WebApp/test/httphandler.test.ts
+++ b/WebApp/test/httphandler.test.ts
@@ -9,7 +9,6 @@ describe('http signaling test in public mode', () => {
   const sessionId3 = "abcd9101112";
   const connectionId = "12345";
   const connectionId2 = "67890";
-  const connectionId3 = "9101112";
   const testsdp = "test sdp";
 
   const { res, next, mockClear } = getMockRes();
@@ -66,7 +65,7 @@ describe('http signaling test in public mode', () => {
   test('get all from session1', async () => {
     await httpHandler.getAll(req, res);
     const connect = { connectionId: connectionId, datetime: expect.anything(), type: "connect" };
-    expect(res.json).toHaveBeenCalledWith({ messages: expect.arrayContaining([connect]) });
+    expect(res.json).toHaveBeenCalledWith({ messages: expect.arrayContaining([connect]), datetime: expect.anything() });
   });
 
   test('post offer from session1', async () => {
@@ -130,7 +129,7 @@ describe('http signaling test in public mode', () => {
   test('disconnection get from session1', async () => {
     await httpHandler.getAll(req, res);
     const disconnect = { connectionId: connectionId, datetime: expect.anything(), type: "disconnect" };
-    expect(res.json).toHaveBeenCalledWith({ messages: expect.arrayContaining([disconnect]) });
+    expect(res.json).toHaveBeenCalledWith({ messages: expect.arrayContaining([disconnect]), datetime: expect.anything() });
   });
 
   test('delete connection from session1', async () => {
@@ -159,7 +158,7 @@ describe('http signaling test in public mode', () => {
     await httpHandler.createSession(sessionId2, res);
 
     await httpHandler.getAll(req, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: [] });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: [], datetime: expect.anything() });
 
     const connectBody = { connectionId: connectionId };
     req.body = connectBody;
@@ -171,9 +170,9 @@ describe('http signaling test in public mode', () => {
 
     const offer = { connectionId: connectionId, sdp: testsdp, datetime: expect.anything(), type: "offer", polite: false };
     await httpHandler.getAll(req, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.not.arrayContaining([offer]) });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.not.arrayContaining([offer]), datetime: expect.anything() });
     await httpHandler.getAll(req2, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([offer]) });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([offer]), datetime: expect.anything() });
 
     const deleteBody = { connectionId: connectionId };
     req2.body = deleteBody;
@@ -187,7 +186,7 @@ describe('http signaling test in public mode', () => {
 
     const disconnect = { connectionId: connectionId, type: "disconnect", datetime: expect.anything() };
     await httpHandler.getAll(req2, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([disconnect]) });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([disconnect]), datetime: expect.anything() });
 
     await httpHandler.deleteSession(req2, res);
   });
@@ -204,7 +203,7 @@ describe('http signaling test in public mode', () => {
     await httpHandler.checkSessionId(req2, res, next);
 
     await httpHandler.getAll(req, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: [] });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: [], datetime: expect.anything() });
 
     const connectBody = { connectionId: connectionId };
     req.body = connectBody;
@@ -216,9 +215,9 @@ describe('http signaling test in public mode', () => {
 
     const offer = { connectionId: connectionId, sdp: testsdp, datetime: expect.anything(), type: "offer", polite: false };
     await httpHandler.getAll(req, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.not.arrayContaining([offer]) });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.not.arrayContaining([offer]), datetime: expect.anything() });
     await httpHandler.getAll(req2, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([offer]) });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([offer]), datetime: expect.anything() });
 
     const answerBody = { connectionId: connectionId, sdp: testsdp };
     req2.body = answerBody;
@@ -264,7 +263,7 @@ test('Timed out sessions are deleted when other sessions check', async () => {
   await httpHandler.checkSessionId(req3, res, next);
 
   await httpHandler.getAll(req, res);
-  expect(res.json).toHaveBeenLastCalledWith({ messages: [] });
+  expect(res.json).toHaveBeenLastCalledWith({ messages: [], datetime: expect.anything() });
 
   const connectBody = { connectionId: connectionId };
   req.body = connectBody;
@@ -276,9 +275,9 @@ test('Timed out sessions are deleted when other sessions check', async () => {
 
   const offer = { connectionId: connectionId, sdp: testsdp, datetime: expect.anything(), type: "offer", polite: false };
   await httpHandler.getAll(req, res);
-  expect(res.json).toHaveBeenLastCalledWith({ messages: expect.not.arrayContaining([offer]) });
+  expect(res.json).toHaveBeenLastCalledWith({ messages: expect.not.arrayContaining([offer]), datetime: expect.anything() });
   await httpHandler.getAll(req2, res);
-  expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([offer]) });
+  expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([offer]), datetime: expect.anything() });
 
   const answerBody = { connectionId: connectionId, sdp: testsdp };
   req2.body = answerBody;
@@ -473,7 +472,7 @@ describe('http signaling test in private mode', () => {
     await httpHandler.createSession(sessionId2, res);
 
     await httpHandler.getAll(req, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: [] });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: [], datetime: expect.anything() });
 
     const connectBody = { connectionId: connectionId };
     req.body = connectBody;
@@ -487,9 +486,9 @@ describe('http signaling test in private mode', () => {
 
     const offer = { connectionId: connectionId, sdp: testsdp, datetime: expect.anything(), type: "offer", polite: true };
     await httpHandler.getAll(req, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.not.arrayContaining([offer]) });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.not.arrayContaining([offer]), datetime: expect.anything() });
     await httpHandler.getAll(req2, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([offer]) });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([offer]), datetime: expect.anything() });
 
     const deleteBody = { connectionId: connectionId };
     req2.body = deleteBody;
@@ -503,7 +502,7 @@ describe('http signaling test in private mode', () => {
 
     const disconnect = { connectionId: connectionId, type: "disconnect", datetime: expect.anything() };
     await httpHandler.getAll(req2, res);
-    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([disconnect]) });
+    expect(res.json).toHaveBeenLastCalledWith({ messages: expect.arrayContaining([disconnect]), datetime: expect.anything() });
 
     await httpHandler.deleteSession(req2, res);
   });

--- a/WebApp/test/renderstreaming.postman_collection.json
+++ b/WebApp/test/renderstreaming.postman_collection.json
@@ -860,6 +860,7 @@
 							"pm.test(\"The response has a valid JSON body\", function () {",
 							"    pm.response.to.be.json;",
 							"    pm.response.to.have.jsonBody(\"messages\");",
+							"    pm.response.to.have.jsonBody(\"datetime\");",
 							"    var jsonData = pm.response.json();",
 							"    console.log(jsonData);",
 							"    pm.expect(jsonData.messages.length).to.be.above(0);",

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/HttpSignaling.cs
@@ -368,8 +368,8 @@ namespace Unity.RenderStreaming.Signaling
 
             if (data == null) return false;
 
-            m_lastTimeGetAllRequest = DateTimeExtension.ParseHttpDate(response.Headers[HttpResponseHeader.Date])
-                .ToJsMilliseconds();
+            m_lastTimeGetAllRequest =
+                long.TryParse(data.datetime, out var result) ? result : DateTime.Now.ToJsMilliseconds();
 
             foreach (var msg in data.messages)
             {

--- a/com.unity.renderstreaming/Runtime/Scripts/Signaling/SignalingMessage.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Signaling/SignalingMessage.cs
@@ -100,6 +100,7 @@ namespace Unity.RenderStreaming
     class AllResData
     {
         public SignalingMessage[] messages;
+        public string datetime;
     }
 
 #pragma warning restore 0649


### PR DESCRIPTION
The resolution in the `Date` header is 1 second. Therefore, if the polling interval is 1 second or less, the `fromtime` of QueryParameter may become the same, and unnecessary responses may be received.
Include the exact last used Timestamp in the `GetAll` response and use it to support short polling intervals.