### PR TITLE
Fix: Command Line Argument Handling

### DIFF
--- a/com.unity.renderstreaming/Runtime/Scripts/SignalingManager.cs
+++ b/com.unity.renderstreaming/Runtime/Scripts/SignalingManager.cs
@@ -330,17 +330,7 @@ namespace Unity.RenderStreaming
             if (!runOnAwake || m_running || handlers.Count == 0)
                 return;
 
-            var settings = m_useDefault ? RenderStreaming.GetSignalingSettings<SignalingSettings>() : signalingSettings;
-            int i = 0;
-            RTCIceServer[] iceServers = new RTCIceServer[settings.iceServers.Count()];
-            foreach (var iceServer in settings.iceServers)
-            {
-                iceServers[i] = (RTCIceServer)iceServer;
-                i++;
-            }
-            RTCConfiguration conf = new RTCConfiguration { iceServers = iceServers };
-            ISignaling signaling = CreateSignaling(settings, SynchronizationContext.Current);
-            _Run(conf, signaling, handlers.ToArray());
+            _Run(null, null, handlers.ToArray());
         }
 
         void OnDestroy()


### PR DESCRIPTION
### Fix for command line arguments handling

**Problem**

When running on Awake and passing arguments via the command line, these values are not applied, the default settings are used instead.

**Root Cause**

The logic inside the `SignalingManager`’s `Awake()` function creates a signaling object that is passed to the `_Run()` function.
Because the `signaling` parameter in `_Run()` is not `null`, it prevents the function from creating a new signaling instance after the command-line arguments have been evaluated.

**Solution**

The creation of the signaling and conf objects has been removed from `Awake()`, and both are now set to `null`.
By doing this, the signaling object is created inside `_Run()` using the updated settings that include the values from the command-line arguments.
