### PR TITLE
fix: Ice servers settings doesn't affecte when runOnAwake is enabled

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingManager.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingManager.cs
@@ -278,7 +278,13 @@ namespace Unity.RenderStreaming
                 return;
 
             var settings = m_useDefault ? RenderStreaming.GetSignalingSettings<SignalingSettings>() : signalingSettings;
-            RTCIceServer[] iceServers = settings.iceServers.OfType<RTCIceServer>().ToArray();
+            int i = 0;
+            RTCIceServer[] iceServers = new RTCIceServer[settings.iceServers.Count()];
+            foreach (var iceServer in settings.iceServers)
+            {
+                iceServers[i] = (RTCIceServer)iceServer;
+                i++;
+            }
             RTCConfiguration conf = new RTCConfiguration { iceServers = iceServers };
             ISignaling signaling = CreateSignaling(settings, SynchronizationContext.Current);
             _Run(conf, signaling, handlers.ToArray());


### PR DESCRIPTION
This fix is issued from these comments.
https://github.com/Unity-Technologies/UnityRenderStreaming/issues/907#issuecomment-1657696511
https://github.com/Unity-Technologies/UnityRenderStreaming/issues/502#issuecomment-1526610985
https://github.com/Unity-Technologies/UnityRenderStreaming/issues/895#issuecomment-1654854938

**OfType<T>** method in Linq returns empty array even if defining type cast method.