### PR TITLE
Fix command line arguments incorrectly replacing ice-candidates with null values leading to a crash

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/CommandLineParser.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/CommandLineParser.cs
@@ -46,18 +46,18 @@ namespace Unity.RenderStreaming
             public string ArgumentName { get; }
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             public bool Defined => m_defined;
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             public readonly bool Required;
 
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             public T Value => m_value;
 
@@ -212,10 +212,10 @@ namespace Unity.RenderStreaming
                 list.Add(arguments[startIndex + 1]);
                 i = startIndex + 2;
             }
-            if (list.Count == 0 && required)
+            if (list.Count == 0)
             {
                 argumentValue = null;
-                return false;
+                return !required;
             }
             argumentValue = list.ToArray();
             return true;

--- a/com.unity.renderstreaming/Tests/Runtime/CommandLineParserTest.cs
+++ b/com.unity.renderstreaming/Tests/Runtime/CommandLineParserTest.cs
@@ -19,6 +19,7 @@ namespace Unity.RenderStreaming.RuntimeTest
             Assert.That(CommandLineParser.TryParse(arguments), Is.True);
             Assert.That((string)CommandLineParser.SignalingUrl, Is.Null);
             Assert.That((int?)CommandLineParser.PollingInterval, Is.Null);
+            Assert.That((string[])CommandLineParser.IceServerUrls, Is.Null);
         }
 
         [Test]


### PR DESCRIPTION
How to reproduce:
- Create HttpSignalingSettings with providing iceServers.
- Call ParseArguments on the HttpSignalingSettings without any IceServerUrl parameters defined.
- The first iceServer will have it's urls replaced with nulls.
- For an application, this could be replicated by running the application with command line arguments that weren't related. In my case, running an application with -force-vulkan would cause it to replace the iceServerUrls.

Description of the changes:
- The commandline parser was returning an empty list when parsing the URL parameters when none were provided on the command line. As a result, the HttpSignalingSettings class would replace the URLs with empty ones since it thought the values were set. This would then later cause issues when connecting since the ice candidate URL is null.

How this was tested:
- Tested by updating, and running Unit tests.
- Tested by running an application that was providing iceServerUrls, and command line arguments that were unrelated.