### PR TITLE
Fix disconnecting on first time PeerConnection state changes to disconnected, and instead rely on failed.

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/PeerConnection.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/PeerConnection.cs
@@ -86,7 +86,7 @@ namespace Unity.RenderStreaming
                     case RTCPeerConnectionState.Connected:
                         OnConnectHandler?.Invoke();
                         break;
-                    case RTCPeerConnectionState.Disconnected:
+                    case RTCPeerConnectionState.Failed:
                         OnDisconnectHandler?.Invoke();
                         break;
                 }

--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingManagerInternal.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingManagerInternal.cs
@@ -365,7 +365,11 @@ namespace Unity.RenderStreaming
             _mapConnectionIdAndPeer[connectionId] = peer;
 
             peer.OnConnectHandler += () => onConnect?.Invoke(connectionId);
-            peer.OnDisconnectHandler += () => onDisconnect?.Invoke(connectionId);
+            peer.OnDisconnectHandler += () =>
+            {
+                _signaling?.CloseConnection(connectionId);
+                onDisconnect?.Invoke(connectionId);
+            };
             peer.OnDataChannelHandler += channel => onAddChannel?.Invoke(connectionId, channel); ;
             peer.OnTrackEventHandler += e => onAddTransceiver?.Invoke(connectionId, e.Transceiver);
             peer.SendOfferHandler += desc => _signaling?.SendOffer(connectionId, desc);


### PR DESCRIPTION
How to reproduce:

- Establish a WebRTC connection between peers.
- Simulate an internet drop / prevent traffic from reaching the ice candidate for 5 seconds.
- Re-establish connection between the peers.
- The PeerConnection will now be disconnected, and the signaling server will not be informed unless it also was unreachable, and timed out itself. 

Description of the changes:

- The disconnected state can happen when the connection between peers is tested and fails a single time. A disconnected state can happen from packet loss, or during shortlived network disruptions. Failed happens after failing to reach the peer 5 times in a row, and represents that the connection is likely no longer valid. This change swaps to disconnecting the peers on failed instead of disconnect, as less reliable network connections can swap into disconnected frequently. With this change, connections are more resilient to network issues, and reconnections are possible. 
-  In addition to the above change, signaling was also an issue when disconnecting via the PeerConnectionStates. Signaling would be unaware the peers had disconnected, and the connection would remain in the signaling server. With this change, the signaling server now also disconnects when the peer state is swapped to failed.
- Note: with this change, the peer state can now take up to 25 seconds to swap into the failed state, and disconnect via the RTCPeerConnectionState.

Relevant info for this change:
- https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState
- https://blog.mozilla.org/webrtc/ice-disconnected-not/

How this was tested:

- Tested by running RenderStreaming unit tests.
- Running through the testing notes, and verifying that reconnects are now possible, and disconnects don't occur after the first missed connection check (5 seconds).