### PR TITLE
Manage active render texture to avoid changing it when recording

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/VideoStreamSender.cs
@@ -708,8 +708,10 @@ namespace Unity.RenderStreaming
                 while (true)
                 {
                     yield return new WaitForEndOfFrame();
+                    var rt = RenderTexture.active;
                     ScreenCapture.CaptureScreenshotIntoRenderTexture(m_screenTexture);
                     Graphics.ConvertTexture(m_screenTexture, m_screenCopyTexture);
+                    RenderTexture.active = rt;
                 }
             }
 


### PR DESCRIPTION
It is cleaner to restore the same active render texture when recording the screen as Unity's ``Graphics.ConvertTexture`` seems to change it internally. 