### PR TITLE
Update Android SDK version for newer unity releases

### DIFF
--- a/com.unity.renderstreaming/Editor/RenderStreamingWizard.cs
+++ b/com.unity.renderstreaming/Editor/RenderStreamingWizard.cs
@@ -21,7 +21,9 @@ namespace Unity.RenderStreaming.Editor
             BuildTarget.Android
         };
 
-#if UNITY_2021_1_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
+        const AndroidSdkVersions RequiredAndroidSdkVersion = AndroidSdkVersions.AndroidApiLevel23;
+#elif UNITY_2021_1_OR_NEWER
         const AndroidSdkVersions RequiredAndroidSdkVersion = AndroidSdkVersions.AndroidApiLevel22;
 #else
         const AndroidSdkVersions RequiredAndroidSdkVersion = AndroidSdkVersions.AndroidApiLevel21;


### PR DESCRIPTION
Downloaded the Unity 6 preview today, and got an error saying that the Android SDK v22 is no longer supported, so I added this bit of code to update it to version 23 as per the error message's suggestion. 