### PR TITLE
fix: DataChannel closing all connections

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/Broadcast.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/Broadcast.cs
@@ -48,7 +48,7 @@ namespace Unity.RenderStreaming
             {
                 RemoveReceiver(connectionId, receiver);
             }
-            foreach (var channel in streams.OfType<IDataChannel>())
+            foreach (var channel in streams.OfType<IDataChannel>().Where(c => c.ConnectionId == connectionId))
             {
                 RemoveChannel(connectionId, channel);
             }

--- a/com.unity.renderstreaming/Runtime/Scripts/DataChannelBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/DataChannelBase.cs
@@ -1,10 +1,11 @@
+using System;
 using Unity.WebRTC;
 using UnityEngine;
 
 namespace Unity.RenderStreaming
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public abstract class DataChannelBase : MonoBehaviour, IDataChannel
     {
@@ -12,48 +13,53 @@ namespace Unity.RenderStreaming
         internal const string LabelPropertyName = nameof(label);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [SerializeField]
         protected bool local = false;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [SerializeField]
         protected string label;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public bool IsLocal => local;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public string Label => label;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public bool IsConnected => Channel != null && Channel.ReadyState == RTCDataChannelState.Open;
 
         /// <summary>
-        /// 
+        ///
+        /// </summary>
+        public string ConnectionId { get; protected set; }
+
+        /// <summary>
+        ///
         /// </summary>
         public RTCDataChannel Channel { get; protected set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public OnStartedChannelHandler OnStartedChannel { get; set; }
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public OnStoppedChannelHandler OnStoppedChannel { get; set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="connectionId"></param>
         /// <param name="channel"></param>
@@ -62,10 +68,12 @@ namespace Unity.RenderStreaming
             Channel = channel;
             if (Channel == null)
             {
+                ConnectionId = String.Empty;
                 OnStoppedChannel?.Invoke(connectionId);
                 return;
             }
 
+            ConnectionId = connectionId;
             label = Channel.Label;
             Channel.OnOpen += () => { OnOpen(connectionId); };
             Channel.OnClose += () => { OnClose(connectionId); };
@@ -78,7 +86,7 @@ namespace Unity.RenderStreaming
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="msg"></param>
         public virtual void Send(byte[] msg)
@@ -87,7 +95,7 @@ namespace Unity.RenderStreaming
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="msg"></param>
         public virtual void Send(string msg)
@@ -96,7 +104,7 @@ namespace Unity.RenderStreaming
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="data"></param>
         public virtual void SetChannel(SignalingEventData data)
@@ -105,7 +113,7 @@ namespace Unity.RenderStreaming
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="bytes"></param>
         protected virtual void OnMessage(byte[] bytes)
@@ -113,7 +121,7 @@ namespace Unity.RenderStreaming
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="connectionId"></param>
         protected virtual void OnOpen(string connectionId)
@@ -121,7 +129,7 @@ namespace Unity.RenderStreaming
             OnStartedChannel?.Invoke(connectionId);
         }
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="connectionId"></param>
         protected virtual void OnClose(string connectionId)

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingHandlerBase.cs
@@ -198,7 +198,7 @@ namespace Unity.RenderStreaming
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="connectionId"></param>
         /// <param name="receiver"></param>
@@ -353,7 +353,7 @@ namespace Unity.RenderStreaming
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public interface IDataChannel
     {
@@ -371,6 +371,11 @@ namespace Unity.RenderStreaming
         ///
         /// </summary>
         string Label { get; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        string ConnectionId { get; }
 
         /// <summary>
         ///

--- a/com.unity.renderstreaming/Samples~/Example/WebBrowserInput/WebBrowserInputChannelReceiver/WebBrowserInputChannelReceiver.cs
+++ b/com.unity.renderstreaming/Samples~/Example/WebBrowserInput/WebBrowserInputChannelReceiver/WebBrowserInputChannelReceiver.cs
@@ -55,6 +55,12 @@ namespace Unity.RenderStreaming.Samples
                     onDeviceChange?.Invoke(remoteInput.RemoteKeyboard, InputDeviceChange.Removed);
                     onDeviceChange?.Invoke(remoteInput.RemoteMouse, InputDeviceChange.Removed);
                     onDeviceChange?.Invoke(remoteInput.RemoteTouchscreen, InputDeviceChange.Removed);
+
+                    if (Channel != null)
+                    {
+                        Channel.OnMessage -= remoteInput.ProcessInput;
+                    }
+
                     remoteInput.Dispose();
                     remoteInput = null;
                 }


### PR DESCRIPTION
How to reproduce:

- Set up test project with RenderStreaming samples.
- Run webapp sample.
- Run WebBrowserInput sample.
- Connect in browser, and open VideoPlayer sample.
- Connect again in browser, and open VideoPlayer sample.
- Close the first tab.
- The still open tab will no longer receive mouse or keyboard input.

Description of the changes:

- Update Broadcast.cs to only disconnect datachannels that are associated with the disconnected connectionId. 
- Update WebBrowserInputChannelReceiver.cs to disconnect from the RTCDataChannel when disconnecting to prevent processing input events when disconnecting.

How this was tested:

- Tested by running RenderStreaming unit tests & adding a new test to cover this issue.
- Ran through package samples, and the above reproduction steps.
