### PR TITLE
fix: Fix NullReferenceException when disabling a flag on SignalingManager inspector

### DIFF
--- a/com.unity.renderstreaming/Editor/SignalingManagerEditor.cs
+++ b/com.unity.renderstreaming/Editor/SignalingManagerEditor.cs
@@ -151,7 +151,7 @@ namespace Unity.RenderStreaming.Editor
 
         private void OnProjectChanged()
         {
-            if(root == null)
+            if (root == null)
                 return;
             var paths = GetAvailableSignalingSettingsPath();
 

--- a/com.unity.renderstreaming/Editor/SignalingManagerEditor.cs
+++ b/com.unity.renderstreaming/Editor/SignalingManagerEditor.cs
@@ -33,12 +33,19 @@ namespace Unity.RenderStreaming.Editor
 
         private void OnEnable()
         {
+            EditorApplication.projectChanged += OnProjectChanged;
+
             m_UseDefault = serializedObject.FindProperty(SignalingManager.UseDefaultPropertyName);
             m_SignalingSettingsObject = serializedObject.FindProperty(SignalingManager.SignalingSettingsObjectPropertyName);
             m_SignalingSettings = serializedObject.FindProperty(SignalingManager.SignalingSettingsPropertyName);
             m_Handlers = serializedObject.FindProperty(SignalingManager.HandlersPropertyName);
             m_RunOnAwake = serializedObject.FindProperty(SignalingManager.RunOnAwakePropertyName);
             m_EvaluateCommandlineArguments = serializedObject.FindProperty(SignalingManager.EvaluateCommandlineArgumentsPropertyName);
+        }
+
+        private void OnDisable()
+        {
+            EditorApplication.projectChanged -= OnProjectChanged;
         }
 
         public override VisualElement CreateInspectorGUI()
@@ -71,8 +78,6 @@ namespace Unity.RenderStreaming.Editor
             root.Add(new ReorderableListField(m_Handlers, "Signaling Handler List"));
             root.Add(new PropertyField(m_RunOnAwake, "Run On Awake"));
             root.Add(new PropertyField(m_EvaluateCommandlineArguments, "Evaluate Commandline Arguments"));
-
-            EditorApplication.projectChanged += OnProjectChanged;
 
             // Disable UI when running in Playmode
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
@@ -146,6 +151,8 @@ namespace Unity.RenderStreaming.Editor
 
         private void OnProjectChanged()
         {
+            if(root == null)
+                return;
             var paths = GetAvailableSignalingSettingsPath();
 
             // Force to use default settings if there are no available settings in project folder.
@@ -168,7 +175,6 @@ namespace Unity.RenderStreaming.Editor
             }
             signalingSettingsPopupField.choices = availableObjects.ToList();
             signalingSettingsPopupField.index = defaultIndex;
-
         }
 
         private void OnClickedOpenProjectSettingsButton()


### PR DESCRIPTION
When disabling the flag "Use Default Settings in Project Settings", throws an exception below.

```
NullReferenceException: SerializedObject of SerializedProperty has been Disposed.
UnityEditor.SerializedProperty.get_objectReferenceValue () (at /home/bokken/build/output/unity/unity/Editor/Mono/SerializedProperty.bindings.cs:1232)
Unity.RenderStreaming.Editor.SignalingManagerEditor.OnProjectChanged () (at ./Library/PackageCache/com.unity.renderstreaming@4e408551e619/Editor/SignalingManagerEditor.cs:159)
UnityEditor.EditorApplication.Internal_CallProjectHasChanged () (at /home/bokken/build/output/unity/unity/Editor/Mono/EditorApplication.cs:409)
UnityEditor.AssetDatabase:CopyAsset(String, String)
Unity.RenderStreaming.Editor.SignalingManagerEditor:CreateDefaultSignalingSettings() (at ./Library/PackageCache/com.unity.renderstreaming@4e408551e619/Editor/SignalingManagerEditor.cs:122)
Unity.RenderStreaming.Editor.SignalingManagerEditor:OnChangeUseDefault(SerializedPropertyChangeEvent) (at ./Library/PackageCache/com.unity.renderstreaming@4e408551e619/Editor/SignalingManagerEditor.cs:196)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&) (at /home/bokken/build/output/unity/unity/Modules/IMGUI/GUIUtility.cs:190)
```